### PR TITLE
Stop hardcoding Solr Home in the webapp

### DIFF
--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -301,18 +301,38 @@ class TestBuild:
         assert "<groupId>org.apache.tomcat</groupId>" in text
         assert "tomcat:apache-tomcat" not in text
 
-    def test_solr_env_entry_declares_a_type(self):
-        # Tomcat 9 reads env-entry-type unconditionally; without it the /solr
-        # context dies on an NPE and returns 404 with no root cause logged.
+    def _solr_env_entries(self):
         web_xml = REPO / "webapps/solr-webapp/src/main/webapp/WEB-INF/web.xml"
         root = ET.parse(web_xml).getroot()
         ns = {"j": "http://java.sun.com/xml/ns/javaee"}
         entries = root.findall("j:env-entry", ns) or root.findall("env-entry")
-        assert entries
+        return entries, ns
+
+    def test_solr_env_entry_declares_a_type(self):
+        # Tomcat 9 reads env-entry-type unconditionally; without it the /solr
+        # context dies on an NPE and returns 404 with no root cause logged.
+        # There need not be any env-entry at all -- see the test below -- but
+        # any that is added has to carry a type.
+        entries, ns = self._solr_env_entries()
         for entry in entries:
             types = (entry.findall("j:env-entry-type", ns)
                      or entry.findall("env-entry-type"))
             assert types, "env-entry without env-entry-type"
+
+    def test_solr_home_is_not_hardcoded_in_the_webapp(self):
+        # A JNDI env-entry beats the solr.solr.home system property, so one
+        # named solr/home overrides what env.sh computes from the deployment's
+        # own location. It used to be "../solr", relative to Tomcat's working
+        # directory rather than the deployment, and Solr looked for its cores
+        # outside the install, found none, and answered every request with 500.
+        entries, ns = self._solr_env_entries()
+        for entry in entries:
+            names = (entry.findall("j:env-entry-name", ns)
+                     or entry.findall("env-entry-name"))
+            for name in names:
+                assert (name.text or "").strip() != "solr/home", (
+                    "solr/home hardcoded in web.xml; it overrides "
+                    "-Dsolr.solr.home from bin/env.sh")
 
     def test_pcs_webapp_supplies_jaxb(self):
         # JAXB left the JDK in Java 11; CXFServlet fails to load without it.

--- a/webapps/solr-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapps/solr-webapp/src/main/webapp/WEB-INF/web.xml
@@ -36,13 +36,21 @@
 
   <!-- People who want to hardcode their "Solr Home" directly into the
        WAR File can set the JNDI property here...
+
+       Deliberately left unset. A JNDI env-entry takes precedence over the
+       solr.solr.home system property, so setting it here silently overrode the
+       -Dsolr.solr.home that bin/env.sh computes from the deployment's own
+       location. The value was "../solr", relative to Tomcat's working
+       directory rather than to the deployment, so Solr looked for its cores
+       outside the install, found none, fell back to a "collection1" that does
+       not exist, and answered every request with HTTP 500:
+
+         initFailures: {"collection1": "Could not load config file
+         .../bigtranslate/../solr/collection1/solrconfig.xml"}
+
+       With no env-entry, solr.solr.home applies and the bigtranslate core is
+       found where it is actually installed.
    -->
-  
-    <env-entry>
-       <env-entry-name>solr/home</env-entry-name>
-       <env-entry-value>../solr</env-entry-value>
-       <env-entry-type>java.lang.String</env-entry-type>
-    </env-entry>
    
    
   <!-- Any path (name) registered in solrconfig.xml will be sent to that filter -->


### PR DESCRIPTION
The Solr webapp carried the JNDI `env-entry` from Solr's example `web.xml`:

```xml
<env-entry>
   <env-entry-name>solr/home</env-entry-name>
   <env-entry-value>../solr</env-entry-value>
   <env-entry-type>java.lang.String</env-entry-type>
</env-entry>
```

A JNDI `env-entry` **takes precedence over the `solr.solr.home` system property**, so this silently overrode the `-Dsolr.solr.home` that `bin/env.sh` carefully computes from the deployment's own location. And the value is relative to Tomcat's working directory rather than to the deployment, so it resolved *outside* the install:

```
initFailures: {"collection1": "Could not load config file
.../bigtranslate/../solr/collection1/solrconfig.xml"}
```

Solr found no cores there, fell back to a `collection1` that does not exist, and answered every request with HTTP 500.

### What it broke

The end of the pipeline posts translated JSON to Solr. Every document failed to index — 211 of them in a test run — while the workflow still reported `FINISHED`. Since nothing downstream checks, the corpus simply never appeared in the index.

### Verification, on a fresh deployment

| | Before | After |
|---|---|---|
| Cores loaded | none — fell back to `collection1` | `['bigtranslate']` |
| `initFailures` | `collection1` config not found | `{}` |
| `/solr/bigtranslate/admin/ping` | HTTP 500 | **HTTP 200** |

Nothing else used the entry. The comment above it in Solr's own example describes it as being for *"People who want to hardcode their Solr Home directly into the WAR File"* — which is exactly what a relocatable distribution must not do, so it is left unset with a note explaining why.