### PR TITLE
Ingest BigTranslate outputs with immediate-parent InputFiles

### DIFF
--- a/pge/src/main/resources/policy/metout/generic_metout_aggregates.xml
+++ b/pge/src/main/resources/policy/metout/generic_metout_aggregates.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<metadataList>
+    
+   <metadata key="TagAccumulator" val="value"/>
+   <metadata key="JobId" val="[JobId]"/>
+   <metadata key="InputFiles"/>
+   <metadata key="ProductionDateTime"/>
+   <metadata key="ProductType" val="EmploymentJobAggregates"/>
+   <metadata key="Filename"/>
+   <metadata key="FileLocation"/>
+   <metadata key="FileSize"/>
+   <metadata key="ProductName" val="[Filename]"/>
+        
+</metadataList>

--- a/pge/src/main/resources/policy/metout/generic_metout_jobs.xml
+++ b/pge/src/main/resources/policy/metout/generic_metout_jobs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<metadataList>
+    
+   <metadata key="TagAccumulator" val="value"/>
+   <metadata key="JobId" val="[JobId]"/>
+   <metadata key="InputFiles" val="[AggregateJsonFile]"/>
+   <metadata key="ProductionDateTime"/>
+   <metadata key="ProductType" val="EmploymentJob"/>
+   <metadata key="Filename"/>
+   <metadata key="FileLocation"/>
+   <metadata key="FileSize"/>
+   <metadata key="ProductName" val="[Filename]"/>
+        
+</metadataList>

--- a/pge/src/main/resources/policy/metout/generic_metout_translated.xml
+++ b/pge/src/main/resources/policy/metout/generic_metout_translated.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<metadataList>
+    
+   <metadata key="TagAccumulator" val="value"/>
+   <metadata key="JobId" val="[JobId]"/>
+   <!-- Filename is still the per-job JSON name (job-1001.json) here. Capture
+        that as InputFiles, then give the translated product its own name so
+        FilenameQuery can tell parent and child apart. -->
+   <metadata key="InputFiles" val="[Filename]"/>
+   <metadata key="Filename" val="[Filename].translated.json"/>
+   <metadata key="ProductionDateTime"/>
+   <metadata key="ProductType" val="EmploymentJobTranslated"/>
+   <metadata key="FileLocation"/>
+   <metadata key="FileSize"/>
+   <metadata key="ProductName" val="[Filename]"/>
+        
+</metadataList>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
@@ -14,32 +14,32 @@
      <cmd>cp [TsvFilePath] [JobInputDir]</cmd>
      <cmd>echo "Staging complete, running BigTranslate"</cmd>
      <cmd>cd [JobOutputDir]/aggregatejson</cmd>
-     <cmd>export TSV_FILE_PREFIX=`basename [TsvFile] .tsv`</cmd>
-     <cmd>tsvtojson -t [JobInputDir]/[TsvFile] -j [JobOutputDir]/aggregatejson/${TSV_FILE_PREFIX}.json -c [ConfFilePath]/colheaders.txt -o employmentjobs -e [ConfFilePath]/encoding.txt -u url -s [NearDupeThreshold] -v > [JobLogDir]/tsvtojson_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>tsvtojson -t [JobInputDir]/[TsvFile] -j [JobOutputDir]/aggregatejson/[AggregateJsonFile] -c [ConfFilePath]/colheaders.txt -o employmentjobs -e [ConfFilePath]/encoding.txt -u url -s [NearDupeThreshold] -v > [JobLogDir]/tsvtojson_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>cd [JobOutputDir]/employmentjobs</cmd>
-     <cmd>repackage -j [JobOutputDir]/aggregatejson/${TSV_FILE_PREFIX}.json -o employmentjobs -v > [JobLogDir]/repackager_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>repackage -j [JobOutputDir]/aggregatejson/[AggregateJsonFile] -o employmentjobs -v > [JobLogDir]/repackager_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>cd [JobOutputDir]/translated</cmd>
      <!-- One invocation for the whole directory, not one per document. The
           Tika-backed predecessor made an HTTP call per field, so a process
           per file cost nothing; Pantogloss loads a local model, so the same
           shape would reload it once per posting. -->
      <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --glossary [TranslateGlossary] --batch-size [TranslateBatchSize] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
-     <cmd>find [JobOutputDir]/translated -name "*.json" | poster -u "[SolrUrl]" -v > [JobLogDir]/solrjsonposter_[DateMilis].log 2[GreaterThan][Ampersand]1 </cmd> 
-
-     <!-- now clean up -->
-     <!-- delete the split file first from the FM -->
-     <cmd>alias fmdel="java -Dorg.apache.oodt.cas.filemgr.properties=[BIGTRANSLATE_HOME]/filemgr/etc/filemgr.properties -cp \"[BIGTRANSLATE_HOME]/filemgr/lib/*\" org.apache.oodt.cas.filemgr.tools.DeleteProduct --fileManagerUrl [FILEMGR_URL] --read"</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/filemgr/bin/query-tool --url [FILEMGR_URL] --sql -query "SELECT CAS.ProductId FROM EmploymentJobAggregatesTsvSplit WHERE CAS.ProductName = '[TsvFile]'"  -outputFormat "\$CAS.ProductId" | fmdel</cmd>
-
-     <!-- remove the working dir stuff -->
-     <cmd>cd [JobDir]</cmd>
-     <cmd>rm -rf [JobOutputDir]/*</cmd>
+     <cmd>find [JobOutputDir]/translated -name "*.json" | poster -u "[SolrUrl]" -v > [JobLogDir]/solrjsonposter_[DateMilis].log 2[GreaterThan][Ampersand]1 </cmd>
   </exe>
 
-  <!-- Files to ingest -->
+  <!-- Files to ingest. CAS-PGE writes .met files after exe, so the working
+       copies have to still be here; DeleteDataFile removes them after ingest.
+       Do not delete the split TSV from File Manager: it is the aggregate's
+       parent and pedigree walks InputFiles by Filename. -->
   <output>
-    <!-- one or more of these -->
- 
+    <dir path="[JobOutputDir]/aggregatejson" createBeforeExe="false">
+       <files regExp=".*\.json$" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout_aggregates.xml"/>
+    </dir>
+    <dir path="[JobOutputDir]/employmentjobs" createBeforeExe="false">
+       <files regExp=".*\.json$" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout_jobs.xml"/>
+    </dir>
+    <dir path="[JobOutputDir]/translated" createBeforeExe="false">
+       <files regExp=".*\.json$" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout_translated.xml"/>
+    </dir>
   </output>
 
   <!-- Custom metadata to add to output files -->
@@ -57,9 +57,11 @@
 
 
     <!-- Casi-specific keys -->
+    <metadata key="PCS_ActionsIds" val="DeleteDataFile" split="true"/>
     <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
     <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
     <metadata key="TsvFile" val="[Filename]"/>
+    <metadata key="AggregateJsonFile" val="[TsvFile].json"/>
     <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/bigtranslate/[TsvFile]_[DateMilis]"/>
     <metadata key="JobInputDir" val="[JobDir]/input"/>
     <metadata key="JobOutputDir" val="[JobDir]/output"/>

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -29,6 +29,8 @@ import pytest
 from conftest import BIN, CONF, POLICY, REPO, RESOURCES, WORKFLOW_POLICY
 
 PGE_CONFIG = POLICY / "no_filter" / "PgeConfig_BigTranslate.xml"
+SPLIT_CONFIG = POLICY / "no_filter" / "PgeConfig_Split.xml"
+METOUT = POLICY / "metout"
 TASKS = WORKFLOW_POLICY / "tasks.xml"
 
 
@@ -64,9 +66,8 @@ class TestJdk21Runtime:
         assert "-Djava.endorsed.dirs" not in script.read_text()
 
     def test_pge_config_carries_no_ext_dirs(self):
-        # The fmdel alias is embedded in the PGE config, not a launcher, and
-        # was the easiest of the fourteen call sites to miss.
         assert "java.ext.dirs" not in PGE_CONFIG.read_text()
+        assert "java.ext.dirs" not in SPLIT_CONFIG.read_text()
 
 
 class TestAvroTransport:
@@ -177,6 +178,72 @@ class TestTranslateStep:
     def test_poster_reads_the_translated_directory(self):
         text = PGE_CONFIG.read_text()
         assert re.search(r"find \[JobOutputDir\]/translated .*\| poster", text)
+
+
+def _pge_output_dirs(path):
+    root = ET.parse(path).getroot()
+    output = root.find("output")
+    assert output is not None, "%s has no <output>" % path
+    return list(output.findall("dir"))
+
+
+def _metout_keys(path):
+    root = ET.parse(path).getroot()
+    found = {}
+    for node in root.findall("metadata"):
+        found[node.get("key")] = node.get("val")
+    return found
+
+
+class TestBigTranslateIngest:
+    """Translate used to throw away its outputs; pedigree needs them cataloged."""
+
+    def test_split_still_writes_met_via_generic_metout(self):
+        dirs = _pge_output_dirs(SPLIT_CONFIG)
+        assert dirs
+        files = dirs[0].find("files")
+        assert files.get("metFileWriterClass").endswith("MetadataListPcsMetFileWriter")
+        assert files.get("args").endswith("generic_metout.xml")
+
+    def test_translate_ingests_each_output_dir(self):
+        dirs = _pge_output_dirs(PGE_CONFIG)
+        paths = [d.get("path") for d in dirs]
+        assert "[JobOutputDir]/aggregatejson" in paths
+        assert "[JobOutputDir]/employmentjobs" in paths
+        assert "[JobOutputDir]/translated" in paths
+        for d in dirs:
+            files = d.find("files")
+            assert files is not None
+            assert files.get("metFileWriterClass").endswith("MetadataListPcsMetFileWriter")
+            assert files.get("args").endswith(".xml")
+            assert files.get("regExp") == r".*\.json$"
+
+    def test_does_not_delete_the_split_parent(self):
+        text = PGE_CONFIG.read_text()
+        assert "DeleteProduct" not in text
+        assert "fmdel" not in text
+
+    def test_does_not_wipe_outputs_before_ingest(self):
+        text = PGE_CONFIG.read_text()
+        assert "rm -rf [JobOutputDir]" not in text
+
+    def test_aggregate_json_name_is_the_split_filename(self):
+        root = ET.parse(PGE_CONFIG).getroot()
+        keys = {m.get("key"): m.get("val") for m in root.find("customMetadata").findall("metadata")}
+        assert keys["AggregateJsonFile"] == "[TsvFile].json"
+        assert "[AggregateJsonFile]" in PGE_CONFIG.read_text()
+
+    def test_metout_sets_product_type_and_immediate_parent(self):
+        aggregates = _metout_keys(METOUT / "generic_metout_aggregates.xml")
+        jobs = _metout_keys(METOUT / "generic_metout_jobs.xml")
+        translated = _metout_keys(METOUT / "generic_metout_translated.xml")
+        assert aggregates["ProductType"] == "EmploymentJobAggregates"
+        assert aggregates["InputFiles"] is None
+        assert jobs["ProductType"] == "EmploymentJob"
+        assert jobs["InputFiles"] == "[AggregateJsonFile]"
+        assert translated["ProductType"] == "EmploymentJobTranslated"
+        assert translated["InputFiles"] == "[Filename]"
+        assert translated["Filename"] == "[Filename].translated.json"
 
     def test_tika_server_classpath_is_retired(self):
         text = (BIN / "setenv.sh").read_text()


### PR DESCRIPTION
The translate PGE never cataloged its outputs. It ran tsvtojson / repackage / pantogloss, posted to Solr, then deleted the split TSV from File Manager and `rm -rf` the job directory. Pedigree walks `InputFiles` by Filename, so a translated job showed as a lone product, and the versioner wrote `.../archive/null/translated_json/...` when that field was missing.

This gives `PgeConfig_BigTranslate` an `<output>` like Split:

- `aggregatejson` → EmploymentJobAggregates, `InputFiles` = the split TSV filename
- `employmentjobs` → EmploymentJob, `InputFiles` = the aggregate JSON filename
- `translated` → EmploymentJobTranslated, `InputFiles` = the per-job JSON filename

`.met` files are written with `MetadataListPcsMetFileWriter` and generic_metout variants. The split parent stays in the catalog. `DeleteDataFile` still removes the working copies after ingest.

Live `pge/policy` on this machine already has the same files so the next pipeline run uses them.