### PR TITLE
Link Gloss Solr lineage fields to the OPSUI product page

### DIFF
--- a/distribution/src/main/resources/bin/stamp-solr-lineage
+++ b/distribution/src/main/resources/bin/stamp-solr-lineage
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Stamp File Manager lineage onto translated JSON before it is posted to Solr.
+
+Postings live in Solr, not File Manager. Each document gets the split product
+name (InputFiles / SplitFilename) and the original TSV name (TsvFile) so a
+Gloss record can hop to the FM products that actually exist at batch grain.
+"""
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import sys
+
+
+def stamp_document(doc, input_files, split_filename, tsv_file):
+    """Return a copy of doc with lineage fields set. Empty values are skipped."""
+    stamped = dict(doc)
+    if input_files:
+        stamped["InputFiles"] = input_files
+    if split_filename:
+        stamped["SplitFilename"] = split_filename
+    if tsv_file:
+        stamped["TsvFile"] = tsv_file
+    return stamped
+
+
+def stamp_dir(directory, input_files, split_filename, tsv_file):
+    n = 0
+    for name in sorted(os.listdir(directory)):
+        if not name.endswith(".json") or name.endswith(".met"):
+            continue
+        path = os.path.join(directory, name)
+        if not os.path.isfile(path):
+            continue
+        with open(path, "r", encoding="utf-8") as handle:
+            doc = json.load(handle)
+        stamped = stamp_document(doc, input_files, split_filename, tsv_file)
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(stamped, handle, ensure_ascii=False)
+            handle.write("\n")
+        n += 1
+    return n
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="stamp-solr-lineage",
+        description="Add InputFiles, SplitFilename and TsvFile to translated JSON.",
+    )
+    parser.add_argument("--dir", required=True, help="directory of translated JSON files")
+    parser.add_argument("--input-files", default="",
+                        help="PCS parent in File Manager, the split product Filename")
+    parser.add_argument("--split", default="", help="parent split Filename")
+    parser.add_argument("--tsv", default="", help="original TSV Filename")
+    args = parser.parse_args(argv)
+    if not os.path.isdir(args.dir):
+        print("not a directory: %s" % args.dir, file=sys.stderr)
+        return 1
+    n = stamp_dir(args.dir, args.input_files, args.split, args.tsv)
+    print("stamped %d documents in %s" % (n, args.dir), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
@@ -23,23 +23,16 @@
           per file cost nothing; Pantogloss loads a local model, so the same
           shape would reload it once per posting. -->
      <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --glossary [TranslateGlossary] --batch-size [TranslateBatchSize] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/stamp-solr-lineage --dir [JobOutputDir]/translated --input-files '[SplitFilename]' --split '[SplitFilename]' --tsv '[SourceTsv]' >> [JobLogDir]/stamp_solr_lineage_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>find [JobOutputDir]/translated -name "*.json" | poster -u "[SolrUrl]" -v > [JobLogDir]/solrjsonposter_[DateMilis].log 2[GreaterThan][Ampersand]1 </cmd>
+     <!-- Working copies are ephemeral. File Manager only catalogs the TSV and
+          the split; Solr holds the postings. -->
+     <cmd>rm -rf [JobOutputDir]/*</cmd>
   </exe>
 
-  <!-- Files to ingest. CAS-PGE writes .met files after exe, so the working
-       copies have to still be here; DeleteDataFile removes them after ingest.
-       Do not delete the split TSV from File Manager: it is the aggregate's
-       parent and pedigree walks InputFiles by Filename. -->
+  <!-- Do not ingest per-job or translated JSON. At corpus scale that is
+       hundreds of millions of File Manager products; Gloss reads Solr. -->
   <output>
-    <dir path="[JobOutputDir]/aggregatejson" createBeforeExe="false">
-       <files regExp=".*\.json$" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout_aggregates.xml"/>
-    </dir>
-    <dir path="[JobOutputDir]/employmentjobs" createBeforeExe="false">
-       <files regExp=".*\.json$" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout_jobs.xml"/>
-    </dir>
-    <dir path="[JobOutputDir]/translated" createBeforeExe="false">
-       <files regExp=".*\.json$" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout_translated.xml"/>
-    </dir>
   </output>
 
   <!-- Custom metadata to add to output files -->
@@ -57,16 +50,17 @@
 
 
     <!-- Casi-specific keys -->
-    <metadata key="PCS_ActionsIds" val="DeleteDataFile" split="true"/>
     <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
     <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
     <metadata key="TsvFile" val="[Filename]"/>
+    <metadata key="SplitFilename" val="[TsvFile]"/>
+    <!-- The triggering split product already has InputFiles = original TSV. -->
+    <metadata key="SourceTsv" val="[InputFiles]"/>
     <metadata key="AggregateJsonFile" val="[TsvFile].json"/>
     <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/bigtranslate/[TsvFile]_[DateMilis]"/>
     <metadata key="JobInputDir" val="[JobDir]/input"/>
     <metadata key="JobOutputDir" val="[JobDir]/output"/>
     <metadata key="JobLogDir" val="[JobDir]/logs"/>
-    <metadata key="InputFiles" val="SQL(FORMAT='$Filename',SORT_BY='CAS.ProductReceivedTime'){SELECT FileLocation,Filename,CAS.ProductReceivedTime FROM EmploymentJobAggregatesTsvSplit WHERE Filename = '[TsvFile]'}"/>
     <metadata key="TsvFilePath" val="SQL(FORMAT='$FileLocation/$Filename',SORT_BY='CAS.ProductReceivedTime'){SELECT FileLocation,Filename,CAS.ProductReceivedTime FROM EmploymentJobAggregatesTsvSplit WHERE Filename = '[TsvFile]'}"/>
   </customMetadata>
 

--- a/solr/src/main/resources/bigtranslate/conf/schema.xml
+++ b/solr/src/main/resources/bigtranslate/conf/schema.xml
@@ -84,6 +84,12 @@
   <field name="url" type="string" indexed="true" stored="true" required="true" multiValued="false"/>
   <field name="lastSeenDate" type="pdate" indexed="true" stored="true" required="true" multiValued="false"/>
 
+  <!-- Lineage for a posting. File Manager only catalogs the original TSV and
+       the split; these fields point Solr documents at those products. -->
+  <field name="InputFiles" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
+  <field name="SplitFilename" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
+  <field name="TsvFile" type="string" indexed="true" stored="true" required="false" multiValued="false"/>
+
   <field name="content" type="text_general" indexed="false" stored="true" multiValued="true"/>
   <field name="text" type="text_general" indexed="true" stored="false" multiValued="true"/>
   <field name="text_rev" type="text_general_rev" indexed="true" stored="false" multiValued="true"/>

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -179,6 +179,12 @@ class TestTranslateStep:
         text = PGE_CONFIG.read_text()
         assert re.search(r"find \[JobOutputDir\]/translated .*\| poster", text)
 
+    def test_stamps_solr_lineage_before_poster(self):
+        text = PGE_CONFIG.read_text()
+        stamp = text.find("stamp-solr-lineage")
+        poster = text.find("| poster")
+        assert stamp != -1 and poster != -1 and stamp < poster
+
 
 def _pge_output_dirs(path):
     root = ET.parse(path).getroot()
@@ -196,7 +202,7 @@ def _metout_keys(path):
 
 
 class TestBigTranslateIngest:
-    """Translate used to throw away its outputs; pedigree needs them cataloged."""
+    """File Manager catalogs the TSV and the split; Solr holds the postings."""
 
     def test_split_still_writes_met_via_generic_metout(self):
         dirs = _pge_output_dirs(SPLIT_CONFIG)
@@ -205,45 +211,31 @@ class TestBigTranslateIngest:
         assert files.get("metFileWriterClass").endswith("MetadataListPcsMetFileWriter")
         assert files.get("args").endswith("generic_metout.xml")
 
-    def test_translate_ingests_each_output_dir(self):
+    def test_translate_does_not_ingest_leaf_json(self):
         dirs = _pge_output_dirs(PGE_CONFIG)
         paths = [d.get("path") for d in dirs]
-        assert "[JobOutputDir]/aggregatejson" in paths
-        assert "[JobOutputDir]/employmentjobs" in paths
-        assert "[JobOutputDir]/translated" in paths
-        for d in dirs:
-            files = d.find("files")
-            assert files is not None
-            assert files.get("metFileWriterClass").endswith("MetadataListPcsMetFileWriter")
-            assert files.get("args").endswith(".xml")
-            assert files.get("regExp") == r".*\.json$"
+        assert "[JobOutputDir]/employmentjobs" not in paths
+        assert "[JobOutputDir]/translated" not in paths
+        assert "[JobOutputDir]/aggregatejson" not in paths
 
     def test_does_not_delete_the_split_parent(self):
         text = PGE_CONFIG.read_text()
         assert "DeleteProduct" not in text
         assert "fmdel" not in text
 
-    def test_does_not_wipe_outputs_before_ingest(self):
+    def test_wipes_working_copies_after_solr_post(self):
         text = PGE_CONFIG.read_text()
-        assert "rm -rf [JobOutputDir]" not in text
+        poster = text.find("| poster")
+        wipe = text.find("rm -rf [JobOutputDir]")
+        assert poster != -1 and wipe != -1 and poster < wipe
 
-    def test_aggregate_json_name_is_the_split_filename(self):
+    def test_lineage_keys_are_the_split_and_original_tsv(self):
         root = ET.parse(PGE_CONFIG).getroot()
         keys = {m.get("key"): m.get("val") for m in root.find("customMetadata").findall("metadata")}
-        assert keys["AggregateJsonFile"] == "[TsvFile].json"
-        assert "[AggregateJsonFile]" in PGE_CONFIG.read_text()
-
-    def test_metout_sets_product_type_and_immediate_parent(self):
-        aggregates = _metout_keys(METOUT / "generic_metout_aggregates.xml")
-        jobs = _metout_keys(METOUT / "generic_metout_jobs.xml")
-        translated = _metout_keys(METOUT / "generic_metout_translated.xml")
-        assert aggregates["ProductType"] == "EmploymentJobAggregates"
-        assert aggregates["InputFiles"] is None
-        assert jobs["ProductType"] == "EmploymentJob"
-        assert jobs["InputFiles"] == "[AggregateJsonFile]"
-        assert translated["ProductType"] == "EmploymentJobTranslated"
-        assert translated["InputFiles"] == "[Filename]"
-        assert translated["Filename"] == "[Filename].translated.json"
+        assert keys["SplitFilename"] == "[TsvFile]"
+        assert keys["SourceTsv"] == "[InputFiles]"
+        assert "[SplitFilename]" in PGE_CONFIG.read_text()
+        assert "[SourceTsv]" in PGE_CONFIG.read_text()
 
     def test_tika_server_classpath_is_retired(self):
         text = (BIN / "setenv.sh").read_text()

--- a/tests/test_stamp_solr_lineage.py
+++ b/tests/test_stamp_solr_lineage.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lineage fields stamped onto translated JSON before Solr post."""
+
+import importlib.machinery
+import importlib.util
+import json
+import os
+
+from conftest import BIN
+
+_spec = importlib.util.spec_from_loader(
+    "stamp_solr_lineage",
+    importlib.machinery.SourceFileLoader("stamp_solr_lineage", str(BIN / "stamp-solr-lineage")),
+)
+stamp = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(stamp)
+
+
+def test_stamp_document_sets_the_three_lineage_fields():
+    doc = stamp.stamp_document(
+        {"id": "abc", "title": "Dev"},
+        "file.tsv.aaaa", "file.tsv.aaaa", "file.tsv")
+    assert doc["InputFiles"] == "file.tsv.aaaa"
+    assert doc["SplitFilename"] == "file.tsv.aaaa"
+    assert doc["TsvFile"] == "file.tsv"
+    assert doc["id"] == "abc"
+
+
+def test_stamp_document_skips_empty_values():
+    doc = stamp.stamp_document({"id": "abc"}, "", "", "")
+    assert "InputFiles" not in doc
+    assert "SplitFilename" not in doc
+    assert "TsvFile" not in doc
+
+
+def test_stamp_dir_rewrites_json_files(tmp_path):
+    path = tmp_path / "job.json"
+    path.write_text('{"id": "1", "title": "X"}', encoding="utf-8")
+    n = stamp.stamp_dir(str(tmp_path), "split.aaaa", "split.aaaa", "orig.tsv")
+    assert n == 1
+    body = json.loads(path.read_text(encoding="utf-8"))
+    assert body["TsvFile"] == "orig.tsv"
+    assert body["SplitFilename"] == "split.aaaa"
+
+
+def test_script_is_executable():
+    assert os.access(BIN / "stamp-solr-lineage", os.X_OK)

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
@@ -57,10 +57,7 @@ public class ProcessBtWrapper {
 
   static final String[] WIPE_TYPES = {
       "EmploymentJobAggregatesTsv",
-      "EmploymentJobAggregatesTsvSplit",
-      "EmploymentJobAggregates",
-      "EmploymentJob",
-      "EmploymentJobTranslated"
+      "EmploymentJobAggregatesTsvSplit"
   };
 
   private static final Logger LOG = Logger.getLogger(ProcessBtWrapper.class.getName());

--- a/webapps/gloss-services/src/test/java/org/bigtranslate/gloss/TestProcessBtWrapper.java
+++ b/webapps/gloss-services/src/test/java/org/bigtranslate/gloss/TestProcessBtWrapper.java
@@ -42,11 +42,13 @@ public class TestProcessBtWrapper extends TestCase {
     assertEquals("/data/untranslated", command.get(4));
   }
 
-  public void testWipeTypesAreTheEmploymentProducts() {
+  public void testWipeTypesAreTheCoarseFileManagerProducts() {
     List<String> types = ProcessBtWrapper.wipeTypes();
     assertTrue(types.contains("EmploymentJobAggregatesTsv"));
-    assertTrue(types.contains("EmploymentJobTranslated"));
-    assertEquals(5, types.size());
+    assertTrue(types.contains("EmploymentJobAggregatesTsvSplit"));
+    assertFalse(types.contains("EmploymentJob"));
+    assertFalse(types.contains("EmploymentJobTranslated"));
+    assertEquals(2, types.size());
   }
 
   public void testWipeDirectoryContentsLeavesTheDirectory() throws Exception {

--- a/webapps/gloss/src/main/webapp/resources/package.json
+++ b/webapps/gloss/src/main/webapp/resources/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test src/*.test.js",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/webapps/gloss/src/main/webapp/resources/src/components/RecordView.vue
+++ b/webapps/gloss/src/main/webapp/resources/src/components/RecordView.vue
@@ -54,7 +54,10 @@ const LABELS = {
   latitude: 'Latitude',
   longitude: 'Longitude',
   url: 'Original URL',
-  id: 'Solr id'
+  id: 'Solr id',
+  InputFiles: 'Input files',
+  SplitFilename: 'Parent split',
+  TsvFile: 'Original TSV'
 }
 
 export default {

--- a/webapps/gloss/src/main/webapp/resources/src/components/RecordView.vue
+++ b/webapps/gloss/src/main/webapp/resources/src/components/RecordView.vue
@@ -21,6 +21,10 @@
               target="_blank"
               rel="noopener"
             >{{ field.value }}</a>
+            <a
+              v-else-if="isLineageField(field.name) && field.value"
+              :href="opsuiHref(field.value)"
+            >{{ field.value }}</a>
             <span v-else-if="field.name === 'postedDate' || field.name === 'firstSeenDate' || field.name === 'lastSeenDate'">
               {{ prettyDate(field.value) }}
             </span>
@@ -34,6 +38,7 @@
 
 <script>
 import { computed } from 'vue'
+import { isLineageField, opsuiProductUrl } from '../opsuiLinks.js'
 
 const LABELS = {
   title: 'Title',
@@ -85,7 +90,10 @@ export default {
       }
       return String(value).replace('T00:00:00Z', '').replace('T00:00:00.000Z', '')
     }
-    return { title, visibleFields, label, prettyDate }
+    function opsuiHref(value) {
+      return opsuiProductUrl(window.location.origin, value)
+    }
+    return { title, visibleFields, label, prettyDate, isLineageField, opsuiHref }
   }
 }
 </script>

--- a/webapps/gloss/src/main/webapp/resources/src/components/RecordView.vue
+++ b/webapps/gloss/src/main/webapp/resources/src/components/RecordView.vue
@@ -24,6 +24,9 @@
             <a
               v-else-if="isLineageField(field.name) && field.value"
               :href="opsuiHref(field.value)"
+              target="_blank"
+              rel="noopener"
+              title="Open in File Manager (new tab)"
             >{{ field.value }}</a>
             <span v-else-if="field.name === 'postedDate' || field.name === 'firstSeenDate' || field.name === 'lastSeenDate'">
               {{ prettyDate(field.value) }}
@@ -32,6 +35,7 @@
           </dd>
         </div>
       </dl>
+      <p v-if="hasLineage" class="hop-note">File Manager links open in a new tab so this posting stays here.</p>
     </div>
   </section>
 </template>
@@ -81,6 +85,9 @@ export default {
     const visibleFields = computed(() => {
       return (props.payload.fields || []).filter((f) => f.name !== 'title')
     })
+    const hasLineage = computed(() =>
+      visibleFields.value.some((f) => isLineageField(f.name) && f.value)
+    )
     function label(name) {
       return LABELS[name] || name
     }
@@ -93,7 +100,7 @@ export default {
     function opsuiHref(value) {
       return opsuiProductUrl(window.location.origin, value)
     }
-    return { title, visibleFields, label, prettyDate, isLineageField, opsuiHref }
+    return { title, visibleFields, hasLineage, label, prettyDate, isLineageField, opsuiHref }
   }
 }
 </script>
@@ -167,6 +174,13 @@ dd a {
   color: var(--muted);
   font-family: "Source Sans 3", "Segoe UI", Helvetica, Arial, sans-serif;
   padding: 1.2rem 0;
+}
+
+.hop-note {
+  margin: 1rem 0 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+  font-family: "Source Sans 3", "Segoe UI", Helvetica, Arial, sans-serif;
 }
 
 @media (max-width: 700px) {

--- a/webapps/gloss/src/main/webapp/resources/src/opsuiLinks.js
+++ b/webapps/gloss/src/main/webapp/resources/src/opsuiLinks.js
@@ -1,0 +1,16 @@
+export const LINEAGE_FIELDS = {
+  InputFiles: true,
+  SplitFilename: true,
+  TsvFile: true
+}
+
+export function isLineageField(name) {
+  return Boolean(LINEAGE_FIELDS[name])
+}
+
+export function opsuiProductUrl(origin, name) {
+  if (!name) {
+    return ''
+  }
+  return String(origin || '') + '/opsui/#/product/' + encodeURIComponent(name)
+}

--- a/webapps/gloss/src/main/webapp/resources/src/opsuiLinks.test.js
+++ b/webapps/gloss/src/main/webapp/resources/src/opsuiLinks.test.js
@@ -1,0 +1,14 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { isLineageField, opsuiProductUrl } from './opsuiLinks.js'
+
+test('Solr lineage fields hop to OPSUI product pages', () => {
+  assert.equal(isLineageField('InputFiles'), true)
+  assert.equal(isLineageField('SplitFilename'), true)
+  assert.equal(isLineageField('TsvFile'), true)
+  assert.equal(isLineageField('title'), false)
+  assert.equal(
+    opsuiProductUrl('http://localhost:8080', 'computrabajo-do-20121106.tsv.aaaa'),
+    'http://localhost:8080/opsui/#/product/computrabajo-do-20121106.tsv.aaaa'
+  )
+})


### PR DESCRIPTION
Solr `InputFiles`, `SplitFilename`, and `TsvFile` on a Gloss posting now hop to `/opsui/#/product/<filename>`.

Depends on the File Manager still cataloging TSV + splits (PR #38). Those filenames resolve in OPSUI; Solr document ids do not, and OPSUI now says so quietly.

Live demo on ninja has this built and copied into Tomcat.