### PR TITLE
Add a translation glossary, tests, and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,81 @@
+name: build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  # Configuration and glossary checks. BigTranslate has no Java source, so this
+  # covers most of what the repository actually contains, and needs neither
+  # OODT nor the translation model.
+  config:
+    name: Configuration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Test
+        run: python -m pytest tests/ -v
+
+  # Packaging check. OODT 1.10-SNAPSHOT is published to Apache snapshots, but
+  # that build is from 2020 and predates the JDK 21 and Avro work this project
+  # depends on, so the fork is built from source first and installed locally.
+  # Maven prefers the locally installed artifact over the remote snapshot.
+  package:
+    name: Maven package (JDK 21)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Check out Apache OODT
+        uses: actions/checkout@v4
+        with:
+          repository: chrismattmann/oodt
+          path: oodt
+
+      - name: Install OODT 1.10-SNAPSHOT
+        working-directory: oodt
+        run: mvn -B -q install -DskipTests -Dmaven.javadoc.skip=true
+
+      - name: Package BigTranslate
+        run: mvn -B package -DskipTests
+
+      - name: Check the distribution contents
+        run: |
+          set -e
+          TARBALL=distribution/target/bigtranslate-distribution-*-bin.tar.gz
+          test -f $TARBALL
+
+          # The translation step and its glossary have to ship, and the shim
+          # has to arrive executable or the PGE cannot invoke it.
+          tar tvzf $TARBALL | grep -E 'bin/pantogloss-translatejson' | grep -q '^-rwx'
+          tar tzf  $TARBALL | grep -q 'conf/glossary.es-en.tsv'
+
+          # Tomcat 9 ships bin/*.sh non-executable through the fileSet unless
+          # they are re-added with an explicit mode.
+          tar tvzf $TARBALL | grep -E 'tomcat/bin/catalina.sh' | grep -q '^-rwx'
+
+          # Java 9 removed the extension mechanism; every launcher that still
+          # references it fails at startup. Assert the scan is non-vacuous
+          # first, so a wildcard that matches nothing cannot pass silently.
+          LAUNCHERS=$(tar tzf $TARBALL | grep -cE '^[^/]+/bin/[^/]+$')
+          echo "scanning $LAUNCHERS launcher scripts"
+          test "$LAUNCHERS" -gt 30
+          ! tar xzOf $TARBALL --wildcards '*/bin/*' 2>/dev/null | grep -q 'java.ext.dirs'
+
+          echo "distribution contents OK"

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,12 @@ local.properties
 # These are scraped third-party postings containing personal data.
 testdata/
 
+
+######################
+# Python
+######################
+
+__pycache__/
+*.pyc
+.venv/
+.pytest_cache/

--- a/distribution/src/main/resources/bin/pantogloss-translatejson
+++ b/distribution/src/main/resources/bin/pantogloss-translatejson
@@ -82,9 +82,31 @@ class TranslationCache:
             "  model  TEXT NOT NULL,"
             "  source TEXT NOT NULL,"
             "  target TEXT NOT NULL,"
+            "  origin TEXT NOT NULL DEFAULT 'model',"
             "  PRIMARY KEY (model, source))"
         )
+        # Caches written before the glossary existed lack the origin column.
+        cols = {r[1] for r in self._conn.execute("PRAGMA table_info(translation)")}
+        if "origin" not in cols:
+            self._conn.execute(
+                "ALTER TABLE translation ADD COLUMN origin TEXT NOT NULL DEFAULT 'model'")
         self._conn.commit()
+
+    def seed_glossary(self, pairs):
+        """Write glossary entries as authoritative, replacing model output.
+
+        Re-seeded on every run so that correcting the glossary file and
+        re-running is enough to fix values already translated and cached.
+        """
+        if not self.enabled or not pairs:
+            return 0
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO translation (model, source, target, origin)"
+            " VALUES (?, ?, ?, 'glossary')",
+            [(self.model, src, tgt) for src, tgt in pairs.items()],
+        )
+        self._conn.commit()
+        return len(pairs)
 
     def get_many(self, sources):
         """Return {source: target} for whichever sources are already cached."""
@@ -105,11 +127,12 @@ class TranslationCache:
         return found
 
     def put_many(self, pairs):
+        """Record model output. INSERT OR IGNORE so a glossary row always wins."""
         if not self.enabled or not pairs:
             return
         self._conn.executemany(
-            "INSERT OR REPLACE INTO translation (model, source, target)"
-            " VALUES (?, ?, ?)",
+            "INSERT OR IGNORE INTO translation (model, source, target, origin)"
+            " VALUES (?, ?, ?, 'model')",
             [(self.model, src, tgt) for src, tgt in pairs.items()],
         )
         self._conn.commit()
@@ -117,6 +140,85 @@ class TranslationCache:
     def close(self):
         if self._conn is not None:
             self._conn.close()
+
+
+# --------------------------------------------------------------------------
+# glossary
+# --------------------------------------------------------------------------
+
+class Glossary:
+    """Authoritative source -> English overrides consulted before the model.
+
+    Two behaviours matter for this corpus:
+
+    Case-insensitive lookup. The model is inconsistent across casings of the
+    same term: on a sample country-day it left "Inmediato" untranslated in 151
+    records while rendering "inmediato" correctly. Matching on a casefolded key
+    means one entry covers every casing.
+
+    Component-wise resolution. Controlled-vocabulary fields hold comma-
+    separated lists such as "Medio Tiempo, Desde Casa". A whole-value entry per
+    combination would not scale, so a value is also resolved when every one of
+    its comma-separated components is known.
+    """
+
+    def __init__(self, entries=None):
+        self._exact = {}
+        self._folded = {}
+        for src, tgt in (entries or {}).items():
+            self._exact[src] = tgt
+            self._folded.setdefault(src.strip().casefold(), tgt)
+
+    def __len__(self):
+        return len(self._exact)
+
+    @property
+    def entries(self):
+        return dict(self._exact)
+
+    @classmethod
+    def load(cls, path):
+        """Read a TSV of source<TAB>target. Blank lines and # comments skipped."""
+        entries = {}
+        with open(path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, 1):
+                line = line.rstrip("\n")
+                if not line.strip() or line.lstrip().startswith("#"):
+                    continue
+                parts = line.split("\t")
+                if len(parts) < 2 or not parts[0].strip() or not parts[1].strip():
+                    print("glossary %s:%d: expected source<TAB>target, skipping"
+                          % (path, lineno), file=sys.stderr)
+                    continue
+                entries[parts[0].strip()] = parts[1].strip()
+        return cls(entries)
+
+    def lookup(self, value):
+        """Return the override for value, or None.
+
+        Tries the whole value first, then falls back to resolving every
+        comma-separated component.
+        """
+        if value is None:
+            return None
+        whole = self._lookup_term(value)
+        if whole is not None:
+            return whole
+
+        if "," not in value:
+            return None
+        parts = [p.strip() for p in value.split(",")]
+        if len(parts) < 2 or not all(parts):
+            return None
+        resolved = [self._lookup_term(p) for p in parts]
+        if any(r is None for r in resolved):
+            return None
+        return ", ".join(resolved)
+
+    def _lookup_term(self, term):
+        if term in self._exact:
+            return self._exact[term]
+        return self._folded.get(term.strip().casefold())
 
 
 # --------------------------------------------------------------------------
@@ -169,6 +271,8 @@ def main(argv=None):
     parser.add_argument("-t", "--to", dest="target_lang", default="en",
                         help="target language; only 'en' is supported")
     parser.add_argument("--cache", default=None, help="SQLite translation cache")
+    parser.add_argument("--glossary", default=None,
+                        help="TSV of authoritative source<TAB>target overrides")
     parser.add_argument("--batch-size", type=int, default=32)
     parser.add_argument("--model", default="pantogloss-500-en")
     parser.add_argument("--device", choices=("auto", "cpu", "gpu"), default="auto")
@@ -202,11 +306,31 @@ def main(argv=None):
     strings = collect_strings(docs, cols)
     log("%d document(s), %d distinct string(s)" % (len(docs), len(strings)))
 
+    glossary = Glossary.load(args.glossary) if args.glossary else Glossary()
+    if len(glossary):
+        log("glossary: %d entr(y|ies) from %s" % (len(glossary), args.glossary))
+
     cache = TranslationCache(args.cache, args.model)
     try:
-        translations = cache.get_many(strings)
-        missing = sorted(strings - set(translations))
-        log("cache: %d hit, %d miss" % (len(translations), len(missing)))
+        # Seed first so the cache reflects the current glossary, and so editing
+        # the glossary corrects values translated on an earlier run.
+        seeded = cache.seed_glossary(glossary.entries)
+        if seeded:
+            log("glossary: seeded %d entr(y|ies) into the cache" % seeded)
+
+        # Glossary wins over both cache and model.
+        translations = {}
+        for src in strings:
+            hit = glossary.lookup(src)
+            if hit is not None:
+                translations[src] = hit
+        log("glossary: resolved %d of %d string(s)" % (len(translations), len(strings)))
+
+        remaining = strings - set(translations)
+        cached = cache.get_many(remaining)
+        translations.update(cached)
+        missing = sorted(remaining - set(cached))
+        log("cache: %d hit, %d miss" % (len(cached), len(missing)))
 
         if missing:
             # Import lazily so --help and argument errors do not pay for

--- a/distribution/src/main/resources/conf/glossary.es-en.tsv
+++ b/distribution/src/main/resources/conf/glossary.es-en.tsv
@@ -1,0 +1,99 @@
+# Spanish -> English glossary for the employment corpus.
+#
+# Authoritative overrides consulted before the model. Entries are seeded into
+# the translation cache on every run, so editing this file and re-running is
+# enough to correct values already translated.
+#
+# Format: source<TAB>target. Blank lines and # comments are ignored.
+#
+# Matching is case-insensitive, and comma-separated values are resolved
+# component by component, so "Medio Tiempo, Desde Casa" is covered by the
+# "Medio Tiempo" and "Desde Casa" entries below.
+#
+# Why these entries exist: on a sample country-day the model left "Inmediato"
+# untranslated in 151 of 211 records while rendering lowercase "inmediato"
+# correctly, translated "correo electronico" as "default mail" across roughly
+# a hundred records, rendered "Medio Tiempo" as both "Half Time" and "Middle
+# Time", and turned "Asap" into the proper noun "Asaph". These are the
+# highest-frequency values in the corpus, so the errors were systematic.
+
+# --- jobtype -------------------------------------------------------------
+Tiempo Completo	Full Time
+Medio Tiempo	Part Time
+Por Horas	Hourly
+Desde Casa	Work From Home
+Beca/Prácticas	Internship
+Beca/Practicas	Internship
+Prácticas	Internship
+Practicas	Internship
+Becario	Intern
+Pasantía	Internship
+Pasantia	Internship
+Temporal	Temporary
+Por Contrato	Contract
+Freelance	Freelance
+Teletrabajo	Remote
+
+# --- duration ------------------------------------------------------------
+Indefinido	Indefinite
+Indefinida	Indefinite
+Indeterminado	Indeterminate
+Indeterminada	Indeterminate
+Permanente	Permanent
+Fijo	Fixed
+Fija	Fixed
+Según Desempeño	Based on Performance
+Segun Desempeño	Based on Performance
+Según Desempeno	Based on Performance
+A convenir	To be agreed
+Por Proyecto	Per Project
+Por Temporada	Seasonal
+
+# --- start ---------------------------------------------------------------
+Inmediato	Immediate
+Inmediata	Immediate
+De inmediato	Immediate
+Lo antes posible	As soon as possible
+Asap	Immediate
+A convenir con el candidato	To be agreed with the candidate
+
+# --- applications --------------------------------------------------------
+Correo Electronico	Email
+Correo Electrónico	Email
+Correo	Email
+E-mail	Email
+Telefono	Telephone
+Teléfono	Telephone
+Personalmente	In person
+En persona	In person
+enviar CV por correo electronico	Send CV by email
+enviar CV por correo electrónico	Send CV by email
+Enviar curriculum por correo electronico	Send resume by email
+Enviar curriculum por correo electrónico	Send resume by email
+Enviar hoja de vida	Send resume
+Vía telefónica	By telephone
+Via telefonica	By telephone
+
+# --- salary --------------------------------------------------------------
+Salario a convenir	Salary to be agreed
+A convenir en la entrevista	To be agreed at the interview
+Según experiencia	Based on experience
+Segun experiencia	Based on experience
+Negociable	Negotiable
+Más comisiones	Plus commission
+Mas comisiones	Plus commission
+Sueldo base más comisiones	Base salary plus commission
+Por hora laborada	Per hour worked
+
+# --- department / misc ---------------------------------------------------
+Todo el país	Nationwide
+Todo el pais	Nationwide
+Ventas	Sales
+Administración	Administration
+Administracion	Administration
+Recursos Humanos	Human Resources
+Atención al Cliente	Customer Service
+Atencion al Cliente	Customer Service
+Contabilidad	Accounting
+Informática	IT
+Informatica	IT

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
@@ -23,7 +23,7 @@
           Tika-backed predecessor made an HTTP call per field, so a process
           per file cost nothing; Pantogloss loads a local model, so the same
           shape would reload it once per posting. -->
-     <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --batch-size [TranslateBatchSize] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --glossary [TranslateGlossary] --batch-size [TranslateBatchSize] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>find [JobOutputDir]/translated -name "*.json" | poster -u "[SolrUrl]" -v > [JobLogDir]/solrjsonposter_[DateMilis].log 2[GreaterThan][Ampersand]1 </cmd> 
 
      <!-- now clean up -->

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared fixtures.
+
+pantogloss-translatejson ships as an executable without a .py suffix, so it is
+loaded here by path rather than imported. Loading it must not pull in
+TensorFlow: the module imports Pantogloss lazily, inside the branch that has
+strings left to translate, so the tests stay fast and run without the model.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+RESOURCES = REPO / "distribution" / "src" / "main" / "resources"
+BIN = RESOURCES / "bin"
+CONF = RESOURCES / "conf"
+POLICY = REPO / "pge" / "src" / "main" / "resources" / "policy"
+WORKFLOW_POLICY = REPO / "workflow" / "src" / "main" / "resources" / "policy"
+
+
+def _load_shim():
+    path = BIN / "pantogloss-translatejson"
+    spec = importlib.util.spec_from_loader(
+        "pantogloss_translatejson",
+        importlib.machinery.SourceFileLoader("pantogloss_translatejson", str(path)),
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pantogloss_translatejson"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+shim = _load_shim()
+
+Glossary = shim.Glossary
+TranslationCache = shim.TranslationCache
+collect_strings = shim.collect_strings
+load_documents = shim.load_documents

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,148 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The SQLite translation cache and its glossary layer.
+
+The cache carries most of the weight in this pipeline: the corpus is daily
+snapshots of a live job board, so the same posting recurs across hundreds of
+files. On a sample country-day 1,477 field instances collapse to 423 distinct
+strings.
+"""
+
+import sqlite3
+
+import pytest
+
+from conftest import TranslationCache
+
+
+@pytest.fixture
+def cache(tmp_path):
+    c = TranslationCache(str(tmp_path / "cache.sqlite"), "test-model")
+    yield c
+    c.close()
+
+
+class TestRoundTrip:
+    def test_stores_and_returns_model_output(self, cache):
+        cache.put_many({"Tiempo Completo": "Full Time"})
+        assert cache.get_many(["Tiempo Completo"]) == {"Tiempo Completo": "Full Time"}
+
+    def test_unknown_sources_are_absent(self, cache):
+        assert cache.get_many(["never seen"]) == {}
+
+    def test_empty_query_is_harmless(self, cache):
+        assert cache.get_many([]) == {}
+
+    def test_accents_survive_the_round_trip(self, cache):
+        cache.put_many({"Prácticas": "Internship"})
+        assert cache.get_many(["Prácticas"])["Prácticas"] == "Internship"
+
+    def test_handles_more_sources_than_the_sqlite_variable_limit(self, cache):
+        # get_many chunks its IN clause; a split file can carry more distinct
+        # strings than SQLite allows host parameters.
+        pairs = {"s%d" % i: "t%d" % i for i in range(2500)}
+        cache.put_many(pairs)
+        assert len(cache.get_many(list(pairs))) == 2500
+
+
+class TestModelScoping:
+    def test_entries_do_not_leak_between_models(self, tmp_path):
+        path = str(tmp_path / "cache.sqlite")
+        a = TranslationCache(path, "model-a")
+        a.put_many({"Inmediato": "from model a"})
+        a.close()
+
+        b = TranslationCache(path, "model-b")
+        assert b.get_many(["Inmediato"]) == {}
+        b.close()
+
+    def test_each_model_keeps_its_own_value(self, tmp_path):
+        path = str(tmp_path / "cache.sqlite")
+        a = TranslationCache(path, "model-a")
+        a.put_many({"x": "a-value"})
+        a.close()
+        b = TranslationCache(path, "model-b")
+        b.put_many({"x": "b-value"})
+        b.close()
+
+        a = TranslationCache(path, "model-a")
+        assert a.get_many(["x"])["x"] == "a-value"
+        a.close()
+
+
+class TestGlossaryPrecedence:
+    def test_seeded_entries_are_readable(self, cache):
+        cache.seed_glossary({"Inmediato": "Immediate"})
+        assert cache.get_many(["Inmediato"]) == {"Inmediato": "Immediate"}
+
+    def test_seeding_overwrites_wrong_model_output(self, cache):
+        # The whole point: correcting the glossary and re-running has to fix
+        # values already translated and cached.
+        cache.put_many({"Inmediato": "Inmediato"})
+        cache.seed_glossary({"Inmediato": "Immediate"})
+        assert cache.get_many(["Inmediato"])["Inmediato"] == "Immediate"
+
+    def test_model_output_never_overwrites_a_glossary_entry(self, cache):
+        cache.seed_glossary({"Medio Tiempo": "Part Time"})
+        cache.put_many({"Medio Tiempo": "Half Time"})
+        assert cache.get_many(["Medio Tiempo"])["Medio Tiempo"] == "Part Time"
+
+    def test_origin_is_recorded(self, cache, tmp_path):
+        cache.seed_glossary({"a": "A"})
+        cache.put_many({"b": "B"})
+        rows = dict(cache._conn.execute("SELECT source, origin FROM translation"))
+        assert rows == {"a": "glossary", "b": "model"}
+
+    def test_seeding_nothing_is_harmless(self, cache):
+        assert cache.seed_glossary({}) == 0
+
+    def test_reseeding_is_idempotent(self, cache):
+        cache.seed_glossary({"a": "A"})
+        cache.seed_glossary({"a": "A"})
+        count = cache._conn.execute("SELECT COUNT(*) FROM translation").fetchone()[0]
+        assert count == 1
+
+
+class TestSchemaMigration:
+    def test_adds_the_origin_column_to_an_older_cache(self, tmp_path):
+        # Caches written before the glossary existed have no origin column.
+        path = str(tmp_path / "old.sqlite")
+        conn = sqlite3.connect(path)
+        conn.execute(
+            "CREATE TABLE translation ("
+            "  model TEXT NOT NULL, source TEXT NOT NULL, target TEXT NOT NULL,"
+            "  PRIMARY KEY (model, source))"
+        )
+        conn.execute("INSERT INTO translation VALUES ('test-model', 'x', 'legacy')")
+        conn.commit()
+        conn.close()
+
+        cache = TranslationCache(path, "test-model")
+        try:
+            cols = {r[1] for r in cache._conn.execute("PRAGMA table_info(translation)")}
+            assert "origin" in cols
+            # Pre-existing rows stay readable and default to model origin.
+            assert cache.get_many(["x"])["x"] == "legacy"
+        finally:
+            cache.close()
+
+
+class TestDisabled:
+    def test_a_cacheless_run_is_supported(self):
+        cache = TranslationCache(None, "test-model")
+        cache.put_many({"a": "A"})
+        assert cache.get_many(["a"]) == {}
+        assert cache.seed_glossary({"b": "B"}) == 0
+        cache.close()

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Glossary lookup for the Pantogloss translation step."""
+
+import pytest
+
+from conftest import CONF, Glossary
+
+
+class TestLookup:
+    def test_exact_match(self):
+        g = Glossary({"Tiempo Completo": "Full Time"})
+        assert g.lookup("Tiempo Completo") == "Full Time"
+
+    def test_is_case_insensitive(self):
+        # The model treats casings differently: on a sample country-day it left
+        # "Inmediato" untranslated while rendering "inmediato" correctly. One
+        # entry has to cover every casing.
+        g = Glossary({"Inmediato": "Immediate"})
+        assert g.lookup("inmediato") == "Immediate"
+        assert g.lookup("INMEDIATO") == "Immediate"
+        assert g.lookup("Inmediato") == "Immediate"
+
+    def test_ignores_surrounding_whitespace(self):
+        g = Glossary({"Inmediato": "Immediate"})
+        assert g.lookup("  Inmediato  ") == "Immediate"
+
+    def test_unknown_value_returns_none(self):
+        g = Glossary({"Tiempo Completo": "Full Time"})
+        assert g.lookup("Analista Programador") is None
+
+    def test_none_input_returns_none(self):
+        assert Glossary({"a": "b"}).lookup(None) is None
+
+    def test_empty_glossary_resolves_nothing(self):
+        assert Glossary().lookup("Tiempo Completo") is None
+
+
+class TestComponentResolution:
+    """Controlled-vocabulary fields hold comma-separated lists."""
+
+    def test_resolves_every_component(self):
+        g = Glossary({"Medio Tiempo": "Part Time", "Desde Casa": "Work From Home"})
+        assert g.lookup("Medio Tiempo, Desde Casa") == "Part Time, Work From Home"
+
+    def test_resolves_three_components(self):
+        g = Glossary({"Tiempo Completo": "Full Time",
+                      "Medio Tiempo": "Part Time",
+                      "Por Horas": "Hourly"})
+        assert (g.lookup("Tiempo Completo, Medio Tiempo, Por Horas")
+                == "Full Time, Part Time, Hourly")
+
+    def test_declines_when_any_component_is_unknown(self):
+        # Falling back to the model for the whole value is better than emitting
+        # a half-translated string.
+        g = Glossary({"Medio Tiempo": "Part Time"})
+        assert g.lookup("Medio Tiempo, Algo Desconocido") is None
+
+    def test_component_match_is_case_insensitive(self):
+        g = Glossary({"Medio Tiempo": "Part Time", "Desde Casa": "Work From Home"})
+        assert g.lookup("medio tiempo, DESDE CASA") == "Part Time, Work From Home"
+
+    def test_whole_value_entry_beats_component_resolution(self):
+        g = Glossary({
+            "Medio Tiempo": "Part Time",
+            "Desde Casa": "Work From Home",
+            "Medio Tiempo, Desde Casa": "Part Time Remote",
+        })
+        assert g.lookup("Medio Tiempo, Desde Casa") == "Part Time Remote"
+
+    def test_does_not_split_a_value_with_an_empty_component(self):
+        g = Glossary({"Medio Tiempo": "Part Time"})
+        assert g.lookup("Medio Tiempo, ") is None
+
+    def test_salary_figures_are_left_alone(self):
+        # Salary values contain commas but are not term lists.
+        g = Glossary({"Tiempo Completo": "Full Time"})
+        assert g.lookup("$ 12,000.00") is None
+
+
+class TestLoad:
+    def _write(self, tmp_path, text):
+        f = tmp_path / "glossary.tsv"
+        f.write_text(text, encoding="utf-8")
+        return f
+
+    def test_reads_tab_separated_pairs(self, tmp_path):
+        f = self._write(tmp_path, "Tiempo Completo\tFull Time\n")
+        assert Glossary.load(str(f)).lookup("Tiempo Completo") == "Full Time"
+
+    def test_skips_comments_and_blank_lines(self, tmp_path):
+        f = self._write(tmp_path, "# a comment\n\n   \nInmediato\tImmediate\n")
+        g = Glossary.load(str(f))
+        assert len(g) == 1
+        assert g.lookup("Inmediato") == "Immediate"
+
+    def test_skips_malformed_lines(self, tmp_path):
+        f = self._write(tmp_path, "no tab here\nInmediato\tImmediate\n")
+        g = Glossary.load(str(f))
+        assert len(g) == 1
+
+    def test_strips_padding_around_fields(self, tmp_path):
+        f = self._write(tmp_path, "  Inmediato  \t  Immediate  \n")
+        assert Glossary.load(str(f)).lookup("Inmediato") == "Immediate"
+
+    def test_reads_accented_sources(self, tmp_path):
+        f = self._write(tmp_path, "Prácticas\tInternship\n")
+        assert Glossary.load(str(f)).lookup("Prácticas") == "Internship"
+
+
+@pytest.fixture(scope="module")
+def glossary():
+    return Glossary.load(str(CONF / "glossary.es-en.tsv"))
+
+
+class TestShippedGlossary:
+    """The file that actually ships in the distribution."""
+
+    def test_loads(self, glossary):
+        assert len(glossary) > 40
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            # Each of these was observed wrong in a real run.
+            ("Inmediato", "Immediate"),          # was left untranslated
+            ("Medio Tiempo", "Part Time"),       # was "Half Time" / "Middle Time"
+            ("Correo Electronico", "Email"),     # was "default mail"
+            ("Asap", "Immediate"),               # was "Asaph"
+            ("Indefinido", "Indefinite"),        # was "undefined"
+            ("Tiempo Completo", "Full Time"),
+        ],
+    )
+    def test_corrects_known_bad_translations(self, glossary, source, expected):
+        assert glossary.lookup(source) == expected
+
+    def test_covers_the_composite_jobtype_values(self, glossary):
+        assert glossary.lookup("Medio Tiempo, Desde Casa") == "Part Time, Work From Home"
+        assert glossary.lookup("Tiempo Completo, Desde Casa") == "Full Time, Work From Home"
+
+    def test_every_target_is_non_empty(self, glossary):
+        for source, target in glossary.entries.items():
+            assert target.strip(), "empty target for %r" % source

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -1,0 +1,278 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The configuration that actually drives the pipeline.
+
+BigTranslate has no Java source; it is policy XML, shell launchers and property
+files. These guard the modernization work, which is almost entirely
+configuration, and the class of regression that only shows up at runtime.
+"""
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from conftest import BIN, CONF, POLICY, REPO, RESOURCES, WORKFLOW_POLICY
+
+PGE_CONFIG = POLICY / "no_filter" / "PgeConfig_BigTranslate.xml"
+TASKS = WORKFLOW_POLICY / "tasks.xml"
+
+
+def xml_files():
+    skip = ("/target/", "/.git/")
+    return [p for p in REPO.rglob("*.xml")
+            if not any(s in str(p) for s in skip)]
+
+
+def launcher_scripts():
+    names = ("filemgr", "filemgr-client", "query-tool", "wmgr", "wmgr-client",
+             "resmgr", "resmgr-client", "batch_stub", "crawlctl",
+             "crawler_launcher", "pcs_ll", "pcs_stat", "pcs_trace")
+    return [p for p in REPO.rglob("src/main/resources/bin/*")
+            if p.is_file() and p.name in names]
+
+
+class TestXmlIsWellFormed:
+    @pytest.mark.parametrize("path", xml_files(), ids=lambda p: p.name)
+    def test_parses(self, path):
+        ET.parse(path)
+
+
+class TestJdk21Runtime:
+    """Both flags were removed in Java 9 and fail at startup, not gradually."""
+
+    @pytest.mark.parametrize("script", launcher_scripts(), ids=lambda p: p.name)
+    def test_no_java_ext_dirs(self, script):
+        assert "java.ext.dirs" not in script.read_text()
+
+    @pytest.mark.parametrize("script", launcher_scripts(), ids=lambda p: p.name)
+    def test_no_java_endorsed_dirs(self, script):
+        assert "-Djava.endorsed.dirs" not in script.read_text()
+
+    def test_pge_config_carries_no_ext_dirs(self):
+        # The fmdel alias is embedded in the PGE config, not a launcher, and
+        # was the easiest of the fourteen call sites to miss.
+        assert "java.ext.dirs" not in PGE_CONFIG.read_text()
+
+
+class TestAvroTransport:
+    """XML-RPC entry points no longer start a server under OODT 1.10."""
+
+    @pytest.mark.parametrize(
+        "script,expected",
+        [
+            ("filemgr", "FileManagerServerMain"),
+            ("filemgr-client", "FileManagerClientMain"),
+            ("wmgr", "WorkflowManagerStarter"),
+            ("wmgr-client", "WorkflowManagerClientStarter"),
+            ("resmgr", "ResourceManagerMain"),
+        ],
+    )
+    def test_entry_point_is_current(self, script, expected):
+        matches = [p for p in launcher_scripts() if p.name == script]
+        assert matches, "launcher %s not found" % script
+        assert expected in matches[0].read_text()
+
+    def test_filemgr_declares_avro_factories(self):
+        text = (REPO / "filemgr/src/main/resources/etc/filemgr.properties").read_text()
+        assert "AvroFileManagerServerFactory" in text
+        assert "AvroFileManagerClientFactory" in text
+
+    def test_solr_catalog_profile_declares_avro_too(self):
+        text = (REPO / "filemgr/src/main/resources/etc"
+                       "/filemgr.fm-solr-catalog.properties").read_text()
+        assert "AvroFileManagerServerFactory" in text
+
+    def test_workflow_declares_avro_factories(self):
+        text = (REPO / "workflow/src/main/resources/etc/workflow.properties").read_text()
+        assert "AvroRpcWorkflowManagerFactory" in text
+
+    def test_property_keys_are_not_corrupted(self):
+        # Two keys carried stray xsorg./orxsg. prefixes from a 2016 edit, which
+        # silently disabled both File Manager timeout settings.
+        text = (REPO / "filemgr/src/main/resources/etc/filemgr.properties").read_text()
+        for line in text.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key = line.split("=", 1)[0]
+                assert not re.match(r"^(xs|orxs)", key), "corrupted key: %r" % key
+
+
+class TestWorkflowExecution:
+    def test_resource_manager_submission_stays_disabled(self):
+        # With it enabled, instances sit in RSUBMIT unless nodes and queues are
+        # provisioned, and the Split task never runs.
+        text = (REPO / "workflow/src/main/resources/etc/workflow.properties").read_text()
+        active = [l for l in text.splitlines()
+                  if l.strip().startswith("org.apache.oodt.cas.workflow.engine"
+                                          ".resourcemgr.url")]
+        assert not active, "resourcemgr.url is enabled: %r" % active
+
+
+class TestTranslateStep:
+    def test_pge_invokes_the_pantogloss_shim(self):
+        assert "pantogloss-translatejson" in PGE_CONFIG.read_text()
+
+    def test_pge_no_longer_invokes_the_tika_backed_tool(self):
+        text = PGE_CONFIG.read_text()
+        assert not re.search(r"\btranslatejson\b(?!\s*\")", text.replace(
+            "pantogloss-translatejson", ""))
+
+    def test_translate_runs_once_per_directory(self):
+        # One process per document would reload the model for every posting.
+        text = PGE_CONFIG.read_text()
+        assert "--in-dir" in text and "--out-dir" in text
+        assert "xargs -I infile" not in text
+
+    def test_shim_receives_the_glossary(self):
+        assert "--glossary" in PGE_CONFIG.read_text()
+
+    def test_poster_reads_the_translated_directory(self):
+        text = PGE_CONFIG.read_text()
+        assert re.search(r"find \[JobOutputDir\]/translated .*\| poster", text)
+
+    def test_tika_server_classpath_is_retired(self):
+        text = (BIN / "setenv.sh").read_text()
+        assert "TIKA_SERVER_CLASSPATH" not in text
+
+
+@pytest.fixture(scope="module")
+def properties():
+    """Configuration properties of the BigTranslate_Task.
+
+    The root element is namespaced but its children are not, so the task
+    elements sit in no namespace.
+    """
+    root = ET.parse(TASKS).getroot()
+    found = {}
+    for task in root.iter("task"):
+        if task.get("name") == "BigTranslate_Task":
+            for prop in task.iter("property"):
+                found[prop.get("name")] = prop.get("value")
+    return found
+
+
+class TestTaskProperties:
+    def test_near_dupe_threshold_is_conservative(self, properties):
+        # Direction is easy to read backwards: higher keeps more. At 0.1 the
+        # filter discarded 206 of 211 rows on a sample country-day.
+        assert float(properties["NearDupeThreshold"]) >= 0.7
+
+    def test_cache_is_sqlite(self, properties):
+        # rlite is unreachable: hirlite no longer builds.
+        assert properties["TranslateCachePath"].endswith(".sqlite")
+
+    def test_glossary_path_is_declared(self, properties):
+        assert properties["TranslateGlossary"].endswith("glossary.es-en.tsv")
+
+    def test_batch_size_is_positive(self, properties):
+        assert int(properties["TranslateBatchSize"]) > 0
+
+    def test_every_referenced_conf_file_ships(self, properties):
+        for key in ("TranslateCols", "TranslateGlossary"):
+            name = properties[key].rsplit("/", 1)[-1]
+            assert (CONF / name).is_file(), "%s missing from conf/" % name
+
+
+class TestCorpusConfig:
+    def test_column_headers_match_the_corpus_width(self):
+        # The computrabajo TSVs parse to exactly 20 tab-separated fields.
+        cols = [c for c in (CONF / "colheaders.txt").read_text().splitlines() if c.strip()]
+        assert len(cols) == 20
+
+    def test_translate_columns_all_exist_in_the_header_list(self):
+        headers = {c.strip() for c in
+                   (CONF / "colheaders.txt").read_text().splitlines() if c.strip()}
+        targets = [c.strip() for c in
+                   (CONF / "translate.cols").read_text().splitlines() if c.strip()]
+        assert targets
+        for col in targets:
+            assert col in headers, "%r is not a known column" % col
+
+    def test_latin1_is_declared(self):
+        # The corpus is not UTF-8: byte 0xe9 in "Mexico" aborts a strict read.
+        encodings = [e.strip() for e in
+                     (CONF / "encoding.txt").read_text().splitlines() if e.strip()]
+        assert "latin-1" in encodings
+
+    def test_encoding_file_has_no_mangled_entries(self):
+        # Appending to a file with no trailing newline once produced
+        # "us-asciilatin-1" as a single line.
+        for line in (CONF / "encoding.txt").read_text().splitlines():
+            if line.strip():
+                assert " " not in line.strip()
+                assert line.strip().count("-") <= 1 or line.strip() in ("latin-1", "us-ascii")
+
+
+@pytest.fixture(scope="module")
+def root_pom():
+    return (REPO / "pom.xml").read_text()
+
+
+class TestBuild:
+    def test_targets_oodt_110(self, root_pom):
+        assert "<oodt.version>1.10-SNAPSHOT</oodt.version>" in root_pom
+
+    def test_no_plaintext_repositories(self, root_pom):
+        assert "http://repository.apache.org" not in root_pom
+        assert "http://download.java.net" not in root_pom
+
+    def test_cas_pge_is_not_pinned_to_an_old_release(self):
+        # pge/pom.xml pinned cas-pge to 0.3 while its siblings used the
+        # property, so one module built against a different OODT.
+        text = (REPO / "pge" / "pom.xml").read_text()
+        match = re.search(
+            r"<artifactId>cas-pge</artifactId>\s*<version>([^<]+)</version>", text)
+        assert match and match.group(1) == "${oodt.version}"
+
+    def test_tomcat_uses_current_coordinates(self):
+        text = (REPO / "distribution" / "pom.xml").read_text()
+        assert "<groupId>org.apache.tomcat</groupId>" in text
+        assert "tomcat:apache-tomcat" not in text
+
+    def test_solr_env_entry_declares_a_type(self):
+        # Tomcat 9 reads env-entry-type unconditionally; without it the /solr
+        # context dies on an NPE and returns 404 with no root cause logged.
+        web_xml = REPO / "webapps/solr-webapp/src/main/webapp/WEB-INF/web.xml"
+        root = ET.parse(web_xml).getroot()
+        ns = {"j": "http://java.sun.com/xml/ns/javaee"}
+        entries = root.findall("j:env-entry", ns) or root.findall("env-entry")
+        assert entries
+        for entry in entries:
+            types = (entry.findall("j:env-entry-type", ns)
+                     or entry.findall("env-entry-type"))
+            assert types, "env-entry without env-entry-type"
+
+    def test_pcs_webapp_supplies_jaxb(self):
+        # JAXB left the JDK in Java 11; CXFServlet fails to load without it.
+        text = (REPO / "webapps/pcs-services/pom.xml").read_text()
+        assert "jaxb-api" in text and "jaxb-runtime" in text
+
+    def test_solr_home_is_set_for_tomcat(self):
+        # Never set before; the Solr webapp came up with no core.
+        assert "solr.solr.home" in (BIN / "env.sh").read_text()
+
+    def test_crawler_exclude_has_a_default(self):
+        # Crawler precondition beans reference the placeholder, so invoking
+        # crawler_launcher directly failed Spring context creation without it.
+        assert "BIGTRANSLATE_EXCLUDE" in (BIN / "setenv.sh").read_text()
+
+
+class TestShippedScripts:
+    def test_shim_is_executable(self):
+        path = BIN / "pantogloss-translatejson"
+        assert path.is_file()
+        assert path.stat().st_mode & 0o111, "shim must ship executable"

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -76,6 +76,7 @@
           <property name="NearDupeThreshold" value="0.8"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
 	  <property name="TranslateCachePath" value="[BIGTRANSLATE_HOME]/data/translationcache/cache.sqlite" envReplace="true"/>
+          <property name="TranslateGlossary" value="[BIGTRANSLATE_HOME]/conf/glossary.es-en.tsv" envReplace="true"/>
           <property name="TranslateBatchSize" value="32"/>
           <property name="SolrUrl" value="http://localhost:8080/solr/bigtranslate/update/json?commit=true"/>
           <requiredMetFields>


### PR DESCRIPTION
## Glossary

The model's errors on this corpus are systematic and land on the
highest-frequency values, so they are worth correcting deterministically. On a
sample country-day the model:

| source | was | occurrences |
|---|---|---|
| `Inmediato` | left untranslated | 151 of 211 |
| `correo electronico` | `default mail` | ~100 |
| `Medio Tiempo` | `Half Time` / `Middle Time` | 25 |
| `Indefinido` | `undefined` | 9 |
| `Asap` | `Asaph` | 6 |

Lowercase `inmediato` translated correctly while `Inmediato` did not, so the
inconsistency is partly a casing artefact.

`conf/glossary.es-en.tsv` holds authoritative overrides consulted before the
model. Two behaviours matter:

- **Lookup is case-insensitive**, so one entry covers every casing of a term.
- **Comma-separated values resolve component by component**, so
  `Medio Tiempo, Desde Casa` is covered by its two component entries rather
  than needing an entry per combination. If any component is unknown the whole
  value falls through to the model, which beats emitting a half-translated
  string. Salary figures containing commas are unaffected, since their
  components are not glossary terms.

Entries are seeded into the SQLite cache each run with `origin='glossary'`, and
model output is written with `INSERT OR IGNORE` so it can never overwrite them.
**Correcting the glossary and re-running therefore repairs values already
translated and cached** — verified by poisoning a cache entry and re-running.
Caches predating the `origin` column are migrated in place.

The glossary resolves 46 of 423 distinct strings on the sample file, but those
are the most frequent values, so the effect is much larger than the count
suggests: `start` goes from 151 untranslated to 181 `Immediate`, and
`applications` from `default mail` to `Email`.

## Tests

191 tests, none requiring OODT, Solr, or the model. The shim imports Pantogloss
lazily, so loading it for tests does not pull in TensorFlow.

- `test_glossary.py` — lookup, component resolution, file parsing, and the
  specific corrections the shipped glossary is responsible for
- `test_cache.py` — round trips, model scoping, glossary precedence, schema
  migration, and the SQLite host-parameter limit
- `test_pipeline_config.py` — the configuration that actually drives the
  pipeline: XML well-formedness, absence of both Java 9 removals across all
  launchers, Avro entry points, corpus column alignment, and the build changes

Since BigTranslate has no Java source, the configuration tests cover most of
what the repository actually contains.

## CI

- **config** — the suite on Python 3.12
- **package** — Maven package on JDK 21, then assertions on the built
  distribution: the shim ships executable, the glossary ships, Tomcat's scripts
  keep their executable bit, and no launcher references `java.ext.dirs`

The package job builds Apache OODT from `chrismattmann/oodt` first. The
`1.10-SNAPSHOT` published to Apache snapshots is a **2020** build that predates
the JDK 21 and Avro work this depends on, and Maven prefers a locally installed
artifact over the remote snapshot — so without that step CI would silently
compile against the wrong OODT.

The distribution assertions were run locally against a real build; the workflow
itself has not executed yet, so this PR is its first run.