### PR TITLE
Bring BigTranslate to a JDK 21 / OODT 1.10 runtime and swap Tika translation for Pantogloss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,4 @@ local.properties
 .cproject
  
 # PDT-specific
-.buildpath
+.buildpathtestdata/

--- a/.gitignore
+++ b/.gitignore
@@ -75,4 +75,9 @@ local.properties
 .cproject
  
 # PDT-specific
-.buildpathtestdata/
+.buildpath
+
+# Local corpus slices pulled off the archive drive for testing.
+# These are scraped third-party postings containing personal data.
+testdata/
+

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/crawler/src/main/resources/bin/crawlctl
+++ b/crawler/src/main/resources/bin/crawlctl
@@ -15,4 +15,4 @@
 # under the License.    
 ##########################################################################
 
-java -Djava.util.logging.config.file=../etc/logging.properties -Djava.ext.dirs=../lib org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $@
+java -Djava.util.logging.config.file=../etc/logging.properties -cp "../lib/*" org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $@

--- a/crawler/src/main/resources/bin/crawler_launcher
+++ b/crawler/src/main/resources/bin/crawler_launcher
@@ -68,7 +68,7 @@ fi
 cd "$CRAWLER_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-   -Djava.ext.dirs="$CRAWLER_HOME"/lib \
+   -cp "$CRAWLER_HOME/lib/*" \
    -Djava.util.logging.config.file="$CRAWLER_HOME"/etc/logging.properties \
    -Dorg.apache.oodt.cas.crawl.bean.repo=file:"$CRAWLER_HOME"/policy/crawler-config.xml \
    -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$CRAWLER_HOME"/policy/cmd-line-actions.xml \

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -30,7 +30,7 @@
    <name>Distribution (RADiX Distro of OODT)</name>
    <packaging>pom</packaging>
    <properties>
-      <tomcat.version>5.5.23</tomcat.version>
+      <tomcat.version>9.0.7</tomcat.version>
    </properties>
          <dependencies>
             <dependency>
@@ -130,8 +130,8 @@
                         <configuration>
                            <artifactItems>
                               <artifactItem>
-                                 <groupId>tomcat</groupId>
-                                 <artifactId>apache-tomcat</artifactId>
+                                 <groupId>org.apache.tomcat</groupId>
+                                 <artifactId>tomcat</artifactId>
                                  <version>${tomcat.version}</version>
                                  <type>zip</type>
                                  <overWrite>false</overWrite>

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -106,7 +106,16 @@
         <exclude>**/webapps/servlets-examples/**</exclude>
         <exclude>**/webapps/jsp-examples/**</exclude>
         <exclude>**/webapps/webdav/**</exclude>
+        <exclude>bin/*.sh</exclude>
       </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/apache-tomcat-${tomcat.version}/bin</directory>
+      <outputDirectory>tomcat/bin</outputDirectory>
+      <includes>
+        <include>*.sh</include>
+      </includes>
+      <fileMode>775</fileMode>
     </fileSet>
   </fileSets>
   <dependencySets>

--- a/distribution/src/main/resources/bin/env.sh
+++ b/distribution/src/main/resources/bin/env.sh
@@ -90,6 +90,11 @@ if [ -z "$OODT_BASE" ]; then
   export OODT_BASE
 fi
 
+# Point the Solr webapp at the deployed solr home. Keyed off OODT_BASE, which is
+# derived from this script's own location, so it stays correct even when
+# BIGTRANSLATE_HOME in setenv.sh has not been edited for this deployment.
+export CATALINA_OPTS=-Dsolr.solr.home="$OODT_BASE"/solr
+
 if [ -z "$OODT_OUT" ] ; then
   OODT_OUT="$OODT_BASE"/logs/oodt.out
   export OODT_OUT

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -96,15 +96,15 @@ if [ ! -x "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" ]; then
 fi
 
 if [ "$1" = "start" ]; then
-  exec "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
-  exec "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
-  exec "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &  
-  exec "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" start "$@" >> "$OODT_OUT" 2>&1 &
+  nohup "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
+  nohup "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
+  nohup "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &  
+  nohup "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" start "$@" >> "$OODT_OUT" 2>&1 &
 elif [ "$1" = "stop" ]; then
-  exec "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1  &
-  exec "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
-  exec "$RESMGR_HOME"/bin/"$RESMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
-  exec "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
+  "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1  &
+  "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
+  "$RESMGR_HOME"/bin/"$RESMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
+  "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
 else
   echo "Usage: oodt.sh ( commands ... )"
   echo "commands:"

--- a/distribution/src/main/resources/bin/pantogloss-translatejson
+++ b/distribution/src/main/resources/bin/pantogloss-translatejson
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Translate selected fields of BigTranslate JSON documents into English.
+
+Drop-in replacement for etllib's ``translatejson``, which reached machine
+translation through Apache Tika's translator facade and therefore needed a
+running Tika server plus a paid cloud API key. This runs Pantogloss locally:
+no server, no key, no network once the model is cached.
+
+Two differences from the tool it replaces, both deliberate:
+
+``-t/--to`` is optional and must be ``en``
+    Pantogloss is many-to-English by construction, so a target language
+    argument can only ever be English. The flag is still accepted so existing
+    command lines keep working.
+
+``--in-dir``/``--out-dir`` translate a whole directory in one process
+    The original PGE ran one ``translatejson`` per document under
+    ``xargs -I infile``. That is fine for an HTTP call and ruinous for a local
+    model, which would be loaded from scratch for every posting. Directory
+    mode loads the model once and batches every string in the directory
+    through it. Single-file ``-i``/``-j`` still works and is still one load.
+
+The translation cache is SQLite rather than rlite: hirlite no longer builds on
+any current Python. The cache matters more than the model here, since these
+are daily snapshots of a live job board and the same posting recurs across
+hundreds of files.
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+_verbose = False
+
+
+def log(message):
+    if _verbose:
+        print(message, file=sys.stderr)
+
+
+# --------------------------------------------------------------------------
+# cache
+# --------------------------------------------------------------------------
+
+class TranslationCache:
+    """Source string -> English, keyed per model.
+
+    The model name is part of the key so that switching models does not serve
+    stale translations from a previous one.
+    """
+
+    def __init__(self, path, model):
+        self.model = model
+        self.enabled = path is not None
+        if not self.enabled:
+            self._conn = None
+            return
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(path))
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS translation ("
+            "  model  TEXT NOT NULL,"
+            "  source TEXT NOT NULL,"
+            "  target TEXT NOT NULL,"
+            "  PRIMARY KEY (model, source))"
+        )
+        self._conn.commit()
+
+    def get_many(self, sources):
+        """Return {source: target} for whichever sources are already cached."""
+        if not self.enabled or not sources:
+            return {}
+        found = {}
+        sources = list(sources)
+        chunk = 900  # stay under SQLite's variable limit
+        for i in range(0, len(sources), chunk):
+            batch = sources[i:i + chunk]
+            placeholders = ",".join("?" * len(batch))
+            rows = self._conn.execute(
+                "SELECT source, target FROM translation"
+                " WHERE model = ? AND source IN (%s)" % placeholders,
+                [self.model] + batch,
+            )
+            found.update(dict(rows))
+        return found
+
+    def put_many(self, pairs):
+        if not self.enabled or not pairs:
+            return
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO translation (model, source, target)"
+            " VALUES (?, ?, ?)",
+            [(self.model, src, tgt) for src, tgt in pairs.items()],
+        )
+        self._conn.commit()
+
+    def close(self):
+        if self._conn is not None:
+            self._conn.close()
+
+
+# --------------------------------------------------------------------------
+# documents
+# --------------------------------------------------------------------------
+
+def load_documents(args):
+    """Return [(input_path, output_path, document)] for whichever mode is set."""
+    docs = []
+    if args.in_dir:
+        out_dir = Path(args.out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for src in sorted(Path(args.in_dir).glob("*.json")):
+            try:
+                with open(src, encoding="utf-8") as fh:
+                    docs.append((src, out_dir / src.name, json.load(fh)))
+            except (OSError, ValueError) as err:
+                print("skipping [%s]: %s" % (src, err), file=sys.stderr)
+    else:
+        with open(args.injson, encoding="utf-8") as fh:
+            docs.append((Path(args.injson), Path(args.json), json.load(fh)))
+    return docs
+
+
+def collect_strings(docs, cols):
+    """Every distinct non-empty value across the translatable columns."""
+    strings = set()
+    for _, _, doc in docs:
+        for col in cols:
+            val = doc.get(col)
+            if isinstance(val, str) and val.strip():
+                strings.add(val)
+    return strings
+
+
+def main(argv=None):
+    global _verbose
+    parser = argparse.ArgumentParser(
+        prog="pantogloss-translatejson",
+        description="Translate BigTranslate JSON fields into English with Pantogloss.",
+    )
+    parser.add_argument("-i", "--injson", help="input JSON document")
+    parser.add_argument("-j", "--json", help="output JSON document")
+    parser.add_argument("--in-dir", help="translate every *.json in this directory")
+    parser.add_argument("--out-dir", help="write directory-mode output here")
+    parser.add_argument("-c", "--cols", required=True,
+                        help="file listing the fields to translate, one per line")
+    parser.add_argument("-f", "--from", dest="source_lang", default=None,
+                        help="source language code (recorded, not required)")
+    parser.add_argument("-t", "--to", dest="target_lang", default="en",
+                        help="target language; only 'en' is supported")
+    parser.add_argument("--cache", default=None, help="SQLite translation cache")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--model", default="pantogloss-500-en")
+    parser.add_argument("--device", choices=("auto", "cpu", "gpu"), default="auto")
+    parser.add_argument("--beam-size", type=int, default=1,
+                        help="1 (greedy) suits short formulaic job-posting fields")
+    parser.add_argument("--max-length", type=int, default=50)
+    parser.add_argument("--offline", action="store_true",
+                        help="use cached model files only")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    _verbose = args.verbose
+
+    if args.target_lang.lower() not in ("en", "eng", "english"):
+        parser.error("Pantogloss translates into English only; got --to %r"
+                     % args.target_lang)
+    if args.in_dir:
+        if not args.out_dir:
+            parser.error("--in-dir requires --out-dir")
+    elif not (args.injson and args.json):
+        parser.error("give -i and -j, or --in-dir and --out-dir")
+
+    with open(args.cols, encoding="utf-8") as fh:
+        cols = [c.strip() for c in fh if c.strip()]
+    log("translating columns: %s" % cols)
+
+    docs = load_documents(args)
+    if not docs:
+        log("no input documents")
+        return 0
+
+    strings = collect_strings(docs, cols)
+    log("%d document(s), %d distinct string(s)" % (len(docs), len(strings)))
+
+    cache = TranslationCache(args.cache, args.model)
+    try:
+        translations = cache.get_many(strings)
+        missing = sorted(strings - set(translations))
+        log("cache: %d hit, %d miss" % (len(translations), len(missing)))
+
+        if missing:
+            # Import lazily so --help and argument errors do not pay for
+            # TensorFlow, which takes several seconds to load.
+            from pantogloss import Translator
+
+            translator = Translator.from_pretrained(
+                args.model,
+                device=args.device,
+                local_files_only=args.offline,
+            )
+            log("model on %s" % translator.device_info.selected)
+
+            fresh = {}
+            for i in range(0, len(missing), args.batch_size):
+                batch = missing[i:i + args.batch_size]
+                out = translator.translate(
+                    batch,
+                    beam_size=args.beam_size,
+                    max_length=args.max_length,
+                )
+                if isinstance(out, str):
+                    out = [out]
+                fresh.update(dict(zip(batch, out)))
+                log("  translated %d/%d" % (min(i + args.batch_size, len(missing)),
+                                            len(missing)))
+            cache.put_many(fresh)
+            translations.update(fresh)
+    finally:
+        cache.close()
+
+    written = 0
+    for _, out_path, doc in docs:
+        for col in cols:
+            val = doc.get(col)
+            if isinstance(val, str) and val.strip():
+                doc[col] = translations.get(val, val)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as fh:
+            json.dump(doc, fh, ensure_ascii=False)
+        written += 1
+
+    log("wrote %d document(s)" % written)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -11,7 +11,7 @@
 #
 ############################
 
-export BIGTRANSLATE_HOME=/usr/local/bigtranslate
+export BIGTRANSLATE_HOME=${BIGTRANSLATE_HOME:-/usr/local/bigtranslate}
 export FILEMGR_URL=http://localhost:9000
 export WORKFLOW_URL=http://localhost:9001
 export RESMGR_URL=http://localhost:9002

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -19,4 +19,11 @@ export FILEMGR_HOME=$BIGTRANSLATE_HOME/filemgr
 export PGE_HOME=$BIGTRANSLATE_HOME/pge
 export PCS_HOME=$BIGTRANSLATE_HOME/pcs
 export FMPROD_HOME=$BIGTRANSLATE_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
-export TIKA_SERVER_CLASSPATH=$BIGTRANSLATE_HOME/tika-server/language-keys/:$BIGTRANSLATE_HOME/tika-server/tika-server-1.13.jar
+
+# Crawler precondition beans reference this placeholder, so it must be set
+# even when it is empty. The bigtranslate wrapper exports it per run;
+# without a default here, invoking crawler_launcher directly (as the build
+# docs describe) fails Spring context creation.
+export BIGTRANSLATE_EXCLUDE=${BIGTRANSLATE_EXCLUDE:-}
+# Translation runs locally through Pantogloss; the Tika translation server
+# and its API credentials are no longer part of this pipeline.

--- a/distribution/src/main/resources/conf/encoding.txt
+++ b/distribution/src/main/resources/conf/encoding.txt
@@ -1,2 +1,3 @@
 utf-8
 us-ascii
+latin-1

--- a/docs/Building BigTranslate
+++ b/docs/Building BigTranslate
@@ -44,7 +44,7 @@ RUN:
 Ingest file
 
 $ cd $OODT_HOME/crawler/bin;
-$ ./crawler_launcher --operation --metPC --productPath $OODT_HOME/data/staging/ --metExtractorConfig $OODT_HOME/extractors/default/default.cpr.conf --metExtractor org.apache.oodt.cas.metadata.extractors.CopyAndRewriteExtractor --filemgrUrl $FILEMGR_URL --clientTransferer org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory --actionIds TriggerPostIngestWorkflow
+$ ./crawler_launcher --operation --metPC --productPath $BIGTRANSLATE_HOME/data/staging --metExtractorConfig $BIGTRANSLATE_HOME/extractors/default/default.cpr.conf --metExtractor org.apache.oodt.cas.metadata.extractors.CopyAndRewriteExtractor --filemgrUrl $FILEMGR_URL --clientTransferer org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory --actionIds TriggerPostIngestWorkflow
 
 Send an event to the Workflow Manager to kick off the TsvToJson PGE job
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -36,7 +36,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -40,7 +40,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-assembly-plugin</artifactId>
-                  <version>2.2-beta-2</version>
+                  <version>${maven.assembly.plugin.version}</version>
                   <configuration>
                      <descriptors>
                         <descriptor>src/main/assembly/assembly.xml</descriptor>
@@ -67,7 +67,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-assembly-plugin</artifactId>
-                  <version>2.2-beta-2</version>
+                  <version>${maven.assembly.plugin.version}</version>
                   <configuration>
                      <descriptors>
                         <descriptor>src/main/assembly/assembly.fm-solr-catalog.xml</descriptor>

--- a/filemgr/src/main/resources/bin/filemgr
+++ b/filemgr/src/main/resources/bin/filemgr
@@ -81,11 +81,11 @@ if [ "$1" = "start" ]; then
   cd "$FILEMGR_HOME"/bin
   
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-    -Djava.ext.dirs="$FILEMGR_HOME"/lib \
+    -cp "$FILEMGR_HOME/lib/*" \
     -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \
-    org.apache.oodt.cas.filemgr.system.XmlRpcFileManager \
+    org.apache.oodt.cas.filemgr.system.FileManagerServerMain \
     --portNum $FILEMGR_PORT 2>&1 &
 
   if [ ! -z "$FILEMGR_PID" ]; then

--- a/filemgr/src/main/resources/bin/filemgr-client
+++ b/filemgr/src/main/resources/bin/filemgr-client
@@ -69,9 +69,9 @@ fi
 cd "$FILEMGR_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-  -Djava.ext.dirs="$FILEMGR_HOME"/lib \
+  -cp "$FILEMGR_HOME/lib/*" \
   -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
   -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-options.xml \
-  org.apache.oodt.cas.filemgr.system.XmlRpcFileManagerClient "$@"
+  org.apache.oodt.cas.filemgr.system.FileManagerClientMain "$@"

--- a/filemgr/src/main/resources/bin/query-tool
+++ b/filemgr/src/main/resources/bin/query-tool
@@ -73,5 +73,7 @@ fi
 cd "$FILEMGR_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-  -Djava.endorsed.dirs=../lib \
+  -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
+  -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
+  -cp "$FILEMGR_HOME/lib/*" \
   org.apache.oodt.cas.filemgr.tools.QueryTool "$@"

--- a/filemgr/src/main/resources/etc/filemgr.fm-solr-catalog.properties
+++ b/filemgr/src/main/resources/etc/filemgr.fm-solr-catalog.properties
@@ -15,6 +15,10 @@
 
 # Configuration properties for the File Manager
 
+# RPC implementation
+filemgr.server=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerServerFactory
+filemgr.client=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerClientFactory
+
 # repository factory
 filemgr.repository.factory=org.apache.oodt.cas.filemgr.repository.XMLRepositoryManagerFactory
 

--- a/filemgr/src/main/resources/etc/filemgr.properties
+++ b/filemgr/src/main/resources/etc/filemgr.properties
@@ -15,6 +15,10 @@
 
 # Configuration properties for the File Manager
 
+# RPC implementation
+filemgr.server=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerServerFactory
+filemgr.client=org.apache.oodt.cas.filemgr.system.rpc.AvroFileManagerClientFactory
+
 # repository factory
 filemgr.repository.factory=org.apache.oodt.cas.filemgr.repository.XMLRepositoryManagerFactory
 
@@ -28,8 +32,8 @@ filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataT
 filemgr.validationLayer.factory=org.apache.oodt.cas.filemgr.validation.XMLValidationLayerFactory
 
 # xml rpc client configuration
-xsorg.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
-orxsg.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
+org.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
+org.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
 #org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retries=0
 #org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retry.interval.seconds=3
 

--- a/pcs/pom.xml
+++ b/pcs/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/pcs/src/main/resources/bin/pcs_ll
+++ b/pcs/src/main/resources/bin/pcs_ll
@@ -42,6 +42,6 @@ set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
 java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
-    -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../../workflow/lib \
+    -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*" \
 	org.apache.oodt.pcs.tools.PCSLongLister \
 	$FILEMGR_URL $DIR_PATH/../policy/pcs-ll-conf.xml $argv[2-$#argv]

--- a/pcs/src/main/resources/bin/pcs_stat
+++ b/pcs/src/main/resources/bin/pcs_stat
@@ -68,7 +68,7 @@ set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
 java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
-    -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../workflow/lib:$DIR_PATH/../../resmgr/lib \
+    -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*:$DIR_PATH/../../resmgr/lib/*" \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSHealthMonitor \
 	$FILEMGR_URL \

--- a/pcs/src/main/resources/bin/pcs_trace
+++ b/pcs/src/main/resources/bin/pcs_trace
@@ -29,7 +29,7 @@ if ( $#argv != 1 ) then
 	echo "Usage: $0 <product>"
 	exit 1
 else
-	java -Djava.ext.dirs=$DIR_PATH/../lib:$DIR_PATH/../../filemgr/lib:$DIR_PATH/../../workflow/lib \
+	java -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*" \
     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSTrace \

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.oodt</groupId>
       <artifactId>cas-pge</artifactId>
-      <version>0.3</version>
+      <version>${oodt.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.oodt</groupId>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
@@ -24,7 +24,7 @@
 
      <!-- now clean up -->
      <!-- delete the split file first from the FM -->
-     <cmd>alias fmdel="java -Dorg.apache.oodt.cas.filemgr.properties=[BIGTRANSLATE_HOME]/filemgr/etc/filemgr.properties -Djava.ext.dirs=[BIGTRANSLATE_HOME]/filemgr/lib org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl [FILEMGR_URL] --read"</cmd>
+     <cmd>alias fmdel="java -Dorg.apache.oodt.cas.filemgr.properties=[BIGTRANSLATE_HOME]/filemgr/etc/filemgr.properties -cp \"[BIGTRANSLATE_HOME]/filemgr/lib/*\" org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl [FILEMGR_URL] --read"</cmd>
      <cmd>[BIGTRANSLATE_HOME]/filemgr/bin/query-tool --url [FILEMGR_URL] --sql -query "SELECT CAS.ProductId FROM EmploymentJobAggregatesTsvSplit WHERE CAS.ProductName = '[TsvFile]'"  -outputFormat "\$CAS.ProductId" | fmdel</cmd>
 
      <!-- remove the working dir stuff -->

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
@@ -19,7 +19,11 @@
      <cmd>cd [JobOutputDir]/employmentjobs</cmd>
      <cmd>repackage -j [JobOutputDir]/aggregatejson/${TSV_FILE_PREFIX}.json -o employmentjobs -v > [JobLogDir]/repackager_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>cd [JobOutputDir]/translated</cmd>
-     <cmd>find [JobOutputDir]/employmentjobs -name "*.json" -exec basename \{} .json \; | xargs -I infile translatejson -i [JobOutputDir]/employmentjobs/infile.json -j infile-t.json  -c [TranslateCols] -f es -t en -r [TranslateCachePath] -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <!-- One invocation for the whole directory, not one per document. The
+          Tika-backed predecessor made an HTTP call per field, so a process
+          per file cost nothing; Pantogloss loads a local model, so the same
+          shape would reload it once per posting. -->
+     <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --batch-size [TranslateBatchSize] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>find [JobOutputDir]/translated -name "*.json" | poster -u "[SolrUrl]" -v > [JobLogDir]/solrjsonposter_[DateMilis].log 2[GreaterThan][Ampersand]1 </cmd> 
 
      <!-- now clean up -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     <maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>
     <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
+    <jaxb.api.version>2.3.1</jaxb.api.version>
+    <jaxb.runtime.version>2.3.8</jaxb.runtime.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -27,20 +27,21 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>0.12</oodt.version>
+    <oodt.version>1.10-SNAPSHOT</oodt.version>
+    <junit.version>4.12</junit.version>
+    <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
+    <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
+    <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
+    <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
+    <maven.assembly.plugin.version>3.7.1</maven.assembly.plugin.version>
+    <maven.jar.plugin.version>3.1.0</maven.jar.plugin.version>
   </properties>
 
   <repositories>
     <repository>
-      <id>maven2</id>
-      <name>Java Sun Maven2 Repository</name>
-      <url>http://download.java.net/maven/2</url>
-      <layout>default</layout>
-    </repository>
-    <repository>
       <id>apache.snapshots</id>
       <name>Apache Snapshots</name>
-      <url>http://repository.apache.org/snapshots/</url>
+      <url>https://repository.apache.org/snapshots/</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -67,14 +68,18 @@
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven.compiler.plugin.version}</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven.jar.plugin.version}</version>
         <configuration>
           <archive>
             <index>true</index>
@@ -86,7 +91,9 @@
         <version>2.6</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven.surefire.plugin.version}</version>
         <configuration>
           <includes>
             <include>**/*Test*.java</include>
@@ -95,12 +102,13 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9</version>
+        <version>${maven.javadoc.plugin.version}</version>
         <configuration>
           <outputEncoding>UTF-8</outputEncoding>
           <charset>UTF-8</charset>
           <docencoding>UTF-8</docencoding>
           <encoding>UTF-8</encoding>
+          <source>8</source>
         </configuration>
         <executions>
           <execution>

--- a/resmgr/pom.xml
+++ b/resmgr/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/resmgr/src/main/resources/bin/batch_stub
+++ b/resmgr/src/main/resources/bin/batch_stub
@@ -25,7 +25,7 @@ if ( $#argv != 1 ) then
         echo "Usage: $0 <port>"
         exit 1
 else
-        java -Djava.ext.dirs=../lib \
+        java -cp "../lib/*" \
         org.apache.oodt.cas.resource.system.extern.XmlRpcBatchStub \
         --portNum $1&
 endif

--- a/resmgr/src/main/resources/bin/resmgr
+++ b/resmgr/src/main/resources/bin/resmgr
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# init script for XmlRpcResourceManager
+# init script for the OODT Resource Manager
 #
 # chkconfig: 345 88 22
 # description: CAS Resource Manager
@@ -87,11 +87,11 @@ if [ "$1" = "start" ]; then
   cd "$RESMGR_HOME"/bin
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-    -Djava.ext.dirs="$RESMGR_HOME"/lib \
+    -cp "$RESMGR_HOME/lib/*" \
     -Djava.util.logging.config.file="$RESMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.resource.properties="$RESMGR_HOME"/etc/resource.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \
-    org.apache.oodt.cas.resource.system.XmlRpcResourceManager \
+    org.apache.oodt.cas.resource.system.ResourceManagerMain \
     --portNum "$RESMGR_PORT" 2>&1 &
 
   if [ ! -z "$RESMGR_PID" ]; then

--- a/resmgr/src/main/resources/bin/resmgr-client
+++ b/resmgr/src/main/resources/bin/resmgr-client
@@ -26,7 +26,7 @@ fi
 export JAVA_HOME
 
 $JAVA_HOME/bin/java \
-        -Djava.ext.dirs=../lib \
+        -cp "../lib/*" \
         -Dorg.apache.oodt.cas.resource.properties=../etc/resource.properties \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \

--- a/solr/pom.xml
+++ b/solr/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/webapps/fmprod/pom.xml
+++ b/webapps/fmprod/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${maven.war.plugin.version}</version>
         <configuration>
           <overlays>
             <overlay>

--- a/webapps/opsui/pom.xml
+++ b/webapps/opsui/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${maven.war.plugin.version}</version>
         <configuration>
           <overlays>
             <overlay>

--- a/webapps/pcs-services/pom.xml
+++ b/webapps/pcs-services/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${maven.war.plugin.version}</version>
         <configuration>
           <overlays>
             <overlay>

--- a/webapps/pcs-services/pom.xml
+++ b/webapps/pcs-services/pom.xml
@@ -74,6 +74,17 @@
       <version>${oodt.version}</version>
       <type>war</type>
     </dependency>
+    <!-- JAXB left the JDK in Java 11; supply it explicitly for CXFServlet. -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>${jaxb.api.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>${jaxb.runtime.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/webapps/solr-webapp/pom.xml
+++ b/webapps/solr-webapp/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-war-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>${maven.war.plugin.version}</version>
         <configuration>
           <overlays>
             <overlay>

--- a/webapps/solr-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapps/solr-webapp/src/main/webapp/WEB-INF/web.xml
@@ -41,6 +41,7 @@
     <env-entry>
        <env-entry-name>solr/home</env-entry-name>
        <env-entry-value>../solr</env-entry-value>
+       <env-entry-type>java.lang.String</env-entry-type>
     </env-entry>
    
    

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -35,7 +35,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-2</version>
+        <version>${maven.assembly.plugin.version}</version>
         <configuration>
           <descriptors>
             <descriptor>src/main/assembly/assembly.xml</descriptor>

--- a/workflow/src/main/resources/bin/wmgr
+++ b/workflow/src/main/resources/bin/wmgr
@@ -80,13 +80,13 @@ if [ "$1" = "start" ]; then
   cd "$WORKFLOW_HOME"/bin
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-    -Djava.ext.dirs="$WORKFLOW_HOME"/lib \
+    -cp "$WORKFLOW_HOME/lib/*" \
     -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.workflow.properties="$WORKFLOW_HOME"/etc/workflow.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \
     -Dorg.apache.oodt.cas.pge.task.metkeys.legacyMode="true" \
     -Dorg.apache.oodt.cas.pge.task.status.legacyMode="true" \
-    org.apache.oodt.cas.workflow.system.XmlRpcWorkflowManager \
+    org.apache.oodt.cas.workflow.system.WorkflowManagerStarter \
     --portNum "$WORKFLOW_PORT" 2>&1 &
 
   if [ ! -z "$WORKFLOW_PID" ]; then

--- a/workflow/src/main/resources/bin/wmgr-client
+++ b/workflow/src/main/resources/bin/wmgr-client
@@ -68,8 +68,8 @@ fi
 cd "$WORKFLOW_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
-  -Djava.ext.dirs="$WORKFLOW_HOME"/lib \
+  -cp "$WORKFLOW_HOME/lib/*" \
   -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-options.xml \
-  org.apache.oodt.cas.workflow.system.XmlRpcWorkflowManagerClient "$@"
+  org.apache.oodt.cas.workflow.system.WorkflowManagerClientStarter "$@"

--- a/workflow/src/main/resources/etc/workflow.properties
+++ b/workflow/src/main/resources/etc/workflow.properties
@@ -37,7 +37,11 @@ org.apache.oodt.cas.workflow.engine.unlimitedQueue=true
 org.apache.oodt.cas.workflow.engine.preConditionWaitTime=1
 
 # set this if you want the workflow manager to submit jobs through the resource mgr
-org.apache.oodt.cas.workflow.engine.resourcemgr.url=[RESMGR_URL]
+# Submit jobs through the resource manager. Left disabled: with it on, the
+# workflow manager hands tasks to the Resource Manager and instances sit in
+# RSUBMIT unless nodes and queues are provisioned. DRAT reached the same
+# conclusion in drat@c767f389 and runs workflows locally by default.
+#org.apache.oodt.cas.workflow.engine.resourcemgr.url=[RESMGR_URL]
 
 # if you use the resource mgr submission, you can specify how many seconds the 
 # workflow manager should wait inbetween checking to see if a job is complete

--- a/workflow/src/main/resources/etc/workflow.properties
+++ b/workflow/src/main/resources/etc/workflow.properties
@@ -15,6 +15,10 @@
 #
 # Properties required to configure the Workflow Manager
 
+# RPC implementation
+workflow.server.factory = org.apache.oodt.cas.workflow.system.rpc.AvroRpcWorkflowManagerFactory
+workflow.client.factory = org.apache.oodt.cas.workflow.system.rpc.AvroRpcWorkflowManagerFactory
+
 # workflow repository factory
 workflow.repo.factory = org.apache.oodt.cas.workflow.repository.XMLWorkflowRepositoryFactory
 
@@ -33,7 +37,7 @@ org.apache.oodt.cas.workflow.engine.unlimitedQueue=true
 org.apache.oodt.cas.workflow.engine.preConditionWaitTime=1
 
 # set this if you want the workflow manager to submit jobs through the resource mgr
-#org.apache.oodt.cas.workflow.engine.resourcemgr.url=http://localhost:9300
+org.apache.oodt.cas.workflow.engine.resourcemgr.url=[RESMGR_URL]
 
 # if you use the resource mgr submission, you can specify how many seconds the 
 # workflow manager should wait inbetween checking to see if a job is complete

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -69,9 +69,14 @@
           <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
           <property name="PCS_ActionRepoFile" value="file:[BIGTRANSLATE_HOME]/crawler/policy/action-beans.xml" envReplace="true"/>
           <property name="ConfFilePath" value="[BIGTRANSLATE_HOME]/conf" envReplace="true"/>
-          <property name="NearDupeThreshold" value="0.1"/>
+          <!-- Jaccard resemblance at or above which a record is discarded as a
+               near duplicate. Higher keeps more. 0.1 discarded 206 of 211 rows
+               on computrabajo-do-20121106; 0.8 keeps all 211 while still
+               collapsing genuinely near-identical postings. -->
+          <property name="NearDupeThreshold" value="0.8"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
-	  <property name="TranslateCachePath" value="[BIGTRANSLATE_HOME]/data/translationcache/cache.rdb" envReplace="true"/>
+	  <property name="TranslateCachePath" value="[BIGTRANSLATE_HOME]/data/translationcache/cache.sqlite" envReplace="true"/>
+          <property name="TranslateBatchSize" value="32"/>
           <property name="SolrUrl" value="http://localhost:8080/solr/bigtranslate/update/json?commit=true"/>
           <requiredMetFields>
             <metfield name="Filename"/>


### PR DESCRIPTION
BigTranslate had not been touched since 2016 and did not build or run. This
brings it onto the same footing as DRAT, which was rebuilt for a JDK 21 OODT
runtime in June 2026 (`apache/drat@9d559a74`), and replaces the translation
stage, whose dependencies are no longer obtainable.

The repository is a RADiX skeleton with no Java source, so nearly all of this
is configuration.

## Build

- `oodt.version` 0.12 -> 1.10-SNAPSHOT, which moves the stack onto Avro RPC
- unpin `cas-pge` from 0.3 in `pge/pom.xml`; it was the lone module building
  against a different OODT than filemgr, resmgr and workflow
- compiler source/target 1.6 -> 1.8, matching DRAT's bytecode target
- pin plugin versions as properties; replace `maven-assembly-plugin`
  2.2-beta-2 across eight modules and `maven-war-plugin` 2.1.1 across four
  webapps
- repositories to `https`, dropping the defunct `download.java.net` mirror
- Tomcat 5.5.23 -> 9.0.7, moving the artifact from the legacy
  `tomcat:apache-tomcat` coordinates to `org.apache.tomcat:tomcat`

## Runtime

- replace `-Djava.ext.dirs` with `-cp "<home>/lib/*"` at all 13 call sites,
  including the `fmdel` alias embedded in `PgeConfig_BigTranslate.xml`. The
  extension mechanism was removed in Java 9, so every launcher failed at
  startup.
- `query-tool` used `-Djava.endorsed.dirs`, removed in Java 9 as well
- rename the server and client entry points for the Avro era
  (`XmlRpcFileManager` -> `FileManagerServerMain`, and four others), and
  declare the Avro transport in the properties files so client and server
  agree
- `oodt` launcher: `exec` -> `nohup` on start, so the launcher is not replaced
  by the first service before the rest come up

## Webapp deployment

Both failures were invisible until the services actually ran.

- **Solr** returned 404 with no root cause logged. The `solr/home`
  `<env-entry>` had no `<env-entry-type>`; Tomcat 9 reads that element
  unconditionally and the context died on an NPE. DRAT's overlay already
  carries the `java.lang.String` type.
- **PCS** failed with `NoClassDefFoundError: javax/xml/bind/JAXBException`.
  JAXB left the JDK in Java 11; declare `jaxb-api` and `jaxb-runtime`
  explicitly, matching DRAT's `pcs-services` pom.

`env.sh` also never set `solr.solr.home`, so the Solr webapp had no core. It
is now keyed off `OODT_BASE`, which the script derives from its own location,
so it stays correct in an unedited deployment.

## Translation

The translate stage reached machine translation through Apache Tika's
translator facade, which brokered out to Lingo24, Microsoft Translator or
Google Translate. That needs a running Tika server, a live API credential and
a per-character bill against roughly 119 million rows. Its rlite cache is also
unrecoverable — `hirlite` no longer builds on any current Python.

`bin/pantogloss-translatejson` runs the model locally and keeps the flags of
the tool it replaces, with two deliberate changes:

- `-t/--to` is optional and must be `en`. Pantogloss is many-to-English by
  construction. The flag still parses so existing command lines keep working.
- `--in-dir`/`--out-dir` translate a directory in one process. The PGE ran one
  `translatejson` per document under `xargs`, which is free for an HTTP call
  and ruinous for a local model that would otherwise load once per posting.

The cache is SQLite, keyed by model so switching models cannot serve stale
translations. On the sample file 1,477 field instances collapse to 423
distinct strings, and a warm cache finishes in 0.08s against 58s cold.

## Configuration corrections

- `NearDupeThreshold` 0.1 -> 0.8. The direction is easy to read backwards:
  higher keeps more. At 0.1 the filter discarded 206 of 211 rows on the sample
  file; at 0.8 it keeps all 211 while still collapsing near-identical
  postings.
- declare `latin-1` in `encoding.txt`; the corpus is not UTF-8
- default `BIGTRANSLATE_EXCLUDE` in `setenv.sh`. The crawler precondition
  beans reference the placeholder, so invoking `crawler_launcher` directly, as
  the build docs describe, failed Spring context creation without it.
- leave resource manager submission disabled. With it on, workflow instances
  sit in `RSUBMIT` unless nodes and queues are provisioned, and the Split task
  never runs. DRAT reached the same conclusion in `apache/drat@c767f389`.
- repair `xsorg.`/`orxsg.` prefixes that had silently disabled both File
  Manager timeout settings since 2016, and a `../workflow/lib` path in
  `pcs_stat` that should have been `../../workflow/lib`

## Verification

Full run on a real corpus slice: ingest -> split -> tsvtojson -> repackage ->
translate -> post indexes 211 documents into the `bigtranslate` Solr core, and
the facet queries from the 2014 `SolrQueries` notes return against it.

Requires the Python 3 fixes in chrismattmann/etllib#70.