### PR TITLE
Install the Python tools from the distribution instead of by hand

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,43 @@ A distributed, parallelized (Map Reduce) system that uses [Pantogloss](https://g
 
 Translation is performed by Pantogloss with a Spanish&rarr;English employment glossary and a local cache. The PGE `pantogloss-translatejson` runs the model offline over selected columns.
 
-Install ETLLib (Python 3.10+, plus libmagic) so `tsvtojson`, `repackage`, and `poster` are on your `PATH`. Translation is Pantogloss; the `etllib[translate]` extra is not needed:
+BigTranslate needs the Python tools `tsvtojson`, `repackage` and `poster` from
+ETLLib (Python 3.10+, plus libmagic). In an unpacked distribution, one command
+installs them into a virtual environment beside the services:
 
 ```bash
-python3 -m pip install "etllib @ git+https://github.com/chrismattmann/etllib.git"
-# or, from this repo:
+PANTOGLOSS_SOURCE=~/git/pantogloss bin/bigtranslate-setup
+bin/oodt restart
+```
+
+Pantogloss is not in `requirements.txt` because it is not published, so
+`PANTOGLOSS_SOURCE` points the setup script at a checkout, a wheel, or any pip
+specifier. It goes into the same environment as ETLLib rather than one of its
+own: the PGE runs `pantogloss-translatejson` through `#!/usr/bin/env python3`,
+which picks whichever interpreter is first on `PATH`. Omit `PANTOGLOSS_SOURCE`
+if you only want the ETLLib tools; the setup script says which of the four it
+ended up with.
+
+Use Python 3.10--3.12. Pantogloss needs TensorFlow 2.18, which publishes no
+wheels above 3.12, so `bigtranslate-setup` prefers `python3.12` and works down
+from there. `PYTHON` overrides the choice.
+
+The restart matters. The PGEs that call these tools are run by the workflow
+manager and inherit *its* environment, so putting the tools on your own `PATH`
+is not enough; `env.sh` adds `$BIGTRANSLATE_HOME/.venv/bin` when the services
+start. `bin/bigtranslate translate` checks the tools resolve before it does
+anything, because without them each step logs "command not found" into its own
+file while the workflow still reports `FINISHED` -- a run that looks like it
+worked and translated nothing.
+
+To install into an environment you manage yourself instead, the dependency list
+is `requirements.txt`, shipped in the distribution:
+
+```bash
 python3 -m pip install -r requirements.txt
 ```
+
+Translation is Pantogloss; the `etllib[translate]` extra is not needed.
 
 See the wiki for more information on installing and running BigTranslate:  
 * [Installation instructions](https://github.com/chrismattmann/bigtranslate/wiki/Installation)  

--- a/distribution/src/main/assembly/assembly.xml
+++ b/distribution/src/main/assembly/assembly.xml
@@ -117,6 +117,17 @@
       </includes>
       <fileMode>775</fileMode>
     </fileSet>
+    <!--
+      The Python side of the pipeline is declared here so a deployment carries
+      its own dependency list. bin/bigtranslate-setup reads it.
+    -->
+    <fileSet>
+      <directory>${basedir}/../</directory>
+      <outputDirectory>.</outputDirectory>
+      <includes>
+        <include>requirements.txt</include>
+      </includes>
+    </fileSet>
   </fileSets>
   <dependencySets>
     <dependencySet>

--- a/distribution/src/main/resources/bin/bigtranslate
+++ b/distribution/src/main/resources/bin/bigtranslate
@@ -37,6 +37,38 @@ function print_ui_info {
 
 FILEMGR_URL=http://${OODT_HOST}:9000
 SOLR_URL=http://${OODT_HOST}:8080/solr/bigtranslate
+
+# This script is not started through env.sh, so pick the virtual environment up
+# the same way env.sh does before looking for anything in it.
+BIGTRANSLATE_HOME=${BIGTRANSLATE_HOME:-$(cd "$(dirname "$0")/.." && pwd)}
+if [ -d "$BIGTRANSLATE_HOME"/.venv/bin ]; then
+    PATH="$BIGTRANSLATE_HOME"/.venv/bin:"$PATH"
+    export PATH
+fi
+
+# The PGE shells out to these. Without them each step writes "command not
+# found" into its own log and the workflow still reports FINISHED, so the run
+# looks successful and translates nothing. Say so up front instead.
+function check_python_tools {
+    missing=""
+    for tool in tsvtojson repackage poster; do
+        command -v $tool > /dev/null 2>&1 || missing="$missing $tool"
+    done
+    # pantogloss-translatejson runs under "#!/usr/bin/env python3", so the
+    # interpreter first on PATH is the one that has to be able to import it
+    python3 -c "import pantogloss" > /dev/null 2>&1 || missing="$missing pantogloss"
+    if [ -n "$missing" ]; then
+        echo "Missing Python tools:$missing"
+        echo
+        echo "Install them with:"
+        echo "  PANTOGLOSS_SOURCE=<checkout or wheel> $BIGTRANSLATE_HOME/bin/bigtranslate-setup"
+        echo "  $BIGTRANSLATE_HOME/bin/oodt restart"
+        echo
+        echo "The services must be restarted afterwards: the PGEs inherit their"
+        echo "environment from the workflow manager, not from this shell."
+        exit 1
+    fi
+}
 CLIENT_URL=http://${OODT_HOST}:9001
 OPSUI_URL=http://${OODT_HOST}:8080/opsui
 
@@ -163,6 +195,7 @@ function reset {
 # Start parsing the arguments.
 case $1 in
     translate)
+        check_python_tools
         translate $2 $3 $4
     ;;
     reset)

--- a/distribution/src/main/resources/bin/bigtranslate-setup
+++ b/distribution/src/main/resources/bin/bigtranslate-setup
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Creates the virtual environment holding the Python half of the pipeline.
+# Run once after unpacking a distribution. Maven does not do this: it ships
+# requirements.txt and this script, and the Python install happens here.
+#
+# env.sh puts $BIGTRANSLATE_HOME/.venv/bin on PATH when this directory exists,
+# so the servers -- and therefore the PGEs they run -- pick the tools up.
+
+set -e
+
+PRGDIR=$(cd "$(dirname "$0")" && pwd)
+BIGTRANSLATE_HOME=${BIGTRANSLATE_HOME:-$(cd "$PRGDIR/.." && pwd)}
+VENV="$BIGTRANSLATE_HOME/.venv"
+REQUIREMENTS="$BIGTRANSLATE_HOME/requirements.txt"
+
+# Pantogloss needs TensorFlow 2.18, which publishes no wheels above Python
+# 3.12, so a bare "python3" on a newer system produces an environment the
+# translate step cannot run in. Prefer a version known to work, newest first,
+# and let PYTHON override.
+if [ -z "$PYTHON" ]; then
+    for candidate in python3.12 python3.11 python3.10 python3; do
+        if command -v "$candidate" > /dev/null 2>&1; then
+            PYTHON=$candidate
+            break
+        fi
+    done
+fi
+
+if [ -z "$PYTHON" ] || ! command -v "$PYTHON" > /dev/null 2>&1; then
+    echo "Cannot find a Python interpreter. Set PYTHON to one between 3.10 and 3.12." >&2
+    exit 1
+fi
+
+PYTHON_VERSION=$("$PYTHON" -c 'import sys; print("%d.%d" % sys.version_info[:2])')
+case "$PYTHON_VERSION" in
+    3.10|3.11|3.12) ;;
+    *)
+        echo "$PYTHON is Python $PYTHON_VERSION."
+        echo "ETLLib is fine with that, but Pantogloss needs TensorFlow 2.18, which"
+        echo "publishes no wheels above 3.12. If you intend to translate, re-run with"
+        echo "PYTHON set to a 3.10-3.12 interpreter."
+        echo
+        ;;
+esac
+
+echo "Using $PYTHON (Python $PYTHON_VERSION)"
+
+if [ ! -f "$REQUIREMENTS" ]; then
+    echo "Cannot find $REQUIREMENTS." >&2
+    echo "This script expects to run from inside an unpacked distribution." >&2
+    exit 1
+fi
+
+if [ -d "$VENV" ]; then
+    echo "Using the existing environment at $VENV"
+else
+    echo "Creating $VENV"
+    "$PYTHON" -m venv "$VENV"
+fi
+
+echo "Installing from $REQUIREMENTS"
+"$VENV/bin/pip" install --upgrade pip
+"$VENV/bin/pip" install -r "$REQUIREMENTS"
+
+# Pantogloss does the translating, but it is not in requirements.txt: it is not
+# published, so a public dependency list cannot name it. It has to go in this
+# same environment rather than one of its own, because the PGE runs
+# bin/pantogloss-translatejson through "#!/usr/bin/env python3" and that
+# resolves to whichever interpreter is first on PATH, which is this one.
+#
+# Point PANTOGLOSS_SOURCE at a checkout, a wheel, or any pip specifier:
+#   PANTOGLOSS_SOURCE=~/git/pantogloss bin/bigtranslate-setup
+if [ -n "$PANTOGLOSS_SOURCE" ]; then
+    echo
+    echo "Installing Pantogloss from $PANTOGLOSS_SOURCE"
+    "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
+fi
+
+echo
+echo "Done. Installed:"
+for tool in tsvtojson repackage poster; do
+    if [ -x "$VENV/bin/$tool" ]; then
+        echo "  $tool"
+    else
+        echo "  $tool  MISSING -- check the output above"
+    fi
+done
+if "$VENV/bin/python" -c "import pantogloss" > /dev/null 2>&1; then
+    echo "  pantogloss"
+else
+    echo "  pantogloss  NOT INSTALLED -- the translate step will fail."
+    echo "              Re-run with PANTOGLOSS_SOURCE set to a checkout or wheel."
+fi
+echo
+echo "Restart the services so they pick the tools up:"
+echo "  $BIGTRANSLATE_HOME/bin/oodt restart"

--- a/distribution/src/main/resources/bin/env.sh
+++ b/distribution/src/main/resources/bin/env.sh
@@ -95,6 +95,16 @@ fi
 # BIGTRANSLATE_HOME in setenv.sh has not been edited for this deployment.
 export CATALINA_OPTS=-Dsolr.solr.home="$OODT_BASE"/solr
 
+# The Python half of the pipeline lives in a virtual environment created by
+# bin/bigtranslate-setup. Put it on PATH here rather than in bin/bigtranslate,
+# because the PGEs that call tsvtojson, repackage, poster and
+# pantogloss-translatejson are run by the workflow manager and inherit its
+# environment, not the environment of whoever typed "bigtranslate translate".
+if [ -d "$OODT_BASE"/.venv/bin ]; then
+  PATH="$OODT_BASE"/.venv/bin:"$PATH"
+  export PATH
+fi
+
 if [ -z "$OODT_OUT" ] ; then
   OODT_OUT="$OODT_BASE"/logs/oodt.out
   export OODT_OUT


### PR DESCRIPTION
The README asked people to `pip install` ETLLib themselves and hope the tools landed on the right `PATH`. Two things made that unreliable.

### The PATH that matters is not yours

The tools are not run by whoever types `bigtranslate translate`. They are run by the **PGE**, which the **workflow manager** starts — so it is the workflow manager's environment that has to contain them. Putting them on your own `PATH` does nothing.

I found this the direct way: exporting `PATH` in my shell still gave `tsvtojson: command not found` in the PGE logs. Only restarting the services with the venv on `PATH` worked.

`env.sh` now adds `$BIGTRANSLATE_HOME/.venv/bin` when that directory exists, so every service started through it passes the tools down to its PGEs.

### When they were missing, nothing said so

Each step wrote `command not found` into its own log file and **the workflow still reported `FINISHED`** — a run that looked successful and translated nothing. `bigtranslate` now checks the four tools resolve before starting:

```
Missing Python tools: tsvtojson repackage poster pantogloss

Install them with:
  PANTOGLOSS_SOURCE=<checkout or wheel> .../bin/bigtranslate-setup
  .../bin/oodt restart

The services must be restarted afterwards: the PGEs inherit their
environment from the workflow manager, not from this shell.
```

### The setup script

`bin/bigtranslate-setup` creates the virtual environment and installs from `requirements.txt` — now **shipped in the distribution** rather than living only in the source tree, so a deployment carries its own dependency list.

Maven copies a text file and two shell scripts. Nothing in the build runs pip.

### Two constraints it had to account for

**Pantogloss is not published**, so `requirements.txt` cannot name it. `PANTOGLOSS_SOURCE` points the setup script at a checkout, a wheel, or any pip specifier. It installs into the *same* environment as ETLLib, which it has to: the PGE runs `pantogloss-translatejson` through `#!/usr/bin/env python3`, and that takes whichever interpreter is first on `PATH`.

**TensorFlow 2.18 publishes no wheels above Python 3.12.** A bare `python3` on a current machine (3.14 here) builds an environment where `pip install pantogloss` fails with `No matching distribution found for tensorflow<2.19,>=2.18`. The setup script prefers `python3.12` and works down; `PYTHON` overrides it.

### Verified on a clean unpack

- `bigtranslate translate` refuses with the message above before setup.
- `bigtranslate-setup` selects `python3.12`, installs `tsvtojson`, `repackage`, `poster` and `pantogloss` into one environment, and lists what it got.
- After `oodt restart`, the workflow manager process has `.venv/bin` on its `PATH`.
- The pipeline runs through `tsvtojson` (211 records), `repackage`, and Pantogloss translation.

### Not in this PR

The Solr post at the end still fails; that is a separate bug — `webapps/solr-webapp/.../web.xml` hardcodes a JNDI `solr/home` of `../solr` which overrides the `-Dsolr.solr.home` that `env.sh` computes. Fixed separately.