### PR TITLE
Depend on Mnemosyne 1.11.0 instead of Apache OODT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Test
         run: python -m pytest tests/ -v
 
-  # Packaging check. OODT 1.10-SNAPSHOT is published to Apache snapshots, but
-  # that build is from 2020 and predates the JDK 21 and Avro work this project
-  # depends on, so the fork is built from source first and installed locally.
-  # Maven prefers the locally installed artifact over the remote snapshot.
+  # Packaging check against Mnemosyne, the continuation of Apache OODT after
+  # the ASF retired it to the Attic. Mnemosyne is built from source until
+  # ai.mattmann.mnemosyne:1.11.0 is published to Maven Central, at which point
+  # this checkout and install step can be dropped entirely.
   package:
     name: Maven package (JDK 21)
     runs-on: ubuntu-latest
@@ -42,14 +42,14 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Check out Apache OODT
+      - name: Check out Mnemosyne
         uses: actions/checkout@v4
         with:
-          repository: chrismattmann/oodt
-          path: oodt
+          repository: chrismattmann/mnemosyne
+          path: mnemosyne
 
-      - name: Install OODT 1.10-SNAPSHOT
-        working-directory: oodt
+      - name: Install Mnemosyne 1.11.0
+        working-directory: mnemosyne
         run: mvn -B -q install -DskipTests -Dmaven.javadoc.skip=true
 
       - name: Package BigTranslate

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -62,13 +62,13 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-crawler</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -57,17 +57,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-metadata</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-filemgr</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-core</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/filemgr/pom.xml
+++ b/filemgr/pom.xml
@@ -96,34 +96,34 @@
          <scope>runtime</scope>
          <exclusions>
             <exclusion>
-               <groupId>org.apache.oodt</groupId>
+               <groupId>ai.mattmann.mnemosyne</groupId>
                <artifactId>cas-filemgr</artifactId>
             </exclusion>
          </exclusions>
       </dependency>
       <dependency>
-         <groupId>org.apache.oodt</groupId>
+         <groupId>ai.mattmann.mnemosyne</groupId>
          <artifactId>cas-filemgr</artifactId>
          <version>${oodt.version}</version>
       </dependency>
       <!-- oodt cas-* -->
       <dependency>
-         <groupId>org.apache.oodt</groupId>
+         <groupId>ai.mattmann.mnemosyne</groupId>
          <artifactId>cas-workflow</artifactId>
          <version>${oodt.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.oodt</groupId>
+         <groupId>ai.mattmann.mnemosyne</groupId>
          <artifactId>cas-pge</artifactId>
          <version>${oodt.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.oodt</groupId>
+         <groupId>ai.mattmann.mnemosyne</groupId>
          <artifactId>cas-resource</artifactId>
          <version>${oodt.version}</version>
       </dependency>
       <dependency>
-         <groupId>org.apache.oodt</groupId>
+         <groupId>ai.mattmann.mnemosyne</groupId>
          <artifactId>cas-metadata</artifactId>
          <version>${oodt.version}</version>
       </dependency>

--- a/pcs/pom.xml
+++ b/pcs/pom.xml
@@ -63,13 +63,13 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-core</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/pge/pom.xml
+++ b/pge/pom.xml
@@ -62,27 +62,27 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-workflow</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-pge</artifactId>
       <version>${oodt.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-crawler</artifactId>
         </exclusion>
       </exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <oodt.version>1.10-SNAPSHOT</oodt.version>
+    <oodt.version>1.11.0</oodt.version>
     <junit.version>4.12</junit.version>
     <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
     <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>

--- a/resmgr/pom.xml
+++ b/resmgr/pom.xml
@@ -63,29 +63,29 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <!-- oodt cas-* -->
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-workflow</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-pge</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-resource</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-metadata</artifactId>
       <version>${oodt.version}</version>
     </dependency>

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -223,8 +223,33 @@ def root_pom():
 
 
 class TestBuild:
-    def test_targets_oodt_110(self, root_pom):
-        assert "<oodt.version>1.10-SNAPSHOT</oodt.version>" in root_pom
+    def test_targets_mnemosyne_release(self, root_pom):
+        # Mnemosyne is the continuation of Apache OODT, which the ASF retired
+        # to the Attic in April 2023. A release, not a SNAPSHOT, so the
+        # coordinate cannot resolve to different bytes on different machines.
+        assert "<oodt.version>1.11.0</oodt.version>" in root_pom
+
+    def test_no_apache_oodt_coordinates_remain(self):
+        # Java packages stay org.apache.oodt.*; only the Maven coordinate moved.
+        # The 2020 org.apache.oodt:1.10-SNAPSHOT on Apache snapshots would
+        # silently resolve in place of the fork if any pom still named it.
+        stale = []
+        for pom in REPO.rglob("pom.xml"):
+            if "/target/" in str(pom):
+                continue
+            if "<groupId>org.apache.oodt</groupId>" in pom.read_text():
+                stale.append(str(pom.relative_to(REPO)))
+        assert not stale, "poms still on Apache coordinates: %s" % stale
+
+    def test_oodt_dependencies_use_the_mnemosyne_group(self):
+        found = False
+        for pom in REPO.rglob("pom.xml"):
+            if "/target/" in str(pom):
+                continue
+            if "<groupId>ai.mattmann.mnemosyne</groupId>" in pom.read_text():
+                found = True
+                break
+        assert found, "no pom declares the Mnemosyne groupId"
 
     def test_no_plaintext_repositories(self, root_pom):
         assert "http://repository.apache.org" not in root_pom

--- a/webapps/fmprod/pom.xml
+++ b/webapps/fmprod/pom.xml
@@ -58,7 +58,7 @@
         <configuration>
           <overlays>
             <overlay>
-              <groupId>org.apache.oodt</groupId>
+              <groupId>ai.mattmann.mnemosyne</groupId>
               <artifactId>cas-product</artifactId>
             </overlay>
           </overlays>
@@ -69,7 +69,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-product</artifactId>
       <version>${oodt.version}</version>
       <type>war</type>

--- a/webapps/opsui/pom.xml
+++ b/webapps/opsui/pom.xml
@@ -58,7 +58,7 @@
         <configuration>
           <overlays>
             <overlay>
-              <groupId>org.apache.oodt</groupId>
+              <groupId>ai.mattmann.mnemosyne</groupId>
               <artifactId>pcs-opsui</artifactId>
             </overlay>
           </overlays>
@@ -69,7 +69,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-opsui</artifactId>
       <version>${oodt.version}</version>
       <type>war</type>

--- a/webapps/pcs-services/pom.xml
+++ b/webapps/pcs-services/pom.xml
@@ -58,7 +58,7 @@
         <configuration>
           <overlays>
             <overlay>
-              <groupId>org.apache.oodt</groupId>
+              <groupId>ai.mattmann.mnemosyne</groupId>
               <artifactId>pcs-services</artifactId>
             </overlay>
           </overlays>
@@ -69,7 +69,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>pcs-services</artifactId>
       <version>${oodt.version}</version>
       <type>war</type>

--- a/workflow/pom.xml
+++ b/workflow/pom.xml
@@ -62,7 +62,7 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.oodt</groupId>
+          <groupId>ai.mattmann.mnemosyne</groupId>
           <artifactId>cas-filemgr</artifactId>
         </exclusion>
       </exclusions>
@@ -70,27 +70,27 @@
 
     <!-- oodt cas-* -->
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-workflow</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-pge</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-resource</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-metadata</artifactId>
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.oodt</groupId>
+      <groupId>ai.mattmann.mnemosyne</groupId>
       <artifactId>cas-filemgr</artifactId>
       <version>${oodt.version}</version>
     </dependency>


### PR DESCRIPTION
Apache OODT was [retired to the Attic in April 2023](https://attic.apache.org/projects/oodt.html).
[Mnemosyne](https://github.com/chrismattmann/mnemosyne) is its continuation,
published under `ai.mattmann.mnemosyne`.

```diff
-<groupId>org.apache.oodt</groupId>
+<groupId>ai.mattmann.mnemosyne</groupId>
-<oodt.version>1.10-SNAPSHOT</oodt.version>
+<oodt.version>1.11.0</oodt.version>
```

35 coordinate sites across 10 poms.

## This removes a real hazard

`org.apache.oodt:cas-*:1.10-SNAPSHOT` resolved to **two different artifacts
depending on the machine**:

| source | build |
|---|---|
| Apache snapshots | `1.10-20200204.100045-4` — 2020, no JDK 21 or Avro work |
| local `~/.m2` | the fork, 179 commits ahead |

Maven prefers the local install — until someone runs with `-U` or builds on a
clean checkout, at which point the 2020 jar silently wins and the failure
surfaces at *runtime* as missing classes rather than as a resolution error.
That is exactly the trap the CI `package` job was built to work around. A fixed
release version cannot do that.

## Only coordinates move

All **863** `org.apache.oodt` references in policy XML, properties files, and
launcher scripts are fully-qualified **class names**, and Mnemosyne deliberately
kept its Java packages as `org.apache.oodt.*`. So `filemgr.properties`,
`tasks.xml`, the PGE configs, and every launcher are untouched — verified, the
count is unchanged at 863.

## Tests

The suite caught this change itself: `test_targets_oodt_110` failed on the
version bump, which is what it was for. Replaced with two stronger assertions —
one fails if any pom still names the Apache coordinates, one requires the
Mnemosyne groupId to be present. 193 passing.

CI's `package` job now checks out `chrismattmann/mnemosyne`. Once
`ai.mattmann.mnemosyne:1.11.0` is on Maven Central, that build-from-source step
can be dropped entirely.

## Verification

Full end-to-end run on the modernized runtime against `cas-*-1.11.0` jars:
ingest → split → tsvtojson → repackage → Pantogloss translate → post indexed
**211 documents** into the `bigtranslate` Solr core, with the glossary
corrections intact (`162× Full Time`, `21× Part Time, Work From Home`,
`181× Immediate`).