### PR TITLE
Add README badges matching DRAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 BigTranslate
 ============
 
+[![Build](https://github.com/chrismattmann/bigtranslate/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/chrismattmann/bigtranslate/actions/workflows/build.yml)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![JDK](https://img.shields.io/badge/JDK-21-orange.svg)](https://adoptium.net/)
+[![Powered by Mnemosyne](https://img.shields.io/badge/powered%20by-Mnemosyne%201.11.0-6E4B8E.svg)](https://github.com/chrismattmann/mnemosyne)
+
 A distributed, parallelized (Map Reduce) wrapper around [Apache&trade; Tika](http://tika.apache.org/) and its Translation API provided by [Tika-Python](http://github.com/chrismattmann/tika-python). BigTranslate uses Apache&trade; OODT to split and distribute machine translation of many millions of rows of data. The system has been tested on up to 190 million rows of TSV data involving millions of translations on 16-core nodes and finishes in reasonable amounts of time. BigTranslate uses [ETLLib](http://github.com/chrismattmann/etllib/) to provide a clean facade to JSON and TSV data processing, and to prepare data for translation using Tika. Once the data is translated it is ingested into Apache&trade; Solr for querying and large scale analytics and retrieval.
 
 Apache&trade; Tika provides a facade to and has been tested with the following Machine Translation APIs.


### PR DESCRIPTION
Adds the DRAT-style README badges that apply to this repo:

- **Build** — GitHub Actions `build.yml`
- **License** — Apache 2.0
- **JDK** — 21 (matches CI)
- **Powered by Mnemosyne** — 1.11.0

Site and Website badges are omitted; this repo has no `site.yml` workflow and no GitHub Pages site.