### PR TITLE
Speak Avro to the resource manager, not XML-RPC

### DIFF
--- a/filemgr/src/main/resources/etc/filemgr.fm-solr-catalog.properties
+++ b/filemgr/src/main/resources/etc/filemgr.fm-solr-catalog.properties
@@ -33,6 +33,8 @@ filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataT
 filemgr.validationLayer.factory=org.apache.oodt.cas.filemgr.validation.XMLValidationLayerFactory
 
 # xml rpc client configuration
+# Read only by the XML-RPC client. This deployment selects Avro above,
+# so these have no effect at present.
 org.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
 org.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
 #org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retries=0

--- a/filemgr/src/main/resources/etc/filemgr.properties
+++ b/filemgr/src/main/resources/etc/filemgr.properties
@@ -32,6 +32,8 @@ filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataT
 filemgr.validationLayer.factory=org.apache.oodt.cas.filemgr.validation.XMLValidationLayerFactory
 
 # xml rpc client configuration
+# Read only by the XML-RPC client. This deployment selects Avro above,
+# so these have no effect at present.
 org.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
 org.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
 #org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retries=0

--- a/resmgr/src/main/resources/bin/batch_stub
+++ b/resmgr/src/main/resources/bin/batch_stub
@@ -26,6 +26,6 @@ if ( $#argv != 1 ) then
         exit 1
 else
         java -cp "../lib/*" \
-        org.apache.oodt.cas.resource.system.extern.XmlRpcBatchStub \
+        org.apache.oodt.cas.resource.system.extern.AvroRpcBatchStub \
         --portNum $1&
 endif

--- a/resmgr/src/main/resources/bin/resmgr-client
+++ b/resmgr/src/main/resources/bin/resmgr-client
@@ -31,4 +31,4 @@ $JAVA_HOME/bin/java \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \
         -Dorg.apache.oodt.cas.cli.option.spring.config=../policy/cmd-line-options.xml \
-        org.apache.oodt.cas.resource.system.XmlRpcResourceManagerClient $*
+        org.apache.oodt.cas.resource.system.ResourceManagerClientMain $*

--- a/resmgr/src/main/resources/etc/resource.properties
+++ b/resmgr/src/main/resources/etc/resource.properties
@@ -16,8 +16,15 @@
 #
 # Properties required to configure the Resource Manager
 
+# RPC implementation for the resource manager itself
+resmgr.manager=org.apache.oodt.cas.resource.system.AvroRpcResourceManager
+resmgr.manager.client=org.apache.oodt.cas.resource.system.AvroRpcResourceManagerClient
+
 # resource batchmgr factory
-resource.batchmgr.factory = org.apache.oodt.cas.resource.batchmgr.XmlRpcBatchMgrFactory
+# Avro. XML-RPC is on its way out of Mnemosyne: Apache XML-RPC has had no
+# release in over a decade and is the last thing keeping commons-httpclient
+# 3.x, and its unfixed CVE-2012-5783, on the classpath.
+resource.batchmgr.factory = org.apache.oodt.cas.resource.batchmgr.AvroRpcBatchMgrFactory
 
 # resource monitor factory
 resource.monitor.factory = org.apache.oodt.cas.resource.monitor.AssignmentMonitorFactory
@@ -44,6 +51,7 @@ org.apache.oodt.cas.resource.jobqueue.jobstack.maxstacksize=1000
 org.apache.oodt.cas.resource.scheduler.wait.seconds=20
 
 # XML-RPC configuration props
+# Read only by the XML-RPC client, which is no longer selected above.
 org.apache.oodt.cas.resource.system.xmlrpc.requestTimeout.minutes=20
 org.apache.oodt.cas.resource.system.xmlrpc.connectionTimeout.minutes=60
 

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -96,6 +96,39 @@ class TestAvroTransport:
                        "/filemgr.fm-solr-catalog.properties").read_text()
         assert "AvroFileManagerServerFactory" in text
 
+    def test_resmgr_declares_avro_transport(self):
+        # The resource manager was the last part still speaking XML-RPC here,
+        # and it named the transport in three separate places: the batch
+        # manager factory, the batch stub launcher, and the client launcher.
+        text = (REPO / "resmgr/src/main/resources/etc/resource.properties").read_text()
+        assert "AvroRpcResourceManager" in text
+        assert "AvroRpcResourceManagerClient" in text
+        assert "AvroRpcBatchMgrFactory" in text
+
+    def test_resmgr_scripts_do_not_name_xmlrpc(self):
+        for name, expected in (("batch_stub", "AvroRpcBatchStub"),
+                               ("resmgr-client", "ResourceManagerClientMain")):
+            matches = [p for p in launcher_scripts() if p.name == name]
+            assert matches, "launcher %s not found" % name
+            text = matches[0].read_text()
+            assert expected in text
+            assert "XmlRpc" not in text
+
+    def test_no_active_xmlrpc_selection_anywhere(self):
+        # A commented-out XML-RPC option is fine; a live one is not. Apache
+        # XML-RPC is being retired from Mnemosyne, and it is the last thing
+        # keeping commons-httpclient 3.x and CVE-2012-5783 on the classpath.
+        offenders = []
+        for path in REPO.glob("*/src/main/resources/etc/*.properties"):
+            for num, line in enumerate(path.read_text().splitlines(), 1):
+                stripped = line.strip()
+                if stripped.startswith("#") or "=" not in stripped:
+                    continue
+                value = stripped.split("=", 1)[1]
+                if "XmlRpc" in value:
+                    offenders.append("%s:%d" % (path.name, num))
+        assert not offenders, "XML-RPC still selected in: %s" % offenders
+
     def test_workflow_declares_avro_factories(self):
         text = (REPO / "workflow/src/main/resources/etc/workflow.properties").read_text()
         assert "AvroRpcWorkflowManagerFactory" in text


### PR DESCRIPTION
First step of [mnemosyne#93](https://github.com/chrismattmann/mnemosyne/issues/93), and the companion to [drat#208](https://github.com/chrismattmann/drat/pull/208).

## What changed

The file manager and workflow manager were **already** on Avro here. The resource manager was the last holdout, and it named the transport in three separate places:

| | was | now |
|---|---|---|
| `resource.batchmgr.factory` | `XmlRpcBatchMgrFactory` | `AvroRpcBatchMgrFactory` |
| `batch_stub` | `XmlRpcBatchStub` | `AvroRpcBatchStub` |
| `resmgr-client` | `XmlRpcResourceManagerClient` | `ResourceManagerClientMain` |
| `resmgr.manager` / `.client` | unset, a default decided | named explicitly |

`resmgr-client` now goes through the factory rather than naming one implementation, so this deployment follows what its configuration says instead of whatever class the script happened to launch. The Avro batch stub takes the same `--portNum`, so the scripts are a drop-in swap.

## Tests

Three added to the `TestAvroTransport` class that already guards this:

- the resmgr properties declare the Avro transport and batch manager
- neither resmgr script names `XmlRpc`
- **no properties file anywhere selects an XML-RPC implementation on a live line**

That last one is the interesting one. It scans every `etc/*.properties` and fails on any uncommented value naming `XmlRpc`, so this cannot quietly come back the way the `java.ext.dirs` flags did. A commented-out option stays legal — that is documentation, not configuration.

Verified by running the assertions directly, since `pytest` is not installed on this machine; CI runs them properly.

## Verification

Checked in the **built tarball**, not just the source:

```
resmgr/etc/resource.properties:
  resmgr.manager=...AvroRpcResourceManager
  resmgr.manager.client=...AvroRpcResourceManagerClient
  resource.batchmgr.factory = ...AvroRpcBatchMgrFactory

resmgr/bin/batch_stub     -> ...system.extern.AvroRpcBatchStub
resmgr/bin/resmgr-client  -> ...system.ResourceManagerClientMain
resmgr/bin/resmgr         -> ...system.ResourceManagerMain
```

`mvn -B clean package`: **BUILD SUCCESS**. No uncommented `XmlRpc` reference remains in any source or config.

## What this does not do

`commons-httpclient` is still resolved, because this builds against the published `cas-resource` and that still declares it. Nothing here calls it any more; the jar leaves when Mnemosyne removes XML-RPC and releases — step 3 of the tracking issue.