### PR TITLE
Resolve Mnemosyne from Maven Central instead of building it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,8 @@ jobs:
       - name: Test
         run: python -m pytest tests/ -v
 
-  # Packaging check against Mnemosyne, the continuation of Apache OODT after
-  # the ASF retired it to the Attic. Mnemosyne is built from source until
-  # ai.mattmann.mnemosyne:1.11.0 is published to Maven Central, at which point
-  # this checkout and install step can be dropped entirely.
+  # Packaging check. Mnemosyne resolves from Maven Central as
+  # ai.mattmann.mnemosyne:1.11.0, so there is nothing to build from source.
   package:
     name: Maven package (JDK 21)
     runs-on: ubuntu-latest
@@ -41,16 +39,6 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
           cache: maven
-
-      - name: Check out Mnemosyne
-        uses: actions/checkout@v4
-        with:
-          repository: chrismattmann/mnemosyne
-          path: mnemosyne
-
-      - name: Install Mnemosyne 1.11.0
-        working-directory: mnemosyne
-        run: mvn -B -q install -DskipTests -Dmaven.javadoc.skip=true
 
       - name: Package BigTranslate
         run: mvn -B package -DskipTests


### PR DESCRIPTION
`ai.mattmann.mnemosyne:1.11.0` is [live on Maven Central](https://repo1.maven.org/maven2/ai/mattmann/mnemosyne/),
so CI no longer needs to check out `chrismattmann/mnemosyne` and `mvn install`
it before every build.

Verified by resolving `cas-filemgr:1.11.0` into an **empty** local repository —
it downloads from Central rather than quietly reusing a local install, which is
the failure mode that would make this look fine locally and break in CI.

Removes several minutes from every run.