### PR TITLE
Make mvn test work

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -123,7 +123,17 @@
                   <executions>
                      <execution>
                         <id>unpack-tomcat</id>
-                        <phase>process-sources</phase>
+                        <!--
+                          prepare-package, not process-sources. This unpacks
+                          war artifacts produced by sibling modules, which do
+                          not exist until those modules reach package. Binding
+                          it early made `mvn test` fail: the reactor builds
+                          siblings only through test, so the wars were absent
+                          while this execution still ran. prepare-package runs
+                          immediately before package, so the assembly still
+                          sees the unpacked layout.
+                        -->
+                        <phase>prepare-package</phase>
                         <goals>
                            <goal>unpack</goal>
                         </goals>


### PR DESCRIPTION
`mvn test` failed outright on this repository:

```
Failed to execute goal maven-dependency-plugin:unpack (unpack-tomcat)
The source file webapps/opsui/target/classes doesn't exist
```

**Cause:** `unpack-tomcat` was bound to `process-sources` — one of the earliest
phases — but it unpacks *war artifacts produced by sibling modules*. Running
`mvn test` builds those siblings only through the `test` phase, so the wars did
not exist yet while this execution still ran. The build had to reach `package`
for its own early-phase step to succeed, which is self-contradictory.

**Fix:** bind it to `prepare-package`, which runs immediately before `package`.
The assembly still sees the unpacked layout, and the test phase never reaches it.

Same fix as `drat@1342ccce`, which carried the identical binding.

| | before | after |
|---|---|---|
| `mvn clean test` | build failure | BUILD SUCCESS |
| `mvn clean install` | success | success, distribution intact |
| `pytest tests/` | 193 passed | 193 passed |

Distribution verified unchanged after the phase move: all four webapps present
(`fmprod`, `opsui`, `pcs`, `solr`).