### PR TITLE
Fix the Gloss ROOT check in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,9 +64,12 @@ jobs:
           tar tvzf $TARBALL | grep -E 'tomcat/bin/catalina.sh' | grep -q '^-rwx'
 
           # Gloss is the GUI; Tomcat's ROOT sends people there.
+          # The assembly has no base directory, so these paths are not
+          # prefixed: */tomcat/... does not match tomcat/...
           tar tzf $TARBALL | grep -q 'tomcat/webapps/gloss/index.html'
           tar tzf $TARBALL | grep -q 'tomcat/webapps/gloss-services/WEB-INF/web.xml'
-          tar xzOf $TARBALL --wildcards '*/tomcat/webapps/ROOT/index.jsp' | grep -q '/gloss/'
+          tar tzf $TARBALL | grep -q 'tomcat/webapps/ROOT/index.jsp'
+          tar xzOf $TARBALL tomcat/webapps/ROOT/index.jsp | grep -q '/gloss/'
 
           # Java 9 removed the extension mechanism; every launcher that still
           # references it fails at startup. Assert the scan is non-vacuous


### PR DESCRIPTION
The Maven package job succeeded; the follow-up tarball check did not.

`includeBaseDirectory` is false, so the redirect lives at
`tomcat/webapps/ROOT/index.jsp`. The check extracted
`*/tomcat/webapps/ROOT/index.jsp`, which GNU tar reports as not in the
archive.

https://github.com/chrismattmann/bigtranslate/actions/runs/33095516619/job/98599275919