### PR TITLE
Align the RADiX overlay with current Mnemosyne

### DIFF
--- a/crawler/src/main/resources/etc/logging.properties
+++ b/crawler/src/main/resources/etc/logging.properties
@@ -41,7 +41,7 @@ org.apache.oodt.cas.crawl.action.level = INFO
 org.apache.oodt.cas.crawl.typedetection.level = INFO
 org.apache.oodt.cas.crawl.util.level = INFO
 org.apache.oodt.cas.crawl.config.level = INFO
-# control the underlying commons-httpclient transport layer for xmlrpc 
+# leftover Apache HttpClient wire logs (XML-RPC is gone; Avro does not use these) 
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO
 httpclient.wire.level = INFO

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -27,3 +27,9 @@ export FMPROD_HOME=$BIGTRANSLATE_HOME/tomcat/webapps/fmprod/WEB-INF/classes/
 export BIGTRANSLATE_EXCLUDE=${BIGTRANSLATE_EXCLUDE:-}
 # Translation runs locally through Pantogloss; the Tika translation server
 # and its API credentials are no longer part of this pipeline.
+
+# Bound every Avro client call (Mnemosyne #197). Ten minutes is the code
+# default; 0 waits forever. JDK_JAVA_OPTIONS reaches File Manager, Workflow
+# Manager, Resource Manager, and Tomcat.
+AVRO_CLIENT_TIMEOUT_MS=${AVRO_CLIENT_TIMEOUT_MS:-600000}
+export JDK_JAVA_OPTIONS="${JDK_JAVA_OPTIONS:+$JDK_JAVA_OPTIONS }-Dorg.apache.oodt.avro.client.requestTimeoutMillis=${AVRO_CLIENT_TIMEOUT_MS}"

--- a/filemgr/src/main/resources/etc/filemgr.fm-solr-catalog.properties
+++ b/filemgr/src/main/resources/etc/filemgr.fm-solr-catalog.properties
@@ -32,13 +32,8 @@ filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataT
 # validation layer factory
 filemgr.validationLayer.factory=org.apache.oodt.cas.filemgr.validation.XMLValidationLayerFactory
 
-# xml rpc client configuration
-# Read only by the XML-RPC client. This deployment selects Avro above,
-# so these have no effect at present.
-org.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
-org.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
-#org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retries=0
-#org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retry.interval.seconds=3
+# Avro client request bound is a JVM system property, not a File Manager key:
+# org.apache.oodt.avro.client.requestTimeoutMillis (set in bin/setenv.sh).
 
 # mapped data source catalog configuration
 #org.apache.oodt.cas.filemgr.catalog.mappeddatasource.mapFile=/path/to/ops.catalog.typemap.properties

--- a/filemgr/src/main/resources/etc/filemgr.properties
+++ b/filemgr/src/main/resources/etc/filemgr.properties
@@ -31,13 +31,8 @@ filemgr.datatransfer.factory=org.apache.oodt.cas.filemgr.datatransfer.LocalDataT
 # validation layer factory
 filemgr.validationLayer.factory=org.apache.oodt.cas.filemgr.validation.XMLValidationLayerFactory
 
-# xml rpc client configuration
-# Read only by the XML-RPC client. This deployment selects Avro above,
-# so these have no effect at present.
-org.apache.oodt.cas.filemgr.system.xmlrpc.connectionTimeout.minutes=20
-org.apache.oodt.cas.filemgr.system.xmlrpc.requestTimeout.minutes=60
-#org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retries=0
-#org.apache.oodt.cas.filemgr.system.xmlrpc.connection.retry.interval.seconds=3
+# Avro client request bound is a JVM system property, not a File Manager key:
+# org.apache.oodt.avro.client.requestTimeoutMillis (set in bin/setenv.sh).
 
 # mapped data source catalog configuration
 #org.apache.oodt.cas.filemgr.catalog.mappeddatasource.mapFile=/path/to/ops.catalog.typemap.properties

--- a/filemgr/src/main/resources/etc/logging.properties
+++ b/filemgr/src/main/resources/etc/logging.properties
@@ -54,7 +54,7 @@ org.apache.oodt.cas.filemgr.util.level = INFO
 # validation
 org.apache.oodt.cas.filemgr.validation.level = INFO
 
-# control the underlying commons-httpclient transport layer for xmlrpc
+# leftover Apache HttpClient wire logs (XML-RPC is gone; Avro does not use these)
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO
 httpclient.wire.level = INFO

--- a/pcs/src/main/resources/etc/logging.properties
+++ b/pcs/src/main/resources/etc/logging.properties
@@ -38,7 +38,7 @@ org.apache.oodt.cas.pge.util.level = OFF
 org.apache.oodt.cas.workflow.system.level = OFF
 org.apache.oodt.cas.workflow.instrepo.level = OFF
 
-# control the underlying commons-httpclient transport layer for xmlrpc 
+# leftover Apache HttpClient wire logs (XML-RPC is gone; Avro does not use these) 
 org.apache.commons.httpclient.level = OFF
 httpclient.wire.header.level = OFF
 httpclient.wire.level = OFF

--- a/resmgr/src/main/resources/etc/logging.properties
+++ b/resmgr/src/main/resources/etc/logging.properties
@@ -50,7 +50,7 @@ org.apache.oodt.cas.resource.scheduler.level = INFO
 
 # system subsystem
 org.apache.oodt.cas.resource.system.level = INFO
-# control the underlying commons-httpclient transport layer for xmlrpc 
+# leftover Apache HttpClient wire logs (XML-RPC is gone; Avro does not use these) 
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO
 httpclient.wire.level = INFO

--- a/resmgr/src/main/resources/etc/resource.properties
+++ b/resmgr/src/main/resources/etc/resource.properties
@@ -50,10 +50,8 @@ org.apache.oodt.cas.resource.jobqueue.jobstack.maxstacksize=1000
 # XML LRUScheduler config properties
 org.apache.oodt.cas.resource.scheduler.wait.seconds=20
 
-# XML-RPC configuration props
-# Read only by the XML-RPC client, which is no longer selected above.
-org.apache.oodt.cas.resource.system.xmlrpc.requestTimeout.minutes=20
-org.apache.oodt.cas.resource.system.xmlrpc.connectionTimeout.minutes=60
+# Avro client request bound is a JVM system property:
+# org.apache.oodt.avro.client.requestTimeoutMillis (set in bin/setenv.sh).
 
 # XStream JobRepo configuration props
 org.apache.oodt.cas.resource.jobrepo.xstream.working.dir=[HOME]/job-repo

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -135,6 +135,36 @@ class TestAvroTransport:
         text = (REPO / "workflow/src/main/resources/etc/workflow.properties").read_text()
         assert "AvroRpcWorkflowManagerFactory" in text
 
+    def test_avro_request_timeout_is_exported(self):
+        text = (BIN / "setenv.sh").read_text()
+        assert "org.apache.oodt.avro.client.requestTimeoutMillis" in text
+
+    def test_opsui_overlay_is_vue_not_wicket(self):
+        web = (REPO / "webapps/opsui/src/main/webapp/WEB-INF/web.xml").read_text()
+        assert "index.html" in web
+        assert "WicketFilter" not in web
+        assert "OpsuiApp" not in web
+        ctx = (REPO / "webapps/opsui/src/main/webapp/META-INF/context.xml").read_text()
+        assert "opsui.skin" not in ctx
+        assert "ganglia.url" not in ctx
+
+    def test_pcs_ll_conf_filename_is_not_typoed(self):
+        ctx = (REPO / "webapps/pcs-services/src/main/webapp/META-INF/context.xml").read_text()
+        assert "pcs-ll-conf.xml" in ctx
+        assert "pcs-ll-conf.xmnl" not in ctx
+
+    def test_workflow_cli_spring_paths_are_runtime_urls(self):
+        text = (REPO / "workflow/src/main/resources/etc/workflow.properties").read_text()
+        assert "file://[WORKFLOW_HOME]/policy/cmd-line-actions.xml" in text
+        assert "src/main/resources/cmd-line-actions.xml" not in text
+
+    def test_no_curator_or_docker_overlay(self):
+        names = [p.name.lower() for p in REPO.rglob("*")
+                 if "/target/" not in str(p) and "/.git/" not in str(p)
+                 and p.is_file()]
+        assert not any("curator" in n for n in names)
+        assert "docker-compose.yml" not in names
+
     def test_property_keys_are_not_corrupted(self):
         # Two keys carried stray xsorg./orxsg. prefixes from a 2016 edit, which
         # silently disabled both File Manager timeout settings.

--- a/webapps/opsui/src/main/webapp/META-INF/context.xml
+++ b/webapps/opsui/src/main/webapp/META-INF/context.xml
@@ -16,49 +16,15 @@ License for the specific language governing permissions and limitations under
 the License.
 -->
 <Context path="/opsui">
-		
+
 	<Parameter name="filemgr.url"
-	    value="[FILEMGR_URL]"/>		
-		
+	    value="[FILEMGR_URL]"/>
+	<Parameter name="filemgr.working.dir"
+	    value="/tmp"/>
+
 	<Parameter name="workflow.url"
 	    value="[WORKFLOW_URL]"/>
-
 	<Parameter name="resmgr.url"
 	    value="[RESMGR_URL]"/>
-
-	<Parameter name="org.apache.oodt.pcs.opsui.workflow.lifecycleFilePath"
-	    value="[WORKFLOW_HOME]/policy/workflow-lifecycle.xml"/>
-	    
-	<Parameter name="org.apache.oodt.pcs.opsui.winst.statuses"
-	    value="QUEUED, RSUBMIT, BUILDING CONFIG FILE, PGE EXEC, CRAWLING, STAGING INPUT, FINISHED, STARTED, PAUSED"/>
-	    
-	<Parameter name="org.apache.oodt.pcs.opsui.winst.metFields.filePath"
-	    value="[WORKFLOW_HOME]/policy/workflow-instance-met.xml"/>   
-	    
-	<Parameter name="org.apache.oodt.pcs.health.crawler.conf.filePath"
-	    value="[PCS_HOME]/policy/pcs-crawlers.xml"/>
-	    
-	<Parameter name="org.apache.oodt.pcs.health.workflow.statuses.filePath"
-	    value="[PCS_HOME]/policy/pcs-workflow-statuses.xml"/>	    
-	 
-	<Parameter name="ganglia.url" value="[GANGLIA_URL]"/>
-	<Parameter name="contact.email" value="user@oodt.apache.org"/>
-
-    <Parameter name="org.apache.oodt.pcs.trace.excludeList"
-               value=""/>   
-    <Parameter name="org.apache.oodt.pcs.trace.enableNotCat"
-               value="true"/>
-               	
-        <!-- OPSUI SKINNING
-                Directions: Set the 'opsui.skin' property's value attribute. 
-                Supported skins:
-                        ""           => No skin
-                        "cleanwhite" => Clean, white background OODT base skin
-                        "navyblue"   => Darker, blue background OODT base skin
-                        "classic"    => The original, OCO (Orbiting Carbon Observatory) skin for OPSUI
-                OR add your own!
-        -->
-        <Parameter name="opsui.skin" value="cleanwhite"/>
-        <Parameter name="opsui.homepage" value="org.apache.oodt.pcs.opsui.HomePage"/>
 
 </Context>

--- a/webapps/opsui/src/main/webapp/WEB-INF/web.xml
+++ b/webapps/opsui/src/main/webapp/WEB-INF/web.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
  Licensed to the Apache Software Foundation (ASF) under one or more
  contributor license agreements.  See the NOTICE file distributed with
@@ -15,37 +15,18 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
-     version="2.4">
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         version="2.5"
+         metadata-complete="true">
 
-    <display-name>opsui</display-name>
+  <display-name>opsui</display-name>
 
-     <!--  
-          There are three means to configure Wickets configuration mode and they are
-          tested in the order given. 
-          1) A system property: -Dwicket.configuration
-          2) servlet specific <init-param>
-          3) context specific <context-param>
-          The value might be either "development" (reloading when templates change)
-          or "deployment". If no configuration is found, "development" is the default.
-    -->
+  <welcome-file-list>
+    <welcome-file>index.html</welcome-file>
+  </welcome-file-list>
 
-    <filter>
-        <filter-name>wicket.browser</filter-name>
-        <filter-class>org.apache.wicket.protocol.http.WicketFilter</filter-class>
-        <init-param>
-            <param-name>applicationClassName</param-name>
-            <param-value>org.apache.oodt.pcs.opsui.OpsuiApp</param-value>
-        </init-param>
-    </filter>
-
- <filter-mapping>
-  <filter-name>wicket.browser</filter-name>
-    <url-pattern>/*</url-pattern>
- </filter-mapping>
- 
   <context-param>
     <param-name>filemgr.working.dir</param-name>
     <param-value>/tmp</param-value>
@@ -64,12 +45,9 @@
     <servlet-name>DataDeliveryServlet</servlet-name>
     <url-pattern>/data</url-pattern>
   </servlet-mapping>
-  
   <servlet-mapping>
     <servlet-name>DatasetDeliveryServlet</servlet-name>
     <url-pattern>/dataset</url-pattern>
-  </servlet-mapping>  
- 
-
+  </servlet-mapping>
 
 </web-app>

--- a/webapps/pcs-services/src/main/webapp/META-INF/context.xml
+++ b/webapps/pcs-services/src/main/webapp/META-INF/context.xml
@@ -27,7 +27,7 @@ the License.
 	    value="[RESMGR_URL]"/>
 	    
 	<Parameter name="org.apache.oodt.pcs.ll.conf.filePath"
-	    value="[PCS_HOME]/policy/pcs-ll-conf.xmnl"/>
+	    value="[PCS_HOME]/policy/pcs-ll-conf.xml"/>
 	    
 	<Parameter name="org.apache.oodt.pcs.health.crawler.conf.filePath"
 	    value="[PCS_HOME]/policy/pcs-crawlers.xml"/>

--- a/workflow/src/main/resources/etc/logging.properties
+++ b/workflow/src/main/resources/etc/logging.properties
@@ -49,7 +49,7 @@ org.apache.oodt.cas.workflow.repository.level = INFO
 
 # system subsystem
 org.apache.oodt.cas.workflow.system.level = INFO
-# control the underlying commons-httpclient transport layer for xmlrpc 
+# leftover Apache HttpClient wire logs (XML-RPC is gone; Avro does not use these) 
 org.apache.commons.httpclient.level = INFO
 httpclient.wire.header.level = INFO
 httpclient.wire.level = INFO

--- a/workflow/src/main/resources/etc/workflow.properties
+++ b/workflow/src/main/resources/etc/workflow.properties
@@ -74,5 +74,21 @@ org.apache.oodt.cas.workflow.repo.dirs=file://[WORKFLOW_HOME]/policy
 # org.apache.oodt.cas.workflow.repo.datasource.jdbc.driver=your.jdbc.Driver
 
 # Spring command line option and action store properties
-org.apache.oodt.cas.cli.action.spring.config=src/main/resources/cmd-line-actions.xml
-org.apache.oodt.cas.cli.option.spring.config=src/main/resources/cmd-line-options.xml
+org.apache.oodt.cas.cli.action.spring.config=file://[WORKFLOW_HOME]/policy/cmd-line-actions.xml
+org.apache.oodt.cas.cli.option.spring.config=file://[WORKFLOW_HOME]/policy/cmd-line-options.xml
+
+# workflow lifecycle Manager
+org.apache.oodt.cas.workflow.lifecycle.filePath=[WORKFLOW_HOME]/policy/workflow-lifecycle.xml
+
+# Avro client request bound is a JVM system property:
+# org.apache.oodt.avro.client.requestTimeoutMillis (set in bin/setenv.sh).
+
+# Queue-based engine (Workflow2). Unused while ThreadPoolWorkflowEngineFactory
+# is selected above. Kept so a switch to the packaged repo does not surprise.
+# workflow.wengine.runner.factory=org.apache.oodt.cas.workflow.engine.runner.AsynchronousLocalEngineRunnerFactory
+# org.apache.oodt.cas.workflow.wengine.prioritizer=org.apache.oodt.cas.workflow.structs.FILOPrioritySorter
+# org.apache.oodt.cas.workflow.wengine.taskquerier.waitSeconds=2
+# org.apache.oodt.cas.workflow.wengine.taskrunner.idleWaitMillis=100
+# org.apache.oodt.cas.workflow.wengine.asynchronous.runner.num.threads=25
+# org.apache.oodt.cas.workflow.wengine.packagedRepo.dir.path=/path/to/wengine/workflow/files
+# org.apache.oodt.cas.workflow.wengine.packagedRepo.parallelProcessors=false


### PR DESCRIPTION
Static compare of BigTranslate (`oodt.version` 1.11.0) against Mnemosyne `master` (through #238).

## Already current

- Avro factories for File Manager, Workflow Manager, and Resource Manager
- No CAS Curator module, WAR, or `/curator` overlay
- No `docker-compose.yml` / `oodt/*` images
- OPSUI and PCS services overlay `ai.mattmann.mnemosyne` WARs (Vue 3 + `/pcs/services/`)
- Workflow instance store is Lucene, not HSQLDB (the 2.7.4 schema is a Mnemosyne JAR concern; DRAT is the place to volume-test it)
- Split + BigTranslate stay `ThreadPoolWorkflowEngine` + XML repo — Workflow2 sub-workflow nesting (#234) and condition `execution=` (#238) are not in this pipeline's graphs

Tika 3.3.2, Avro request timeouts (#197), transceiver ownership (#194/#219), Workflow2, and HSQLDB 2.7.4 ride in on the next `mvn install` of Mnemosyne (still versioned `1.11.0` on master). Do not bump `oodt.version` until that release is cut.

## This PR (overlay that would otherwise stomp the new stack)

| Change | Why |
|---|---|
| Replace OPSUI `web.xml` | Overlay mapped Wicket `/*` over Vue `index.html` |
| Drop `opsui.skin` / Ganglia from OPSUI context | JSP skins are gone |
| Export `-Dorg.apache.oodt.avro.client.requestTimeoutMillis` from `setenv.sh` | XML-RPC timeout keys do not bound Avro |
| Delete those XML-RPC timeout keys | Dead config |
| Workflow CLI Spring paths → `file://[WORKFLOW_HOME]/policy/…` | `src/main/resources/…` is not on the installed disk |
| `pcs-ll-conf.xmnl` → `.xml` | Inherited radix typo |
| Comment the Workflow2 property block | Ready if this stack ever switches engines |

Guarded by `tests/test_pipeline_config.py` (184 passing).