### PR TITLE
Ban the retired OODT coordinates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <oodt.version>1.11.0</oodt.version>
     <junit.version>4.12</junit.version>
+    <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
     <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
     <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
     <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
@@ -69,6 +70,43 @@
     <sourceDirectory>${basedir}/src/main/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>
     <plugins>
+      <!--
+        BigTranslate depends on Mnemosyne, which keeps its Java packages as
+        org.apache.oodt.*. Its classes therefore share fully-qualified names
+        with the retired org.apache.oodt artifacts still on Maven Central.
+        Maven treats those as unrelated artifacts because the groupIds differ,
+        so dependency mediation will not collapse them: if one reaches the tree
+        transitively, the classpath silently carries two copies of every class.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven.enforcer.plugin.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-no-retired-oodt</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>org.apache.oodt:*</exclude>
+                  </excludes>
+                  <message>
+                    org.apache.oodt artifacts are the retired Apache OODT
+                    release line, superseded by ai.mattmann.mnemosyne. Exclude
+                    them where they enter the tree rather than relaxing this
+                    rule.
+                  </message>
+                </bannedDependencies>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Mnemosyne keeps its Java packages as `org.apache.oodt.*`, so its classes share
fully-qualified names with the retired `org.apache.oodt` artifacts still on
Maven Central — 249 of `cas-filemgr`'s classes are name-identical between
`org.apache.oodt:cas-filemgr:1.9.1` and `ai.mattmann.mnemosyne:cas-filemgr:1.11.0`.

Because the groupIds differ, **Maven treats them as unrelated artifacts and will
not collapse them.** If one reaches this tree transitively, the classpath
silently carries two copies of every class, resolved by classpath order rather
than by dependency mediation.

This project depended on `org.apache.oodt` directly until recently, which makes
it one of the likeliest places for a stale coordinate to reappear. Mnemosyne's
own enforcer rule only guards Mnemosyne's tree, so the protection has to live
here too.

`maven-enforcer-plugin` with `bannedDependencies` on `org.apache.oodt:*`, in the
root pom so every module inherits it.

Verified in **both** directions, since a rule that never fires is worse than no
rule:

- runs across **15 modules** and passes on a clean tree
- injecting `org.apache.oodt:cas-metadata:1.9.1` fails the build:
  ```
  [ERROR] BannedDependencies failed with message:
  [ERROR]    org.apache.oodt:cas-metadata:jar:1.9.1 <--- banned via the exclude/include list
  ```

The usual remedy — a `<relocation>` POM under the old coordinates — is
unavailable, since that requires owning the `org.apache.oodt` groupId.