### PR TITLE
Restore proper logging configuration

### DIFF
--- a/crawler/src/main/assembly/assembly.xml
+++ b/crawler/src/main/assembly/assembly.xml
@@ -49,6 +49,7 @@
       <outputDirectory>crawler/etc</outputDirectory>
       <includes>
         <include>**.properties</include>
+        <include>**.xml</include>
       </includes>
     </fileSet>
     <fileSet>

--- a/crawler/src/main/resources/bin/crawlctl
+++ b/crawler/src/main/resources/bin/crawlctl
@@ -15,4 +15,4 @@
 # under the License.    
 ##########################################################################
 
-java -Djava.util.logging.config.file=../etc/logging.properties -cp "../lib/*" org.apache.oodt.cas.crawl.daemon.CrawlDaemonController $@
+java -Dlog4j.configurationFile=../etc/log4j2.xml -Djava.util.logging.config.file=../etc/logging.properties -cp "../lib/*" org.apache.oodt.cas.crawl.daemon.AvroRpcCrawlDaemonController $@

--- a/crawler/src/main/resources/bin/crawler_launcher
+++ b/crawler/src/main/resources/bin/crawler_launcher
@@ -69,6 +69,7 @@ cd "$CRAWLER_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
    -cp "$CRAWLER_HOME/lib/*" \
+   -Dlog4j.configurationFile="$CRAWLER_HOME"/etc/log4j2.xml \
    -Djava.util.logging.config.file="$CRAWLER_HOME"/etc/logging.properties \
    -Dorg.apache.oodt.cas.crawl.bean.repo=file:"$CRAWLER_HOME"/policy/crawler-config.xml \
    -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$CRAWLER_HOME"/policy/cmd-line-actions.xml \

--- a/crawler/src/main/resources/etc/log4j2.xml
+++ b/crawler/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the BigTranslate crawler.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several BigTranslate steps pipe one OODT tool into another, and anything on
+  stdout is read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_crawler.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/crawler/src/main/resources/etc/logging.properties
+++ b/crawler/src/main/resources/etc/logging.properties
@@ -20,12 +20,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -38,16 +36,11 @@ java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
     
 # Set the default logging level for the subsystems
 
-org.apache.oodt.cas.crawl.level = ALL
-
-org.apache.oodt.cas.crawl.action.level = ALL
-
-org.apache.oodt.cas.crawl.typedetection.level = ALL
-
-org.apache.oodt.cas.crawl.util.level = ALL
-
-org.apache.oodt.cas.crawl.config.level = ALL
-
+org.apache.oodt.cas.crawl.level = INFO
+org.apache.oodt.cas.crawl.action.level = INFO
+org.apache.oodt.cas.crawl.typedetection.level = INFO
+org.apache.oodt.cas.crawl.util.level = INFO
+org.apache.oodt.cas.crawl.config.level = INFO
 # control the underlying commons-httpclient transport layer for xmlrpc 
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO

--- a/filemgr/src/main/assembly/assembly.xml
+++ b/filemgr/src/main/assembly/assembly.xml
@@ -57,6 +57,7 @@
       <outputDirectory>filemgr/etc</outputDirectory>
       <includes>
         <include>filemgr.properties</include>
+        <include>logging.properties</include>
         <include>**.xml</include>
       </includes>
       <fileMode>664</fileMode>

--- a/filemgr/src/main/resources/bin/filemgr
+++ b/filemgr/src/main/resources/bin/filemgr
@@ -82,6 +82,7 @@ if [ "$1" = "start" ]; then
   
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
     -cp "$FILEMGR_HOME/lib/*" \
+    -Dlog4j.configurationFile="$FILEMGR_HOME"/etc/log4j2.xml \
     -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/filemgr/src/main/resources/bin/filemgr-client
+++ b/filemgr/src/main/resources/bin/filemgr-client
@@ -71,6 +71,7 @@ cd "$FILEMGR_HOME"/bin
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
   -cp "$FILEMGR_HOME/lib/*" \
   -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
+  -Dlog4j.configurationFile="$FILEMGR_HOME"/etc/log4j2.xml \
   -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$FILEMGR_HOME"/policy/cmd-line-options.xml \

--- a/filemgr/src/main/resources/bin/query-tool
+++ b/filemgr/src/main/resources/bin/query-tool
@@ -74,6 +74,7 @@ cd "$FILEMGR_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
   -Dorg.apache.oodt.cas.filemgr.properties="$FILEMGR_HOME"/etc/filemgr.properties \
+  -Dlog4j.configurationFile="$FILEMGR_HOME"/etc/log4j2.xml \
   -Djava.util.logging.config.file="$FILEMGR_HOME"/etc/logging.properties \
   -cp "$FILEMGR_HOME/lib/*" \
   org.apache.oodt.cas.filemgr.tools.QueryTool "$@"

--- a/filemgr/src/main/resources/etc/log4j2.xml
+++ b/filemgr/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the BigTranslate filemgr.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several BigTranslate steps pipe one OODT tool into another, and anything on
+  stdout is read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_filemgr.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/filemgr/src/main/resources/etc/logging.properties
+++ b/filemgr/src/main/resources/etc/logging.properties
@@ -19,12 +19,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -41,8 +39,7 @@ java.util.logging.FileHandler.formatter = java.util.logging.SimpleFormatter
 org.apache.oodt.cas.filemgr.catalog.level = INFO
 
 # repository subsystem
-org.apache.oodt.cas.filemgr.repository.level = FINE
-
+org.apache.oodt.cas.filemgr.repository.level = INFO
 # system subsystem
 org.apache.oodt.cas.filemgr.system.level = INFO
 
@@ -50,8 +47,7 @@ org.apache.oodt.cas.filemgr.system.level = INFO
 org.apache.oodt.cas.filemgr.versioning.level = INFO
 
 # data transfer subsystem
-org.apache.oodt.cas.filemgr.datatransfer.level = FINE
-
+org.apache.oodt.cas.filemgr.datatransfer.level = INFO
 # util
 org.apache.oodt.cas.filemgr.util.level = INFO
 

--- a/pcs/src/main/resources/bin/pcs_ll
+++ b/pcs/src/main/resources/bin/pcs_ll
@@ -41,7 +41,8 @@ cd $DIR
 set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
-java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
+java -Dlog4j.configurationFile=$DIR_PATH/../etc/log4j2.xml \
+     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*" \
 	org.apache.oodt.pcs.tools.PCSLongLister \
 	$FILEMGR_URL $DIR_PATH/../policy/pcs-ll-conf.xml $argv[2-$#argv]

--- a/pcs/src/main/resources/bin/pcs_stat
+++ b/pcs/src/main/resources/bin/pcs_stat
@@ -67,7 +67,8 @@ cd $DIR
 set DIR_PATH = `pwd`
 cd $ORIG_DIR
 
-java -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
+java -Dlog4j.configurationFile=$DIR_PATH/../etc/log4j2.xml \
+     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*:$DIR_PATH/../../resmgr/lib/*" \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSHealthMonitor \

--- a/pcs/src/main/resources/bin/pcs_trace
+++ b/pcs/src/main/resources/bin/pcs_trace
@@ -30,7 +30,8 @@ if ( $#argv != 1 ) then
 	exit 1
 else
 	java -cp "$DIR_PATH/../lib/*:$DIR_PATH/../../filemgr/lib/*:$DIR_PATH/../../workflow/lib/*" \
-    -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
+    -Dlog4j.configurationFile=$DIR_PATH/../etc/log4j2.xml \
+     -Djava.util.logging.config.file=$DIR_PATH/../etc/logging.properties \
     -Dorg.apache.oodt.cas.filemgr.properties=$DIR_PATH/../../filemgr/etc/filemgr.properties \
 	org.apache.oodt.pcs.tools.PCSTrace \
 	--fm $FILEMGR_URL \

--- a/pcs/src/main/resources/etc/log4j2.xml
+++ b/pcs/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the BigTranslate pcs.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several BigTranslate steps pipe one OODT tool into another, and anything on
+  stdout is read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_pcs.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/pcs/src/main/resources/etc/logging.properties
+++ b/pcs/src/main/resources/etc/logging.properties
@@ -19,11 +19,9 @@
 handlers = java.util.logging.ConsoleHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
     

--- a/resmgr/src/main/resources/bin/resmgr
+++ b/resmgr/src/main/resources/bin/resmgr
@@ -88,6 +88,7 @@ if [ "$1" = "start" ]; then
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
     -cp "$RESMGR_HOME/lib/*" \
+    -Dlog4j.configurationFile="$RESMGR_HOME"/etc/log4j2.xml \
     -Djava.util.logging.config.file="$RESMGR_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.resource.properties="$RESMGR_HOME"/etc/resource.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/resmgr/src/main/resources/bin/resmgr-client
+++ b/resmgr/src/main/resources/bin/resmgr-client
@@ -28,6 +28,7 @@ export JAVA_HOME
 $JAVA_HOME/bin/java \
         -cp "../lib/*" \
         -Dorg.apache.oodt.cas.resource.properties=../etc/resource.properties \
+        -Dlog4j.configurationFile=../etc/log4j2.xml \
         -Djava.util.logging.config.file=../etc/logging.properties \
         -Dorg.apache.oodt.cas.cli.action.spring.config=../policy/cmd-line-actions.xml \
         -Dorg.apache.oodt.cas.cli.option.spring.config=../policy/cmd-line-options.xml \

--- a/resmgr/src/main/resources/etc/log4j2.xml
+++ b/resmgr/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the BigTranslate resmgr.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several BigTranslate steps pipe one OODT tool into another, and anything on
+  stdout is read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_resource.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/resmgr/src/main/resources/etc/logging.properties
+++ b/resmgr/src/main/resources/etc/logging.properties
@@ -20,12 +20,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -51,8 +49,7 @@ org.apache.oodt.cas.resource.jobqueue.level = INFO
 org.apache.oodt.cas.resource.scheduler.level = INFO
 
 # system subsystem
-org.apache.oodt.cas.resource.system.level = FINE
-
+org.apache.oodt.cas.resource.system.level = INFO
 # control the underlying commons-httpclient transport layer for xmlrpc 
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO

--- a/workflow/src/main/resources/bin/wmgr
+++ b/workflow/src/main/resources/bin/wmgr
@@ -81,6 +81,7 @@ if [ "$1" = "start" ]; then
 
   "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
     -cp "$WORKFLOW_HOME/lib/*" \
+    -Dlog4j.configurationFile="$WORKFLOW_HOME"/etc/log4j2.xml \
     -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
     -Dorg.apache.oodt.cas.workflow.properties="$WORKFLOW_HOME"/etc/workflow.properties \
     -Djava.io.tmpdir="$OODT_TMPDIR" \

--- a/workflow/src/main/resources/bin/wmgr-client
+++ b/workflow/src/main/resources/bin/wmgr-client
@@ -69,6 +69,7 @@ cd "$WORKFLOW_HOME"/bin
 
 "$_RUNJAVA" $JAVA_OPTS $OODT_OPTS \
   -cp "$WORKFLOW_HOME/lib/*" \
+  -Dlog4j.configurationFile="$WORKFLOW_HOME"/etc/log4j2.xml \
   -Djava.util.logging.config.file="$WORKFLOW_HOME"/etc/logging.properties \
   -Dorg.apache.oodt.cas.cli.action.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-actions.xml \
   -Dorg.apache.oodt.cas.cli.option.spring.config=file:"$WORKFLOW_HOME"/policy/cmd-line-options.xml \

--- a/workflow/src/main/resources/etc/log4j2.xml
+++ b/workflow/src/main/resources/etc/log4j2.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Logging configuration for the BigTranslate workflow.
+
+  The console carries only what someone needs to act on, and writes to stderr:
+  several BigTranslate steps pipe one OODT tool into another, and anything on
+  stdout is read as data. The file appender keeps the full record.
+
+  The start script points at this file with -Dlog4j.configurationFile. Without
+  it log4j2 falls back to its default, which is ERROR to the console and no
+  file appender at all.
+-->
+<Configuration status="WARN">
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="error" onMatch="ACCEPT" onMismatch="DENY"/>
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="../logs/cas_workflow.log" immediateFlush="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="org.springframework" level="error"/>
+        <Logger name="org.mortbay" level="error"/>
+        <Logger name="org.apache.avro.ipc" level="warn"/>
+        <Logger name="org.jboss.netty" level="warn"/>
+
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/workflow/src/main/resources/etc/logging.properties
+++ b/workflow/src/main/resources/etc/logging.properties
@@ -19,12 +19,10 @@
 handlers = java.util.logging.ConsoleHandler, java.util.logging.FileHandler
 
 # Set the default logging level for the root logger
-.level = ALL
-    
+.level = INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level = ALL
-java.util.logging.FileHandler.level = ALL
-        
+java.util.logging.ConsoleHandler.level = SEVERE
+java.util.logging.FileHandler.level = INFO
 # Set the default formatter for new ConsoleHandler instances
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
@@ -50,8 +48,7 @@ org.apache.oodt.cas.workflow.instrepo.level = INFO
 org.apache.oodt.cas.workflow.repository.level = INFO
 
 # system subsystem
-org.apache.oodt.cas.workflow.system.level = FINE
-
+org.apache.oodt.cas.workflow.system.level = INFO
 # control the underlying commons-httpclient transport layer for xmlrpc 
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO


### PR DESCRIPTION
Closes #30.

Three problems, one of which was breaking the pipeline.

## Levels

All five `etc/logging.properties` shipped `.level = ALL`, with the console and file handlers at `ALL` too. `ALL` means FINE, FINER and FINEST — that is the noise. Now `INFO`, console at `SEVERE`.

## There was no log4j2 configuration at all

OODT routes slf4j through log4j2. BigTranslate shipped no `log4j2.xml` and passed no `-Dlog4j.configurationFile`, so logging was configured by whichever `log4j2.xml` happened to be first on the classpath — one packaged inside `cas-workflow`, set to `<Root level="debug">` writing to `SYSTEM_OUT`.

**That broke the post-ingest PGE.** It pipes one file manager tool into another:

```
query-tool --url ... -query "SELECT CAS.ProductId FROM ..." | DeleteProduct --read
```

and `DeleteProduct` got a Netty debug line where a product id belonged:

```
CatalogException: Product: [18:54:07.833 [main] DEBUG org.apache.avro.ipc.NettyTransceiver -
Using Netty bootstrap options: {connectTimeoutMillis=40000, ...}] NOT found in the catalog!
```

Each component now has an `etc/log4j2.xml` — root `info`, console gated to errors on **stderr**, file appender keeping the full record — and all **12** scripts pass `-Dlog4j.configurationFile` beside the `-Djava.util.logging.config.file` they already passed.

| | Before | After |
|---|---|---|
| Console output, stack startup | 67,003 lines | **14** (all JVM warnings) |
| On-disk record | none from log4j2 | `cas_filemgr.log`, `cas_workflow.log`, `cas_resource.log` at INFO |

## This is also required by mnemosyne#96

chrismattmann/mnemosyne#96 stops library jars carrying logging config. Without our own, we would fall back to log4j2's default — errors to console, **no file appender at all** — and lose the on-disk record.

## Two things found while doing it

**`crawlctl` named a deleted class.** It invoked `org.apache.oodt.cas.crawl.daemon.CrawlDaemonController`, removed with XML-RPC in mnemosyne#95 — `ClassNotFoundException` the first time anyone controlled a crawl daemon after upgrading. Now `AvroRpcCrawlDaemonController`.

**Two assembly gaps.** The filemgr assembly never shipped `etc/logging.properties`, although every filemgr script passes `-Djava.util.logging.config.file` pointing at it — so those settings had never once taken effect. The crawler assembly matched only `**.properties` for `etc/`, so its new `log4j2.xml` would not have shipped either. Both fixed. I only caught these by unpacking the tarball and looking at what actually landed in `etc/`.

## Verified end to end

Stack starts, the TSV crawls and ingests (`EmploymentJobAggregatesTsv` 1 product), the split workflow produces `EmploymentJobAggregatesTsvSplit`, both workflows report `FINISHED`, and the `query-tool` pipe no longer carries a log line — zero occurrences of the `CatalogException` above, against two on the previous run.