### PR TITLE
Install etllib for tsvtojson, repackage, and poster

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,13 @@ A distributed, parallelized (Map Reduce) system that uses [Pantogloss](https://g
 
 Translation is performed by Pantogloss with a Spanish&rarr;English employment glossary and a local cache. The PGE `pantogloss-translatejson` runs the model offline over selected columns.
 
-Install ETLLib with the `translate` extra (Python 3.10+, plus libmagic):
+Install ETLLib (Python 3.10+, plus libmagic) so `tsvtojson`, `repackage`, and `poster` are on your `PATH`. Translation is Pantogloss; the `etllib[translate]` extra is not needed:
 
 ```bash
-python3 -m pip install "etllib[translate] @ git+https://github.com/chrismattmann/etllib.git"
+python3 -m pip install "etllib @ git+https://github.com/chrismattmann/etllib.git"
 # or, from this repo:
 python3 -m pip install -r requirements.txt
 ```
-
-`[translate]` pulls hirlite for etllib's `translatejson` CLI. The PGE itself uses `pantogloss-translatejson`. If hirlite fails to build, `python3 -m pip install "etllib @ git+https://github.com/chrismattmann/etllib.git"` is enough for `tsvtojson` / `repackage` / `poster`.
 
 See the wiki for more information on installing and running BigTranslate:  
 * [Installation instructions](https://github.com/chrismattmann/bigtranslate/wiki/Installation)  

--- a/README.md
+++ b/README.md
@@ -7,9 +7,19 @@ BigTranslate
 [![Powered by Mnemosyne](https://img.shields.io/badge/powered%20by-Mnemosyne%201.11.0-6E4B8E.svg)](https://github.com/chrismattmann/mnemosyne)
 [![Website](https://img.shields.io/badge/website-chrismattmann.github.io%2Fbigtranslate-informational.svg)](https://chrismattmann.github.io/bigtranslate/)
 
-A distributed, parallelized (Map Reduce) system that uses [Pantogloss](https://github.com/chrismattmann/pantogloss) to machine-translate many millions of rows of TSV data. Pantogloss is a TensorFlow/Keras many-to-English library that runs locally — no hosted translation APIs. BigTranslate uses [Mnemosyne](https://github.com/chrismattmann/mnemosyne) to split and distribute those translations. The system has been tested on up to 190 million rows of TSV data involving millions of translations on 16-core nodes and finishes in reasonable amounts of time. BigTranslate uses [ETLLib](http://github.com/chrismattmann/etllib/) to provide a clean facade to JSON and TSV data processing, and to prepare records for Pantogloss. Once the data is translated it is ingested into Apache&trade; Solr for querying and large scale analytics and retrieval.
+A distributed, parallelized (Map Reduce) system that uses [Pantogloss](https://github.com/chrismattmann/pantogloss) to machine-translate many millions of rows of TSV data. Pantogloss is a TensorFlow/Keras many-to-English library that runs locally — no hosted translation APIs. BigTranslate uses [Mnemosyne](https://github.com/chrismattmann/mnemosyne) to split and distribute those translations. The system has been tested on up to 190 million rows of TSV data involving millions of translations on 16-core nodes and finishes in reasonable amounts of time. BigTranslate uses [ETLLib](https://github.com/chrismattmann/etllib/) (`tsvtojson`, `repackage`, `poster`) to prepare records for Pantogloss. Once the data is translated it is ingested into Apache&trade; Solr for querying and large scale analytics and retrieval.
 
 Translation is performed by Pantogloss with a Spanish&rarr;English employment glossary and a local cache. The PGE `pantogloss-translatejson` runs the model offline over selected columns.
+
+Install ETLLib with the `translate` extra (Python 3.10+, plus libmagic):
+
+```bash
+python3 -m pip install "etllib[translate] @ git+https://github.com/chrismattmann/etllib.git"
+# or, from this repo:
+python3 -m pip install -r requirements.txt
+```
+
+`[translate]` pulls hirlite for etllib's `translatejson` CLI. The PGE itself uses `pantogloss-translatejson`. If hirlite fails to build, `python3 -m pip install "etllib @ git+https://github.com/chrismattmann/etllib.git"` is enough for `tsvtojson` / `repackage` / `poster`.
 
 See the wiki for more information on installing and running BigTranslate:  
 * [Installation instructions](https://github.com/chrismattmann/bigtranslate/wiki/Installation)  

--- a/docs/Building BigTranslate
+++ b/docs/Building BigTranslate
@@ -2,12 +2,18 @@ Requirements for BigTranslate
 
 REQUIREMENTS:
 
-* Java Development Kit (JDK) 1.6+
-* JAVA_HOME set 
-* Python 2.7
-* ETLlib installed and available on the Path.
-* Tika-Python installed and available on the Path.
-* OODT version 0.10-SNAPSHOT
+* Java Development Kit (JDK) 21
+* JAVA_HOME set
+* Python 3.10+
+* ETLLib on PATH: `pip install "etllib[translate] @ git+https://github.com/chrismattmann/etllib.git"`
+  (or `pip install -r requirements.txt` from this repo). The PGE uses
+  `tsvtojson`, `repackage`, and `poster`; translation is Pantogloss, not
+  etllib's `translatejson`.
+* Pantogloss importable (`from pantogloss import Translator`)
+* libmagic
+* Mnemosyne 1.11.0 (resolved from Maven Central)
+
+Current walkthrough: https://github.com/chrismattmann/bigtranslate/wiki/Installation
 
 INSTALLATION:
 

--- a/docs/Building BigTranslate
+++ b/docs/Building BigTranslate
@@ -5,10 +5,10 @@ REQUIREMENTS:
 * Java Development Kit (JDK) 21
 * JAVA_HOME set
 * Python 3.10+
-* ETLLib on PATH: `pip install "etllib[translate] @ git+https://github.com/chrismattmann/etllib.git"`
+* ETLLib on PATH: `pip install "etllib @ git+https://github.com/chrismattmann/etllib.git"`
   (or `pip install -r requirements.txt` from this repo). The PGE uses
   `tsvtojson`, `repackage`, and `poster`; translation is Pantogloss, not
-  etllib's `translatejson`.
+  etllib's `translatejson`. The `etllib[translate]` extra is not required.
 * Pantogloss importable (`from pantogloss import Translator`)
 * libmagic
 * Mnemosyne 1.11.0 (resolved from Maven Central)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Python side of the pipeline. tsvtojson, repackage, and poster come from
+# etllib. The [translate] extra pulls hirlite for etllib's translatejson CLI;
+# the PGE itself translates with pantogloss-translatejson.
+etllib[translate] @ git+https://github.com/chrismattmann/etllib.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Python side of the pipeline. tsvtojson, repackage, and poster come from
-# etllib. The [translate] extra pulls hirlite for etllib's translatejson CLI;
-# the PGE itself translates with pantogloss-translatejson.
-etllib[translate] @ git+https://github.com/chrismattmann/etllib.git
+# etllib. Translation is pantogloss-translatejson, so the [translate] extra
+# (hirlite) is not required.
+etllib @ git+https://github.com/chrismattmann/etllib.git


### PR DESCRIPTION
BigTranslate never showed a pip command for ETLLib. This adds \`requirements.txt\` and documents:

\`\`\`
python3 -m pip install \"etllib @ git+https://github.com/chrismattmann/etllib.git\"
\`\`\`

The \`[translate]\` extra is **not** used: translation is \`pantogloss-translatejson\`, not etllib's \`translatejson\`.