### PR TITLE
Stop addressing services by ports written into the source

### DIFF
--- a/distribution/src/main/resources/bin/bigtranslate
+++ b/distribution/src/main/resources/bin/bigtranslate
@@ -33,11 +33,26 @@ function print_help {
 }
 
 function print_ui_info {
-    echo "Navigate to http://${OODT_HOST}:8080/gloss/ for Gloss, http://${OODT_HOST}:8080/opsui/ for the OODT browser, and http://${OODT_HOST}:8983/solr for the Solr catalog."
+    echo "Navigate to http://${OODT_HOST}:${TOMCAT_PORT}/gloss/ for Gloss, http://${OODT_HOST}:${TOMCAT_PORT}/opsui/ for the OODT browser, and http://${OODT_HOST}:${SOLR_PORT}/solr for the Solr catalog."
 }
 
-FILEMGR_URL=http://${OODT_HOST}:9000
-SOLR_URL=http://${OODT_HOST}:8983/solr/bigtranslate
+# Read from setenv.sh, which is what the services themselves were started
+# with. These were fixed at the defaults, so a deployment moved off them --
+# to sit beside another OODT stack on the same machine -- had its driver
+# script still talking to 9000 and 8983. Those belong to somebody else there:
+# the service checks passed against a neighbour's ports and the run posted its
+# output into a neighbour's Solr, where it 404'd and was lost.
+if [ -f "$(dirname "$0")/setenv.sh" ]; then
+    . "$(dirname "$0")/setenv.sh"
+fi
+FILEMGR_PORT=${FILEMGR_PORT:-9000}
+WORKFLOW_PORT=${WORKFLOW_PORT:-9001}
+RESMGR_PORT=${RESMGR_PORT:-9002}
+SOLR_PORT=${SOLR_PORT:-8983}
+TOMCAT_PORT=${TOMCAT_PORT:-8080}
+
+FILEMGR_URL=http://${OODT_HOST}:${FILEMGR_PORT}
+SOLR_URL=http://${OODT_HOST}:${SOLR_PORT}/solr/bigtranslate
 
 # This script is not started through env.sh, so pick the virtual environment up
 # the same way env.sh does before looking for anything in it.
@@ -70,12 +85,31 @@ function check_python_tools {
         exit 1
     fi
 }
-CLIENT_URL=http://${OODT_HOST}:9001
-OPSUI_URL=http://${OODT_HOST}:8080/opsui
+CLIENT_URL=http://${OODT_HOST}:${WORKFLOW_PORT}
+OPSUI_URL=http://${OODT_HOST}:${TOMCAT_PORT}/opsui
 
 # Crawl and translate the given TSV dataset.
 # Expects one or three argument(s) -- the file path of the TSV files to be crawled and
 # --exclude file/directory name.
+
+
+# Record what is running, where the other half can read it.
+#
+# Gloss kept this in a field of the web application, set only when a run was
+# started through Gloss. Runs are started here, so Gloss reported IDLE for the
+# whole of every real translation. The file is the shared fact; both sides
+# write it and both sides read it.
+RUN_MARKER="$BIGTRANSLATE_HOME/data/run"
+
+mark_run() {
+    mkdir -p "$(dirname "$RUN_MARKER")" 2>/dev/null
+    printf '{"status":"%s","startedBy":"cli","path":"%s","exclude":"%s","startedAt":%s}\n' \
+        "$1" "${2//\"/}" "${3//\"/}" "$(($(date +%s) * 1000))" > "$RUN_MARKER" 2>/dev/null
+}
+
+unmark_run() {
+    rm -f "$RUN_MARKER" 2>/dev/null
+}
 
 function translate {
     check_services_running
@@ -88,8 +122,12 @@ function translate {
 	export BIGTRANSLATE_EXCLUDE=""
 	PRODUCT_PATH=$1
     fi
+    mark_run "TRANSLATING" "$PRODUCT_PATH" "$BIGTRANSLATE_EXCLUDE"
+    # The crawl is the part this script waits for; the translation itself runs
+    # on in the workflow manager, so the marker is cleared by whoever sees the
+    # workflow finish rather than here.
     pushd $BIGTRANSLATE_HOME/crawler/bin >> $BIGTRANSLATE_HOME/logs/bigtranslate.log 2>&1
-    
+
    ./crawler_launcher --operation --metPC --metExtractorConfig \
    $BIGTRANSLATE_HOME/extractors/default/default.cpr.conf --metExtractor org.apache.oodt.cas.metadata.extractors.CopyAndRewriteExtractor \
    --filemgrUrl $FILEMGR_URL --clientTransferer org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory \
@@ -143,12 +181,12 @@ function check_port {
 # Otherwise, check the ports are not busy.
 function check_services_running {
     if [[ $# == 0 ]]; then
-        if [[ ! -n $(check_port 9000) ]] || [[ ! -n $(check_port 9001) ]] || [[ ! -n $(check_port 9002) ]] || [[ ! -n $(check_port 8080) ]]; then
+        if [[ ! -n $(check_port ${FILEMGR_PORT}) ]] || [[ ! -n $(check_port ${WORKFLOW_PORT}) ]] || [[ ! -n $(check_port ${RESMGR_PORT}) ]] || [[ ! -n $(check_port ${TOMCAT_PORT}) ]]; then
             echo "Please start OODT by running '\$BIGTRANSLATE_HOME/bin/oodt start'"
             echo "Aborting..."
             exit 1
         fi
-    elif [[ -n $(check_port 9000) ]] || [[ -n $(check_port 9001) ]] || [[ -n $(check_port 9002) ]] || [[ -n $(check_port 8080) ]]; then
+    elif [[ -n $(check_port ${FILEMGR_PORT}) ]] || [[ -n $(check_port ${WORKFLOW_PORT}) ]] || [[ -n $(check_port ${RESMGR_PORT}) ]] || [[ -n $(check_port ${TOMCAT_PORT}) ]]; then
         echo "Please stop OODT by running '\$BIGTRANSLATE_HOME/bin/oodt stop'"
         echo "Aborting..."
         exit 1
@@ -183,6 +221,9 @@ function do_reset {
 # Reset bigtranslate to prepare for translating a new dataset.
 # Optional --yes skips the confirmation prompt (used by Gloss).
 function reset {
+    mark_run "RESETTING" "" ""
+    trap 'unmark_run' EXIT
+
     local yes=0
     if [ "$1" = "--yes" ]; then
         yes=1

--- a/distribution/src/main/resources/bin/bigtranslate
+++ b/distribution/src/main/resources/bin/bigtranslate
@@ -111,6 +111,81 @@ unmark_run() {
     rm -f "$RUN_MARKER" 2>/dev/null
 }
 
+
+# Check the corpus path before anything is started.
+#
+# The path is pasted, and a pasted path picks things up: a trailing comma from
+# a list, a stray quote, a shell-expanded "~" that never expanded because it
+# was quoted. DRAT accepted one of those and reported a running audit over a
+# directory that did not exist -- the catalog was cleared, the crawl found
+# nothing, and the first sign of trouble was a zero where a count should have
+# been. Refusing costs a second; a run that translates nothing costs an hour.
+#
+# Sets CORPUS_PATH to the resolved, absolute path.
+validate_corpus_path() {
+    local given="$1"
+
+    if [[ -z "$given" ]]; then
+        echo "No path given. Pass the directory holding the TSV files."
+        exit 1
+    fi
+
+    # Anything that cannot be part of a real path here is almost certainly
+    # punctuation that came along for the ride.
+    local trimmed="${given%"${given##*[![:space:]]}"}"
+    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+    if [[ "$trimmed" != "$given" ]]; then
+        echo "The path has whitespace around it: [$given]"
+        echo "Quote it, or remove the spaces."
+        exit 1
+    fi
+    case "$given" in
+        *,|*\"|*\'|*\;|*\||*\&)
+            echo "The path ends in '${given: -1}': [$given]"
+            echo "That usually means it picked something up when it was pasted."
+            exit 1
+            ;;
+    esac
+    case "$given" in
+        "~"*)
+            echo "The path starts with a literal ~: [$given]"
+            echo "It was quoted, so the shell did not expand it. Use \$HOME."
+            exit 1
+            ;;
+    esac
+
+    if [[ ! -e "$given" ]]; then
+        echo "There is nothing at [$given]."
+        exit 1
+    fi
+    if [[ ! -d "$given" ]]; then
+        echo "[$given] is a file, not a directory."
+        echo "Pass the directory that holds the TSV files."
+        exit 1
+    fi
+    if [[ ! -r "$given" ]]; then
+        echo "[$given] cannot be read."
+        exit 1
+    fi
+
+    CORPUS_PATH=$(cd "$given" 2>/dev/null && pwd -P)
+    if [[ -z "$CORPUS_PATH" ]]; then
+        echo "[$given] could not be resolved."
+        exit 1
+    fi
+
+    # An empty directory is a crawl that finishes instantly having done
+    # nothing, which reads exactly like success.
+    local count
+    count=$(find "$CORPUS_PATH" -maxdepth 1 -type f -name '*.tsv' 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$count" == "0" ]]; then
+        echo "No .tsv files in [$CORPUS_PATH]."
+        echo "BigTranslate crawls TSV; there is nothing here to translate."
+        exit 1
+    fi
+    echo "Translating $count TSV file(s) from $CORPUS_PATH"
+}
+
 function translate {
     check_services_running
     if [ $1 = "--exclude" ]; then
@@ -122,6 +197,11 @@ function translate {
 	export BIGTRANSLATE_EXCLUDE=""
 	PRODUCT_PATH=$1
     fi
+
+    # Before the services are touched and before anything is marked running.
+    validate_corpus_path "$PRODUCT_PATH"
+    PRODUCT_PATH="$CORPUS_PATH"
+
     mark_run "TRANSLATING" "$PRODUCT_PATH" "$BIGTRANSLATE_EXCLUDE"
     # The crawl is the part this script waits for; the translation itself runs
     # on in the workflow manager, so the marker is cleared by whoever sees the

--- a/distribution/src/main/resources/bin/bigtranslate-setup
+++ b/distribution/src/main/resources/bin/bigtranslate-setup
@@ -89,7 +89,34 @@ echo "Installing from $REQUIREMENTS"
 if [ -n "$PANTOGLOSS_SOURCE" ]; then
     echo
     echo "Installing Pantogloss from $PANTOGLOSS_SOURCE"
-    "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
+    # With its [server] extra, which is fastapi and uvicorn.
+    #
+    # "pantogloss serve" keeps one translator loaded behind a local HTTP API,
+    # which is how the translate step avoids reloading the model for every
+    # invocation -- about thirty seconds each time. Installed plain, serve
+    # exists as a subcommand and fails with "No module named 'uvicorn'" the
+    # moment it is asked to run, which is a poor way to find out.
+    #
+    # A specifier the extra cannot be appended to -- a URL, a wheel path --
+    # is installed as given and the extra requested separately, so the
+    # server half arrives either way.
+    case "$PANTOGLOSS_SOURCE" in
+        *"["*"]"*)
+            "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
+            ;;
+        *://*|*.whl|*.tar.gz)
+            "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
+            "$VENV/bin/pip" install "fastapi>=0.115,<1" "uvicorn>=0.34,<1"
+            ;;
+        *)
+            "$VENV/bin/pip" install "${PANTOGLOSS_SOURCE}[server]" \
+                || {
+                    echo "  [server] extra not available; installing plain"
+                    "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
+                    "$VENV/bin/pip" install "fastapi>=0.115,<1" "uvicorn>=0.34,<1"
+                }
+            ;;
+    esac
 fi
 
 echo
@@ -103,6 +130,14 @@ for tool in tsvtojson repackage poster; do
 done
 if "$VENV/bin/python" -c "import pantogloss" > /dev/null 2>&1; then
     echo "  pantogloss"
+    # Said here rather than left to fail at run time.
+    if "$VENV/bin/python" -c "import uvicorn, fastapi" > /dev/null 2>&1; then
+        echo "  pantogloss serve  (the translation service)"
+    else
+        echo "  pantogloss serve  NOT AVAILABLE -- no fastapi/uvicorn."
+        echo "                    The translate step will load the model per"
+        echo "                    invocation instead of using the service."
+    fi
 else
     echo "  pantogloss  NOT INSTALLED -- the translate step will fail."
     echo "              Re-run with PANTOGLOSS_SOURCE set to a checkout or wheel."

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -98,7 +98,61 @@ if [ ! -x "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" ]; then
   exit 1
 fi
 
-if [ "$1" = "start" ]; then
+
+# The ports these services listen on, so start and stop can tell whether they
+# actually did anything.
+oodt_ports() {
+  echo "$FILEMGR_PORT $WORKFLOW_PORT $RESMGR_PORT $TOMCAT_PORT $SOLR_PORT"
+}
+
+port_busy() {
+  if command -v lsof > /dev/null 2>&1; then
+    lsof -ti tcp:"$1" > /dev/null 2>&1
+  else
+    nc -z localhost "$1" > /dev/null 2>&1
+  fi
+}
+
+# Wait until every port is free, or say which ones are not.
+#
+# stop used to return as soon as it had asked each service to stop, which is
+# not the same as their having stopped: a start immediately afterwards found
+# Solr still holding its port, failed with "Port ... is already being used",
+# and left the deployment with nothing running at all.
+wait_for_stopped() {
+  waited=0
+  while [ "$waited" -lt 180 ]; do
+    busy=""
+    for p in $(oodt_ports); do
+      port_busy "$p" && busy="$busy $p"
+    done
+    [ -z "$busy" ] && return 0
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo "Still listening after ${waited}s:$busy"
+  return 1
+}
+
+# Wait until every port answers, so a caller that starts and then immediately
+# uses the services is not racing them.
+wait_for_started() {
+  waited=0
+  while [ "$waited" -lt 120 ]; do
+    missing=""
+    for p in $(oodt_ports); do
+      port_busy "$p" || missing="$missing $p"
+    done
+    [ -z "$missing" ] && return 0
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo "Not listening after ${waited}s:$missing"
+  echo "See $OODT_OUT"
+  return 1
+}
+
+start_oodt() {
   nohup "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &  
@@ -110,7 +164,10 @@ if [ "$1" = "start" ]; then
     nohup "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" start -p "$SOLR_PORT" \
       --solr-home "$OODT_BASE"/solr --user-managed >> "$OODT_OUT" 2>&1 &
   fi
-elif [ "$1" = "stop" ]; then
+  wait_for_started
+}
+
+stop_oodt() {
   "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1  &
   "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
   "$RESMGR_HOME"/bin/"$RESMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
@@ -118,11 +175,26 @@ elif [ "$1" = "stop" ]; then
   if [ -x "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" ]; then
     "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" stop -p "$SOLR_PORT" >> "$OODT_OUT" 2>&1 &
   fi
+  wait_for_stopped
+}
+
+if [ "$1" = "start" ]; then
+  start_oodt
+elif [ "$1" = "stop" ]; then
+  stop_oodt
+elif [ "$1" = "restart" ]; then
+  # The README has told people to run this since before it existed, and the
+  # script answered by printing its usage and exiting 1 -- quietly enough that
+  # a configuration change made just beforehand looked as though it had been
+  # picked up when the services were still running with the old one.
+  stop_oodt || exit 1
+  start_oodt
 else
   echo "Usage: oodt.sh ( commands ... )"
   echo "commands:"
   echo "  start             Start OODT in a separate window"
-  echo "  stop              Stop OODT, waiting up to 5 seconds for the process to end"
+  echo "  stop              Stop OODT and wait for its ports to be free"
+  echo "  restart           Stop OODT, wait for it, and start it again"
 #  echo "  version           What version of OODT are you running?"
   exit 1
 fi

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -101,8 +101,85 @@ fi
 
 # The ports these services listen on, so start and stop can tell whether they
 # actually did anything.
+#
+# The translation service is deliberately not in this list. It loads a model
+# before it answers -- half a minute or so -- and a start that waited for it
+# would look hung; the translate step checks it for itself and says plainly
+# if it is not ready. Its port is still stopped and started with everything
+# else.
 oodt_ports() {
   echo "$FILEMGR_PORT $WORKFLOW_PORT $RESMGR_PORT $TOMCAT_PORT $SOLR_PORT"
+}
+
+PANTOGLOSS_LOG="$OODT_BASE/logs/pantogloss-serve.log"
+PANTOGLOSS_PID="$OODT_BASE/run/pantogloss-serve.pid"
+
+# One resident model for the deployment, rather than one load per split.
+#
+# Started here because the translate step is run by the workflow manager, and
+# a service that has to be remembered separately is one that is not running
+# when it matters -- the model then loads inside every split's own process,
+# thirty seconds at a time, which is the cost this removes.
+start_pantogloss() {
+  serve_bin="$OODT_BASE/.venv/bin/pantogloss"
+  if [ ! -x "$serve_bin" ]; then
+    echo "No Pantogloss in $OODT_BASE/.venv -- run bin/bigtranslate-setup."
+    echo "Translation will fail until it is there."
+    return 0
+  fi
+  if ! "$OODT_BASE"/.venv/bin/python -c "import uvicorn, fastapi" > /dev/null 2>&1; then
+    echo "Pantogloss is installed without its server extra, so the"
+    echo "translation service cannot start. Re-run bin/bigtranslate-setup."
+    return 0
+  fi
+  if port_busy "$PANTOGLOSS_PORT"; then
+    echo "Something is already listening on $PANTOGLOSS_PORT;"
+    echo "leaving it alone. If it is not Pantogloss, set PANTOGLOSS_PORT."
+    return 0
+  fi
+
+  # As many at once as the engine runs splits at once. The service defaults
+  # to one, and one is the wrong answer here: every worker but the first
+  # waits, and the queue is longer than the work.
+  concurrency="$PANTOGLOSS_CONCURRENCY"
+  if [ -z "$concurrency" ]; then
+    concurrency=$(sed -n 's/^org.apache.oodt.cas.workflow.engine.minPoolSize=\([0-9]*\).*/\1/p' \
+      "$OODT_BASE/workflow/etc/workflow.properties" 2>/dev/null | tail -1)
+  fi
+  if [ -z "$concurrency" ]; then
+    concurrency=8
+  fi
+
+  mkdir -p "$(dirname "$PANTOGLOSS_PID")" "$(dirname "$PANTOGLOSS_LOG")" 2>/dev/null
+  nohup "$serve_bin" serve --port "$PANTOGLOSS_PORT" --no-browser \
+    --max-concurrency "$concurrency" \
+    --max-queued-requests $((concurrency * 8)) \
+    --device "$PANTOGLOSS_DEVICE" \
+    >> "$PANTOGLOSS_LOG" 2>&1 &
+  echo $! > "$PANTOGLOSS_PID"
+  echo "Translation service starting on $PANTOGLOSS_PORT: $concurrency at a time"
+  echo "on $PANTOGLOSS_DEVICE. It answers once the model is loaded"
+  echo "(see $PANTOGLOSS_LOG)."
+}
+
+stop_pantogloss() {
+  if [ -f "$PANTOGLOSS_PID" ]; then
+    pid=$(cat "$PANTOGLOSS_PID" 2>/dev/null)
+    if [ -n "$pid" ] && kill -0 "$pid" > /dev/null 2>&1; then
+      kill "$pid" > /dev/null 2>&1
+    fi
+    rm -f "$PANTOGLOSS_PID"
+  fi
+
+  waited=0
+  while [ "$waited" -lt 60 ]; do
+    port_busy "$PANTOGLOSS_PORT" || return 0
+    sleep 2
+    waited=$((waited + 2))
+  done
+  # Not fatal: it may be somebody else's, which start_pantogloss also
+  # declines to touch.
+  echo "Port $PANTOGLOSS_PORT is still busy after ${waited}s."
 }
 
 port_busy() {
@@ -164,6 +241,7 @@ start_oodt() {
     nohup "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" start -p "$SOLR_PORT" \
       --solr-home "$OODT_BASE"/solr --user-managed >> "$OODT_OUT" 2>&1 &
   fi
+  start_pantogloss
   wait_for_started
 }
 
@@ -175,6 +253,7 @@ stop_oodt() {
   if [ -x "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" ]; then
     "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" stop -p "$SOLR_PORT" >> "$OODT_OUT" 2>&1 &
   fi
+  stop_pantogloss
   wait_for_stopped
 }
 

--- a/distribution/src/main/resources/bin/pantogloss-translatejson
+++ b/distribution/src/main/resources/bin/pantogloss-translatejson
@@ -47,6 +47,8 @@ import json
 import os
 import sqlite3
 import sys
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 _verbose = False
@@ -55,6 +57,125 @@ _verbose = False
 def log(message):
     if _verbose:
         print(message, file=sys.stderr)
+
+
+# --------------------------------------------------------------------------
+# the translation service
+# --------------------------------------------------------------------------
+#
+# Translation goes through a running "pantogloss serve" rather than loading
+# the model in this process. A model load is about thirty seconds, and this
+# program runs once per split: a baseline over ten TSV files spent forty-nine
+# loads on one run, every one of them loading the same model again.
+#
+# There is deliberately no fallback to loading it here. A fallback would be
+# invisible: the run would simply take the time it always did, and the fact
+# that the service was never reached would show up only as slowness. Every
+# silent fallback in this pipeline has cost a run -- posting to a Solr core
+# that was not there, services running with configuration they had not
+# reloaded -- so this stops instead, and says which of the things that can be
+# wrong is wrong.
+
+DEFAULT_SERVICE_URL = "http://127.0.0.1:8765"
+
+
+class ServiceUnavailable(Exception):
+    """The service is not there, is not ready, or is not Pantogloss."""
+
+
+def _get_json(url, timeout):
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _port_of(base_url):
+    tail = base_url.rsplit(":", 1)[-1]
+    port = tail.split("/")[0]
+    return port if port.isdigit() else "8765"
+
+
+def check_service(base_url, timeout=10):
+    """Confirm the service is up, is Pantogloss, and has its model loaded.
+
+    Three different faults needing three different answers, so they are told
+    apart rather than all reported as "unreachable". The middle one is not
+    hypothetical: Pantogloss's default port is an ordinary one, and a plain
+    ``python3 -m http.server`` sitting on it answers with a cheerful 404 that
+    is not a connection failure at all.
+    """
+    health = base_url.rstrip("/") + "/health"
+    try:
+        payload = _get_json(health, timeout)
+    except urllib.error.HTTPError as e:
+        raise ServiceUnavailable(
+            "something is listening at %s but it is not Pantogloss: GET "
+            "/health returned HTTP %s. Check what is on that port, or point "
+            "PANTOGLOSS_URL at the right one." % (base_url, e.code))
+    except urllib.error.URLError as e:
+        raise ServiceUnavailable(
+            "no translation service at %s (%s). Start one with 'pantogloss "
+            "serve --port %s', or set PANTOGLOSS_URL to where it is running."
+            % (base_url, e.reason, _port_of(base_url)))
+    except ValueError:
+        raise ServiceUnavailable(
+            "something is listening at %s but it is not Pantogloss: GET "
+            "/health did not return JSON. Check what is on that port."
+            % base_url)
+
+    if not isinstance(payload, dict) or "model_status" not in payload:
+        raise ServiceUnavailable(
+            "something is listening at %s but it is not Pantogloss: GET "
+            "/health returned %s. Check what is on that port."
+            % (base_url, json.dumps(payload)[:120]))
+
+    if not payload.get("ready"):
+        raise ServiceUnavailable(
+            "the translation service at %s is not ready: the model is %s. "
+            "Wait for it to finish loading and run this again."
+            % (base_url, payload.get("model_status", "in an unknown state")))
+
+    return payload
+
+
+def translate_batch(base_url, texts, beam_size, max_length, timeout):
+    """One batch through the service, answered in the order it was given."""
+    body = {"text": list(texts), "max_length": max_length}
+    if beam_size and beam_size > 1:
+        body["beam_size"] = beam_size
+        body["preset"] = "custom"
+
+    request = urllib.request.Request(
+        base_url.rstrip("/") + "/translate",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = ": " + e.read().decode("utf-8")[:200]
+        except Exception:
+            pass
+        raise ServiceUnavailable(
+            "the translation service at %s refused a batch of %d (HTTP %s)%s"
+            % (base_url, len(texts), e.code, detail))
+    except urllib.error.URLError as e:
+        raise ServiceUnavailable(
+            "the translation service at %s stopped answering partway through "
+            "(%s)." % (base_url, e.reason))
+
+    out = payload.get("translation")
+    if isinstance(out, str):
+        out = [out]
+    if not isinstance(out, list) or len(out) != len(texts):
+        raise ServiceUnavailable(
+            "the translation service at %s returned %s results for a batch of "
+            "%d; refusing to guess which goes with which"
+            % (base_url, "no" if out is None else len(out), len(texts)))
+    return out
 
 
 # --------------------------------------------------------------------------
@@ -274,7 +395,16 @@ def main(argv=None):
     parser.add_argument("--glossary", default=None,
                         help="TSV of authoritative source<TAB>target overrides")
     parser.add_argument("--batch-size", type=int, default=32)
-    parser.add_argument("--model", default="pantogloss-500-en")
+    parser.add_argument("--model", default="pantogloss-500-en",
+                        help="recorded for provenance; the service decides "
+                             "which model it serves")
+    parser.add_argument("--service-url",
+                        default=os.environ.get("PANTOGLOSS_URL",
+                                               DEFAULT_SERVICE_URL),
+                        help="a running 'pantogloss serve' (PANTOGLOSS_URL)")
+    parser.add_argument("--service-timeout", type=int,
+                        default=int(os.environ.get("PANTOGLOSS_TIMEOUT", "600")),
+                        help="seconds to wait on one request to the service")
     parser.add_argument("--device", choices=("auto", "cpu", "gpu"), default="auto")
     parser.add_argument("--beam-size", type=int, default=1,
                         help="1 (greedy) suits short formulaic job-posting fields")
@@ -333,31 +463,25 @@ def main(argv=None):
         log("cache: %d hit, %d miss" % (len(cached), len(missing)))
 
         if missing:
-            # Import lazily so --help and argument errors do not pay for
-            # TensorFlow, which takes several seconds to load.
-            from pantogloss import Translator
-
-            translator = Translator.from_pretrained(
-                args.model,
-                device=args.device,
-                local_files_only=args.offline,
-            )
-            log("model on %s" % translator.device_info.selected)
+            # Checked once, before any work: a service that is not there is
+            # not something to discover on the last batch of a long run.
+            health = check_service(args.service_url, args.service_timeout)
+            log("service at %s, model %s"
+                % (args.service_url, health.get("model_status")))
 
             fresh = {}
             for i in range(0, len(missing), args.batch_size):
                 batch = missing[i:i + args.batch_size]
-                out = translator.translate(
-                    batch,
-                    beam_size=args.beam_size,
-                    max_length=args.max_length,
-                )
-                if isinstance(out, str):
-                    out = [out]
+                out = translate_batch(args.service_url, batch,
+                                      args.beam_size, args.max_length,
+                                      args.service_timeout)
                 fresh.update(dict(zip(batch, out)))
+                # Written as they are produced. A service that dies halfway
+                # through leaves what it did translate in the cache, so the
+                # re-run pays only for what is left.
+                cache.put_many(dict(zip(batch, out)))
                 log("  translated %d/%d" % (min(i + args.batch_size, len(missing)),
                                             len(missing)))
-            cache.put_many(fresh)
             translations.update(fresh)
     finally:
         cache.close()
@@ -378,4 +502,12 @@ def main(argv=None):
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    try:
+        sys.exit(main())
+    except ServiceUnavailable as unavailable:
+        # One line on stderr and a non-zero exit, rather than a traceback.
+        # The PGE that runs this writes its output to a log nobody reads
+        # until something has gone wrong, and a stack trace there says only
+        # that Python was upset, not what to do about it.
+        print("pantogloss-translatejson: %s" % unavailable, file=sys.stderr)
+        sys.exit(2)

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -12,9 +12,29 @@
 ############################
 
 export BIGTRANSLATE_HOME=${BIGTRANSLATE_HOME:-/usr/local/bigtranslate}
-export FILEMGR_URL=http://localhost:9000
-export WORKFLOW_URL=http://localhost:9001
-export RESMGR_URL=http://localhost:9002
+# Ports first, urls derived from them. The launchers bind FILEMGR_PORT and its
+# siblings while everything else looks up the urls, so setting only the urls
+# left each service listening on the default and every client looking
+# elsewhere. Setting a port here moves both.
+#
+# A machine running more than one OODT stack needs these to differ: the
+# defaults below are what DRAT and a stock RADiX deployment also use, and two
+# stacks on the same port do not fail loudly -- the second one's clients talk
+# to the first one's services.
+export FILEMGR_PORT=${FILEMGR_PORT:-9000}
+export WORKFLOW_PORT=${WORKFLOW_PORT:-9001}
+export RESMGR_PORT=${RESMGR_PORT:-9002}
+export SOLR_PORT=${SOLR_PORT:-8983}
+export TOMCAT_PORT=${TOMCAT_PORT:-8080}
+
+export FILEMGR_URL=http://localhost:$FILEMGR_PORT
+export WORKFLOW_URL=http://localhost:$WORKFLOW_PORT
+export RESMGR_URL=http://localhost:$RESMGR_PORT
+
+# The core url rather than the base. Gloss reads SOLR_URL as the collection it
+# queries and derives the base from it, so a base url here sends every Gloss
+# query to /solr/select and it reports no documents while Solr fills up.
+export SOLR_URL=http://localhost:$SOLR_PORT/solr/bigtranslate
 export FILEMGR_HOME=$BIGTRANSLATE_HOME/filemgr
 export PGE_HOME=$BIGTRANSLATE_HOME/pge
 export PCS_HOME=$BIGTRANSLATE_HOME/pcs

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -35,6 +35,33 @@ export RESMGR_URL=http://localhost:$RESMGR_PORT
 # queries and derives the base from it, so a base url here sends every Gloss
 # query to /solr/select and it reports no documents while Solr fills up.
 export SOLR_URL=http://localhost:$SOLR_PORT/solr/bigtranslate
+
+# The translation service. One resident model for the whole deployment
+# instead of a fresh load in every split's process -- about thirty seconds
+# each, and a ten-file run does it dozens of times.
+#
+# 8765 is Pantogloss's own default and is an ordinary enough port to be
+# somebody else's; move it here if it is.
+export PANTOGLOSS_PORT=${PANTOGLOSS_PORT:-8765}
+export PANTOGLOSS_URL=${PANTOGLOSS_URL:-http://127.0.0.1:$PANTOGLOSS_PORT}
+
+# How many translations the service will do at once.
+#
+# This has to match the number of splits the workflow engine runs at once,
+# and it is not a free choice: pantogloss serve defaults to one, so eight
+# workers sharing it queue behind a single translation. Measured on the ten
+# file corpus that spent 1,885 seconds queued against 347 seconds actually
+# translating -- slower than loading the model separately in every worker,
+# which is the thing the service exists to avoid.
+#
+# Left unset it is read from the engine's own pool size below, so the two
+# cannot drift apart.
+export PANTOGLOSS_CONCURRENCY=${PANTOGLOSS_CONCURRENCY:-}
+
+# Which device the model runs on. "auto" prefers the GPU -- Metal here, CUDA
+# on Linux -- and falls back to the CPU when there is none. Set "cpu" to keep
+# the GPU free for something else.
+export PANTOGLOSS_DEVICE=${PANTOGLOSS_DEVICE:-auto}
 export FILEMGR_HOME=$BIGTRANSLATE_HOME/filemgr
 export PGE_HOME=$BIGTRANSLATE_HOME/pge
 export PCS_HOME=$BIGTRANSLATE_HOME/pcs

--- a/filemgr/src/main/resources/etc/filemgr.properties
+++ b/filemgr/src/main/resources/etc/filemgr.properties
@@ -45,6 +45,9 @@ org.apache.oodt.cas.filemgr.catalog.lucene.writeLockTimeout.seconds=60
 org.apache.oodt.cas.filemgr.catalog.lucene.mergeFactor=20
 
 # solr catalog configuration
+# Overridden by SOLR_URL's port where one is set; see bin/setenv.sh. The
+# default here is shared with every other OODT deployment, so on a machine
+# running more than one it points at whichever came first.
 org.apache.oodt.cas.filemgr.catalog.solr.url=http://localhost:8983/solr
 org.apache.oodt.cas.filemgr.catalog.solr.productSerializer=org.apache.oodt.cas.filemgr.catalog.solr.DefaultProductSerializer
 org.apache.oodt.cas.filemgr.catalog.solr.productIdGenerator=org.apache.oodt.cas.filemgr.catalog.solr.UUIDProductIdGenerator

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_BigTranslate.xml
@@ -22,7 +22,7 @@
           Tika-backed predecessor made an HTTP call per field, so a process
           per file cost nothing; Pantogloss loads a local model, so the same
           shape would reload it once per posting. -->
-     <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --glossary [TranslateGlossary] --batch-size [TranslateBatchSize] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/pantogloss-translatejson --in-dir [JobOutputDir]/employmentjobs --out-dir [JobOutputDir]/translated -c [TranslateCols] -f es --cache [TranslateCachePath] --glossary [TranslateGlossary] --batch-size [TranslateBatchSize] --service-url [PantoglossUrl] --offline -v >> [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/stamp-solr-lineage --dir [JobOutputDir]/translated --input-files '[SplitFilename]' --split '[SplitFilename]' --tsv '[SourceTsv]' >> [JobLogDir]/stamp_solr_lineage_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>find [JobOutputDir]/translated -name "*.json" | poster -u "[SolrUrl]" -v > [JobLogDir]/solrjsonposter_[DateMilis].log 2[GreaterThan][Ampersand]1 </cmd>
      <!-- Working copies are ephemeral. File Manager only catalogs the TSV and

--- a/tests/test_corpus_path.py
+++ b/tests/test_corpus_path.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The corpus path is checked before anything is started.
+
+A path is pasted, and a pasted path picks things up: a comma from a list, a
+stray quote, a "~" that never expanded because it was quoted. DRAT accepted
+one of those and reported a running audit over a directory that did not
+exist -- catalog cleared, crawl found nothing, and the first sign of trouble
+was a zero where a count should have been. Refusing costs a second.
+"""
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DRIVER = REPO / "distribution" / "src" / "main" / "resources" / "bin" / "bigtranslate"
+
+
+def run_validation(argument):
+    """Call validate_corpus_path on its own, out of the driver script."""
+    body = subprocess.run(
+        ["sed", "-n", "/^validate_corpus_path() {/,/^}/p", str(DRIVER)],
+        capture_output=True, text=True, check=True).stdout
+    assert body.strip(), "validate_corpus_path is not in the driver script"
+    script = body + '\nvalidate_corpus_path "$1"\necho "RESOLVED=$CORPUS_PATH"\n'
+    return subprocess.run(["bash", "-c", script, "bash", argument],
+                          capture_output=True, text=True)
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    (tmp_path / "one.tsv").write_text("a\tb\n")
+    (tmp_path / "two.tsv").write_text("c\td\n")
+    return tmp_path
+
+
+def test_a_directory_of_tsv_is_accepted_and_resolved(corpus):
+    done = run_validation(str(corpus))
+    assert done.returncode == 0, done.stdout + done.stderr
+    assert "RESOLVED=" in done.stdout
+    assert "2 TSV file(s)" in done.stdout
+
+
+def test_a_trailing_comma_is_refused(corpus):
+    """The one that actually happened."""
+    done = run_validation(str(corpus) + ",")
+    assert done.returncode != 0
+    assert "ends in ','" in done.stdout
+    assert "pasted" in done.stdout, "does not say what probably went wrong"
+
+
+@pytest.mark.parametrize("junk", ['"', "'", ";", "|", "&"])
+def test_other_pasted_punctuation_is_refused(corpus, junk):
+    done = run_validation(str(corpus) + junk)
+    assert done.returncode != 0, "accepted a path ending in %r" % junk
+
+
+def test_a_path_that_is_not_there_is_refused(tmp_path):
+    done = run_validation(str(tmp_path / "nope"))
+    assert done.returncode != 0
+    assert "nothing at" in done.stdout
+
+
+def test_a_file_is_refused_with_the_right_advice(corpus):
+    done = run_validation(str(corpus / "one.tsv"))
+    assert done.returncode != 0
+    assert "is a file, not a directory" in done.stdout
+
+
+def test_an_empty_directory_is_refused(tmp_path):
+    """A crawl of nothing finishes instantly and reads exactly like success."""
+    done = run_validation(str(tmp_path))
+    assert done.returncode != 0
+    assert "No .tsv files" in done.stdout
+
+
+def test_an_unexpanded_tilde_is_refused():
+    done = run_validation("~/bigtranslate/input")
+    assert done.returncode != 0
+    assert "literal ~" in done.stdout
+
+
+def test_nothing_at_all_is_refused():
+    done = run_validation("")
+    assert done.returncode != 0
+    assert "No path given" in done.stdout
+
+
+def test_translate_validates_before_it_marks_a_run():
+    """Order matters: marking first would leave a marker for a run that never
+    started, and Gloss would report it as running for ever."""
+    text = DRIVER.read_text()
+    validate_at = text.index("validate_corpus_path \"$PRODUCT_PATH\"")
+    mark_at = text.index('mark_run "TRANSLATING"')
+    assert validate_at < mark_at, (
+        "the run is marked before the path is checked")
+
+
+def test_the_service_runs_as_many_at_once_as_there_are_workers():
+    """One at a time is the default, and it is the wrong answer here: eight
+    workers sharing one translation queue behind each other, which measured
+    slower than loading the model separately in every worker."""
+    oodt = (REPO / "distribution" / "src" / "main" / "resources" / "bin" / "oodt").read_text()
+    assert "--max-concurrency" in oodt
+    assert "minPoolSize" in oodt, (
+        "concurrency is not derived from the engine's pool size, so the two "
+        "can drift apart")
+
+
+def test_the_device_is_configurable():
+    oodt = (REPO / "distribution" / "src" / "main" / "resources" / "bin" / "oodt").read_text()
+    setenv = (REPO / "distribution" / "src" / "main" / "resources" / "bin" / "setenv.sh").read_text()
+    assert "--device" in oodt
+    assert "PANTOGLOSS_DEVICE" in setenv
+    assert "PANTOGLOSS_DEVICE:-auto}" in setenv, "the default is not auto"

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -456,7 +456,12 @@ class TestBuild:
     def test_cli_translate_still_exists_alongside_gloss(self):
         text = (BIN / "bigtranslate").read_text()
         assert "function translate" in text
-        assert "8080/gloss" in text
+        # The script still points people at Gloss, but by the port the
+        # deployment was started on rather than the literal 8080: that
+        # default belongs to whatever OODT stack came first on a machine
+        # running more than one. See tests/test_port_isolation.py.
+        assert "/gloss/" in text
+        assert "${TOMCAT_PORT}/gloss/" in text
 
     def test_gloss_services_expose_table_and_facets(self):
         text = (REPO / "webapps/gloss-services/src/main/java/org/bigtranslate/gloss/rest"

--- a/tests/test_port_isolation.py
+++ b/tests/test_port_isolation.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Nothing addresses a service by a port written into the source.
+
+BigTranslate's defaults -- 9000, 9001, 9002, 8080, 8983 -- are the same ones
+DRAT and any stock RADiX deployment use. A machine running two of them does
+not fail loudly: the second stack's clients reach the first stack's services.
+That is not hypothetical. Run against a deployment moved onto its own ports,
+the driver script checked a neighbour's ports and reported the services up,
+and the translate step posted every document to a neighbour's Solr, where the
+core did not exist, the posts 404'd, and 5,968 translations were lost with
+nothing said. Gloss reported that neighbour's health as its own.
+
+So: a port may be a default, and it may be read from the environment, but it
+may not be the way a component names a service.
+"""
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+BIN = REPO / "distribution" / "src" / "main" / "resources" / "bin"
+GLOSS = REPO / "webapps" / "gloss-services" / "src" / "main" / "java"
+WORKFLOW_POLICY = REPO / "workflow" / "src" / "main" / "resources" / "policy"
+
+SHARED_PORTS = ("9000", "9001", "9002", "8080", "8983")
+
+
+def _addressing_lines(text):
+    """Lines that use a shared port to address something, not to default one.
+
+    `FILEMGR_PORT=${FILEMGR_PORT:-9000}` names a default and is fine; the
+    environment can still move it. `http://localhost:9000` is an address, and
+    is not.
+    """
+    out = []
+    for number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith("*"):
+            continue
+        for port in SHARED_PORTS:
+            if re.search(r"(localhost|127\.0\.0\.1|\$\{OODT_HOST\}):%s\b" % port, line):
+                out.append((number, stripped))
+                break
+            if re.search(r"check_port\s+%s\b" % port, line):
+                out.append((number, stripped))
+                break
+            if re.search(r'portOpen\([^)]*,\s*%s\s*\)' % port, line):
+                out.append((number, stripped))
+                break
+    return out
+
+
+def test_the_driver_script_does_not_address_services_by_a_written_in_port():
+    offenders = _addressing_lines((BIN / "bigtranslate").read_text())
+    assert offenders == [], (
+        "bin/bigtranslate addresses a service by a written-in port:\n  "
+        + "\n  ".join("%d: %s" % o for o in offenders))
+
+
+def test_the_driver_script_reads_the_deployment_settings():
+    text = (BIN / "bigtranslate").read_text()
+    assert "setenv.sh" in text, (
+        "bin/bigtranslate never reads setenv.sh, so a deployment moved onto "
+        "its own ports has a driver script still talking to the defaults")
+
+
+def test_gloss_does_not_probe_written_in_ports():
+    offenders = []
+    for java in GLOSS.rglob("*.java"):
+        for number, line in _addressing_lines(java.read_text()):
+            offenders.append((java.name, number, line))
+    assert offenders == [], (
+        "Gloss addresses a service by a written-in port:\n  "
+        + "\n  ".join("%s:%d: %s" % o for o in offenders))
+
+
+def test_the_translate_task_posts_where_the_deployment_says():
+    text = (WORKFLOW_POLICY / "tasks.xml").read_text()
+    assert "[SOLR_URL]" in text, (
+        "tasks.xml does not take SolrUrl from the environment")
+    assert 'value="http://localhost:8983' not in text, (
+        "tasks.xml still posts to a written-in Solr port")
+
+
+def test_oodt_can_restart():
+    """The README has told people to run this for longer than it has existed.
+
+    It fell through to the usage branch, so a configuration change made just
+    before it looked as though it had been picked up while the services were
+    still running with the old one.
+    """
+    text = (BIN / "oodt").read_text()
+    assert '"$1" = "restart"' in text, "bin/oodt has no restart"
+
+
+def test_stop_waits_for_the_ports_to_be_free():
+    """Returning early is how a stop-then-start leaves nothing running.
+
+    Solr still held its port when the following start ran, which failed with
+    "Port ... is already being used" and left the deployment down.
+    """
+    text = (BIN / "oodt").read_text()
+    assert "wait_for_stopped" in text, "bin/oodt does not wait for its ports"
+    assert "wait_for_started" in text, "bin/oodt does not wait for its services"
+
+
+def test_setup_installs_the_translation_service():
+    """Without fastapi and uvicorn, `pantogloss serve` is a subcommand that
+    exits with "No module named 'uvicorn'" the first time it is used."""
+    text = (BIN / "bigtranslate-setup").read_text()
+    assert "uvicorn" in text, (
+        "bigtranslate-setup installs Pantogloss without its server extra")

--- a/tests/test_translate_service.py
+++ b/tests/test_translate_service.py
@@ -1,0 +1,174 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Translation goes through the service, and says so when it cannot.
+
+The PGE ran once per split and loaded the model each time -- about thirty
+seconds, forty-nine times over a ten-file baseline, loading the same model
+again every time. It now asks a running "pantogloss serve" instead.
+
+There is deliberately no fallback to loading the model in-process. A fallback
+would be invisible: the run would take the time it always did and nobody would
+learn the service was never reached. So the interesting cases here are the
+failures, and that each one says something different and useful.
+"""
+import http.server
+import json
+import threading
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+PGE = REPO / "distribution" / "src" / "main" / "resources" / "bin" / "pantogloss-translatejson"
+
+
+def _load():
+    spec = importlib.util.spec_from_loader(
+        "translatejson", loader=None, origin=str(PGE))
+    module = importlib.util.module_from_spec(spec)
+    exec(compile(PGE.read_text(), str(PGE), "exec"), module.__dict__)
+    return module
+
+
+tj = _load()
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    health = {"status": "ok", "model_status": "ready", "ready": True}
+    translation = None
+
+    def log_message(self, *args):
+        pass
+
+    def _send(self, code, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._send(200, type(self).health)
+        else:
+            self._send(404, {"error": "not found"})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        asked = json.loads(self.rfile.read(length))
+        texts = asked["text"]
+        if type(self).translation is not None:
+            self._send(200, {"translation": type(self).translation})
+            return
+        self._send(200, {"translation": ["EN:" + t for t in texts],
+                         "count": len(texts)})
+
+
+class _NotPantogloss(http.server.BaseHTTPRequestHandler):
+    """What a plain `python3 -m http.server` does: a cheerful 404."""
+
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+@pytest.fixture
+def server():
+    made = []
+
+    def start(handler):
+        httpd = http.server.HTTPServer(("127.0.0.1", 0), handler)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        made.append(httpd)
+        return "http://127.0.0.1:%d" % httpd.server_address[1]
+
+    yield start
+    for httpd in made:
+        httpd.shutdown()
+
+
+def test_a_ready_service_is_accepted(server):
+    url = server(_Handler)
+    health = tj.check_service(url, timeout=5)
+    assert health["ready"] is True
+
+
+def test_nothing_listening_says_how_to_start_one():
+    with pytest.raises(tj.ServiceUnavailable) as raised:
+        tj.check_service("http://127.0.0.1:9", timeout=2)
+    said = str(raised.value)
+    assert "no translation service" in said
+    assert "pantogloss serve" in said, "does not say how to fix it"
+
+
+def test_something_else_on_the_port_is_not_reported_as_unreachable(server):
+    """The failure that actually happened.
+
+    Pantogloss's default port is an ordinary one, and a plain
+    `python3 -m http.server` was sitting on it. That is a successful HTTP
+    response, not a connection failure, and calling it "unreachable" sends
+    the reader looking for the wrong thing entirely.
+    """
+    url = server(_NotPantogloss)
+    with pytest.raises(tj.ServiceUnavailable) as raised:
+        tj.check_service(url, timeout=5)
+    said = str(raised.value)
+    assert "not Pantogloss" in said, said
+    assert "what is on that port" in said, said
+
+
+def test_a_service_still_loading_says_to_wait(server):
+    class Loading(_Handler):
+        health = {"status": "ok", "model_status": "loading", "ready": False}
+
+    url = server(Loading)
+    with pytest.raises(tj.ServiceUnavailable) as raised:
+        tj.check_service(url, timeout=5)
+    said = str(raised.value)
+    assert "not ready" in said
+    assert "loading" in said
+
+
+def test_a_batch_comes_back_in_the_order_it_was_sent(server):
+    url = server(_Handler)
+    out = tj.translate_batch(url, ["uno", "dos", "tres"], 1, 50, 10)
+    assert out == ["EN:uno", "EN:dos", "EN:tres"]
+
+
+def test_a_short_answer_is_refused_rather_than_misaligned(server):
+    """Zipping a short reply against the batch would silently mislabel every
+    translation after the gap, which is worse than failing."""
+    class Short(_Handler):
+        translation = ["only one"]
+
+    url = server(Short)
+    with pytest.raises(tj.ServiceUnavailable) as raised:
+        tj.translate_batch(url, ["uno", "dos", "tres"], 1, 50, 10)
+    assert "refusing to guess" in str(raised.value)
+
+
+def test_the_model_is_not_loaded_in_this_process():
+    """The whole point: no in-process load, and no quiet fallback to one."""
+    source = PGE.read_text()
+    assert "Translator.from_pretrained" not in source, (
+        "the PGE still loads the model itself")
+    assert "DEFAULT_SERVICE_URL" in source

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/FileConstants.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/FileConstants.java
@@ -98,20 +98,65 @@ public final class FileConstants {
   public static String filemgrUrl() {
     String url = firstNonEmpty(System.getenv("FILEMGR_URL"),
         System.getProperty("FILEMGR_URL"));
-    return url == null ? "http://localhost:9000" : url;
+    return url == null ? "http://localhost:" + filemgrPort() : url;
   }
 
   public static String solrCoreUrl() {
     String url = firstNonEmpty(System.getenv("SOLR_URL"),
         System.getProperty("SOLR_URL"));
-    return url == null ? "http://localhost:8983/solr/bigtranslate" : url;
+    return url == null ? "http://localhost:" + solrPort() + "/solr/bigtranslate" : url;
+  }
+
+  /**
+   * A port a service listens on, from the environment, falling back to the
+   * default this project has always used.
+   *
+   * <p>
+   * The defaults are shared with DRAT and with any stock RADiX deployment, so
+   * on a machine running more than one of them they belong to whichever
+   * started first. Reading them from the environment is what lets a
+   * deployment be moved out of the way; it is set in bin/setenv.sh, which is
+   * also what the services themselves are started with.
+   * </p>
+   */
+  static int portFor(String name, int fallback) {
+    String value = firstNonEmpty(System.getenv(name), System.getProperty(name));
+    if (value == null) {
+      return fallback;
+    }
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      return fallback;
+    }
+  }
+
+  public static int filemgrPort() {
+    return portFor("FILEMGR_PORT", 9000);
+  }
+
+  public static int workflowPort() {
+    return portFor("WORKFLOW_PORT", 9001);
+  }
+
+  public static int resmgrPort() {
+    return portFor("RESMGR_PORT", 9002);
+  }
+
+  public static int tomcatPort() {
+    return portFor("TOMCAT_PORT", 8080);
+  }
+
+  public static int solrPort() {
+    return portFor("SOLR_PORT", 8983);
   }
 
   public static String solrBaseUrl() {
     String core = solrCoreUrl();
     int slash = core.lastIndexOf('/');
-    if (slash <= "http://localhost:8983/solr".length()) {
-      return "http://localhost:8983/solr";
+    String fallbackBase = "http://localhost:" + solrPort() + "/solr";
+    if (slash <= fallbackBase.length()) {
+      return fallbackBase;
     }
     // core url is .../solr/bigtranslate -> .../solr
     int solr = core.lastIndexOf("/solr");

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
@@ -344,9 +344,20 @@ public class ProcessBtWrapper {
     }
   }
 
+  /**
+   * The tail of whichever log this run is writing.
+   *
+   * <p>
+   * Gloss keeps a log of what it did itself, and reads it here. A run started
+   * from the command line writes to the deployment's own log instead, so this
+   * returned nothing for the whole of every real run and the page sat on
+   * "Waiting for log..." -- waiting for a file that was never going to be
+   * written. Prefer the one with something in it, most recent first.
+   * </p>
+   */
   public static String readLogTail(int maxBytes) {
-    File log = new File(FileConstants.logFile());
-    if (!log.exists()) {
+    File log = mostRecentLog();
+    if (log == null || !log.exists()) {
       return "";
     }
     try {
@@ -358,6 +369,22 @@ public class ProcessBtWrapper {
     } catch (IOException e) {
       return e.getLocalizedMessage();
     }
+  }
+
+  /** Whichever of the two logs was written to last, or null if neither was. */
+  static File mostRecentLog() {
+    File[] candidates = {
+        new File(FileConstants.logFile()),
+        new File(FileConstants.path("/logs/bigtranslate.log"))
+    };
+    File best = null;
+    for (File candidate : candidates) {
+      if (candidate.exists() && candidate.length() > 0
+          && (best == null || candidate.lastModified() > best.lastModified())) {
+        best = candidate;
+      }
+    }
+    return best;
   }
 
   public static long countJobDirs() {

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
@@ -78,14 +78,46 @@ public class ProcessBtWrapper {
   ProcessBtWrapper() {
   }
 
+  /**
+   * What is happening, from where it is written down before this process's
+   * own memory.
+   *
+   * <p>
+   * A translation is normally started from the command line, and this web
+   * application had no way of knowing that: the fields below are set only
+   * when a run is started through Gloss, so Gloss reported IDLE throughout
+   * somebody else's run. The marker is written by whichever side starts one.
+   * </p>
+   */
   public synchronized Map<String, Object> snapshot() {
     Map<String, Object> snap = new LinkedHashMap<String, Object>();
+
+    Map<String, Object> recorded = RunMarker.read();
+    if (recorded != null && !TRANSLATING.equals(status)
+        && !RESETTING.equals(status)) {
+      // Something is running and it was not started here.
+      snap.put("status", asText(recorded.get("status"), TRANSLATING));
+      snap.put("path", asText(recorded.get("path"), ""));
+      snap.put("exclude", asText(recorded.get("exclude"), ""));
+      snap.put("message", "started from the command line");
+      snap.put("startedAt", recorded.get("startedAt"));
+      return snap;
+    }
+
     snap.put("status", status);
     snap.put("path", path);
     snap.put("exclude", exclude);
     snap.put("message", message);
     snap.put("startedAt", startedAt == 0 ? null : Long.valueOf(startedAt));
     return snap;
+  }
+
+  private static String asText(Object value, String fallback) {
+    if (value == null) {
+      return fallback;
+    }
+    String text = String.valueOf(value);
+    return text.isEmpty() ? fallback : text;
   }
 
   public synchronized String getStatus() {
@@ -111,6 +143,9 @@ public class ProcessBtWrapper {
     this.path = productPath.trim();
     this.exclude = excludePattern == null ? "" : excludePattern.trim();
     this.status = TRANSLATING;
+    // Written down as well as held, so a reader that is not this process --
+    // another browser, a restarted Tomcat -- can still see the run.
+    RunMarker.write(TRANSLATING, "gloss", productPath, excludePattern);
     this.message = "";
     this.startedAt = System.currentTimeMillis();
     final List<String> command = buildTranslateCommand(
@@ -125,9 +160,11 @@ public class ProcessBtWrapper {
           synchronized (ProcessBtWrapper.this) {
             if (code == 0) {
               status = IDLE;
+              RunMarker.clear();
               message = "translate finished";
             } else {
               status = ERROR;
+              RunMarker.clear();
               message = "translate exited " + code;
             }
           }
@@ -135,6 +172,7 @@ public class ProcessBtWrapper {
         } catch (Exception e) {
           synchronized (ProcessBtWrapper.this) {
             status = ERROR;
+            RunMarker.clear();
             message = e.getLocalizedMessage();
           }
           appendLog("ERROR translate " + e.getLocalizedMessage());
@@ -150,18 +188,21 @@ public class ProcessBtWrapper {
       throw new IOException("A run is already " + status);
     }
     status = RESETTING;
+    RunMarker.write(RESETTING, "gloss", "", "");
     message = "";
     startedAt = System.currentTimeMillis();
     try {
       appendLog("START reset");
       liveReset();
       status = IDLE;
+      RunMarker.clear();
       message = "reset finished";
       path = "";
       exclude = "";
       appendLog("END reset");
     } catch (IOException e) {
       status = ERROR;
+      RunMarker.clear();
       message = e.getLocalizedMessage();
       appendLog("ERROR reset " + e.getLocalizedMessage());
       throw e;

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/RunMarker.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/RunMarker.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bigtranslate.gloss;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * What is running, written down where anything can read it.
+ *
+ * <p>
+ * Gloss used to keep this in a field of the web application, set when a run
+ * was started through Gloss and by nothing else. A translation started from
+ * the command line -- which is how runs are started -- therefore left Gloss
+ * reporting IDLE for its entire duration, with no repository, no start time
+ * and no way to tell a busy deployment from an idle one. The fact lived in
+ * the heap of whichever process you were not looking at.
+ * </p>
+ *
+ * <p>
+ * A file in the deployment outlives both, so the side that did not start the
+ * run can still describe it, and a Tomcat restarted mid-run does not lose it.
+ * </p>
+ */
+public final class RunMarker {
+
+  private static final Logger LOG = Logger.getLogger(RunMarker.class.getName());
+
+  private RunMarker() {
+  }
+
+  static String markerPath() {
+    return FileConstants.path("/data/run");
+  }
+
+  /** Record that something is running. */
+  public static synchronized void write(String status, String startedBy,
+      String path, String exclude) {
+    File marker = new File(markerPath());
+    File parent = marker.getParentFile();
+    if (parent != null && !parent.exists() && !parent.mkdirs()) {
+      LOG.log(Level.WARNING, "Unable to create " + parent
+          + "; the running translation will not be recorded");
+      return;
+    }
+
+    StringBuilder json = new StringBuilder();
+    json.append('{');
+    field(json, "status", status, true);
+    field(json, "startedBy", startedBy, false);
+    field(json, "path", path, false);
+    field(json, "exclude", exclude, false);
+    json.append(",\"startedAt\":").append(System.currentTimeMillis());
+    json.append('}');
+
+    FileWriter writer = null;
+    try {
+      writer = new FileWriter(marker);
+      writer.write(json.toString());
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Unable to record the running translation: "
+          + e.getMessage());
+    } finally {
+      if (writer != null) {
+        try {
+          writer.close();
+        } catch (Exception ignored) {
+          // Nothing useful to do about a failed close of a marker file.
+        }
+      }
+    }
+  }
+
+  /** Record that nothing is running. */
+  public static synchronized void clear() {
+    File marker = new File(markerPath());
+    if (marker.exists() && !marker.delete()) {
+      LOG.log(Level.WARNING, "Unable to remove " + marker
+          + "; Gloss will go on reporting a run that has ended");
+    }
+  }
+
+  /** Whether a run is recorded. Existence is the durable fact. */
+  public static synchronized boolean isRecorded() {
+    return new File(markerPath()).exists();
+  }
+
+  /**
+   * The recorded run, or null when there is none.
+   *
+   * <p>
+   * Parsed by hand rather than with a JSON library: this module has none on
+   * its compile path, and the file is written by {@link #write} and by
+   * bin/bigtranslate, both of which produce flat string fields.
+   * </p>
+   */
+  public static synchronized Map<String, Object> read() {
+    File marker = new File(markerPath());
+    if (!marker.exists()) {
+      return null;
+    }
+    String body;
+    try {
+      body = new String(Files.readAllBytes(Paths.get(marker.getPath())),
+          StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      // Unreadable is not the same as absent: a marker caught mid-write says
+      // nothing about whether a run is happening, and reporting IDLE on that
+      // basis is the bug this class exists to prevent.
+      LOG.log(Level.WARNING, "Unable to read the run marker: " + e.getMessage());
+      return null;
+    }
+
+    Map<String, Object> run = new LinkedHashMap<String, Object>();
+    for (String name : new String[] {"status", "startedBy", "path", "exclude"}) {
+      String value = stringField(body, name);
+      if (value != null) {
+        run.put(name, value);
+      }
+    }
+    Long startedAt = longField(body, "startedAt");
+    if (startedAt != null) {
+      run.put("startedAt", startedAt);
+    }
+    return run.isEmpty() ? null : run;
+  }
+
+  private static void field(StringBuilder json, String name, String value,
+      boolean first) {
+    if (!first) {
+      json.append(',');
+    }
+    json.append('"').append(name).append("\":\"")
+        .append(escape(value == null ? "" : value)).append('"');
+  }
+
+  private static String escape(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"")
+        .replace("\n", " ").replace("\r", " ");
+  }
+
+  private static String stringField(String body, String name) {
+    String key = "\"" + name + "\"";
+    int at = body.indexOf(key);
+    if (at < 0) {
+      return null;
+    }
+    int colon = body.indexOf(':', at + key.length());
+    if (colon < 0) {
+      return null;
+    }
+    int open = body.indexOf('"', colon);
+    if (open < 0) {
+      return null;
+    }
+    StringBuilder value = new StringBuilder();
+    for (int i = open + 1; i < body.length(); i++) {
+      char c = body.charAt(i);
+      if (c == '\\' && i + 1 < body.length()) {
+        value.append(body.charAt(++i));
+      } else if (c == '"') {
+        return value.toString();
+      } else {
+        value.append(c);
+      }
+    }
+    return null;
+  }
+
+  private static Long longField(String body, String name) {
+    String key = "\"" + name + "\"";
+    int at = body.indexOf(key);
+    if (at < 0) {
+      return null;
+    }
+    int colon = body.indexOf(':', at + key.length());
+    if (colon < 0) {
+      return null;
+    }
+    StringBuilder digits = new StringBuilder();
+    for (int i = colon + 1; i < body.length(); i++) {
+      char c = body.charAt(i);
+      if (Character.isDigit(c)) {
+        digits.append(c);
+      } else if (digits.length() > 0) {
+        break;
+      }
+    }
+    try {
+      return digits.length() == 0 ? null : Long.valueOf(digits.toString());
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/rest/ServicesRestResource.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/rest/ServicesRestResource.java
@@ -54,11 +54,16 @@ public class ServicesRestResource {
   @Path("/status/oodt")
   public Map<String, Object> oodtStatus() {
     Map<String, Object> status = new LinkedHashMap<String, Object>();
-    boolean fm = SolrSupport.portOpen("localhost", 9000);
-    boolean wm = SolrSupport.portOpen("localhost", 9001);
-    boolean rm = SolrSupport.portOpen("localhost", 9002);
-    boolean tomcat = SolrSupport.portOpen("localhost", 8080);
-    boolean solr = SolrSupport.portOpen("localhost", 8983);
+    // The ports this deployment was actually started on. These were the
+    // defaults, written in: on a machine running a second OODT stack they are
+    // somebody else's, so the panel reported a neighbour's services as this
+    // deployment's -- green when BigTranslate was down, and red when it was
+    // up on ports of its own.
+    boolean fm = SolrSupport.portOpen("localhost", FileConstants.filemgrPort());
+    boolean wm = SolrSupport.portOpen("localhost", FileConstants.workflowPort());
+    boolean rm = SolrSupport.portOpen("localhost", FileConstants.resmgrPort());
+    boolean tomcat = SolrSupport.portOpen("localhost", FileConstants.tomcatPort());
+    boolean solr = SolrSupport.portOpen("localhost", FileConstants.solrPort());
     status.put("fm", Boolean.valueOf(fm));
     status.put("wm", Boolean.valueOf(wm));
     status.put("rm", Boolean.valueOf(rm));

--- a/webapps/gloss/src/main/webapp/resources/src/components/ProgressPane.vue
+++ b/webapps/gloss/src/main/webapp/resources/src/components/ProgressPane.vue
@@ -4,12 +4,28 @@
       <h2>In progress</h2>
       <p>
         {{ progress.status || 'TRANSLATING' }}
+        <!-- Who started it. A run begun from the command line is the ordinary
+             case, and the back end says so; the panel used to drop that on the
+             floor, leaving no way to tell it from one started here. -->
+        <span v-if="progress.message" class="whose"> ({{ progress.message }})</span>
         <span v-if="progress.path"> · {{ progress.path }}</span>
         <span v-if="progress.solrDocs != null"> · {{ progress.solrDocs }} in Solr</span>
         <span v-if="progress.jobDirs != null"> · {{ progress.jobDirs }} job dirs</span>
       </p>
     </header>
-    <pre>{{ log || 'Waiting for log…' }}</pre>
+    <!--
+      A run started from the command line writes to the deployment's own log,
+      not to the one Gloss keeps of what it did itself, so this waited for a
+      log that was never going to arrive and said "Waiting for log…" for the
+      length of the run. The back end now hands over whichever log the run is
+      actually writing; when there genuinely is not one yet, say that rather
+      than implying something is stuck.
+    -->
+    <pre v-if="log">{{ log }}</pre>
+    <p v-else class="nolog">
+      No log output yet. The workflow manager is running this; its progress
+      shows above and in OPSUI.
+    </p>
   </section>
 </template>
 
@@ -30,6 +46,18 @@ export default {
   border-radius: 4px;
   margin: 0.5rem 0 1rem;
   overflow: hidden;
+}
+
+.whose {
+  opacity: 0.75;
+  font-style: italic;
+}
+
+.nolog {
+  margin: 0;
+  padding: 0.8rem 1rem 1rem;
+  opacity: 0.7;
+  font-size: 0.85rem;
 }
 
 header {

--- a/webapps/gloss/src/main/webapp/resources/src/style.css
+++ b/webapps/gloss/src/main/webapp/resources/src/style.css
@@ -91,11 +91,28 @@ input[type="text"]:focus {
 .pill.error { background: #f7dede; color: var(--bad); }
 
 .dot {
-  width: 0.55rem;
-  height: 0.55rem;
+  /*
+   * Bigger, and outlined. A 0.55rem dot in a mid green on this cream ground
+   * is about the least visible thing on the page: the eye has to hunt for
+   * the one control that says whether the system is up. The ring gives it an
+   * edge whatever it sits on, and the two states now differ in more than
+   * hue, so it reads without relying on colour vision.
+   */
+  width: 0.72rem;
+  height: 0.72rem;
   border-radius: 50%;
   display: inline-block;
+  vertical-align: -0.05rem;
+  margin-right: 0.15rem;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
 }
 
-.dot.on { background: var(--good); }
-.dot.off { background: #c4b8a6; }
+.dot.on {
+  background: #1f9d4d;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.45), 0 0 0 3px rgba(31, 157, 77, 0.22);
+}
+
+.dot.off {
+  background: #b9ab97;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
+}

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -78,7 +78,13 @@
 	  <property name="TranslateCachePath" value="[BIGTRANSLATE_HOME]/data/translationcache/cache.sqlite" envReplace="true"/>
           <property name="TranslateGlossary" value="[BIGTRANSLATE_HOME]/conf/glossary.es-en.tsv" envReplace="true"/>
           <property name="TranslateBatchSize" value="32"/>
-          <property name="SolrUrl" value="http://localhost:8983/solr/bigtranslate/update/json?commit=true"/>
+          <!-- Env replaced like everything around it. Written in, this sent every
+               run's output to whatever owns 8983, which on a machine running a
+               second OODT stack is that stack's Solr: the posts 404 against a
+               core that is not there and the translations are lost with nothing
+               reported. SOLR_URL is the core url, so the update handler hangs
+               off it. -->
+          <property name="SolrUrl" value="[SOLR_URL]/update/json?commit=true" envReplace="true"/>
           <requiredMetFields>
             <metfield name="Filename"/>
           </requiredMetFields>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -78,6 +78,13 @@
 	  <property name="TranslateCachePath" value="[BIGTRANSLATE_HOME]/data/translationcache/cache.sqlite" envReplace="true"/>
           <property name="TranslateGlossary" value="[BIGTRANSLATE_HOME]/conf/glossary.es-en.tsv" envReplace="true"/>
           <property name="TranslateBatchSize" value="32"/>
+          <!-- Passed rather than inherited. The PGE would read PANTOGLOSS_URL
+               from its environment, but that environment is the workflow
+               manager's, which is one more thing that has to have been right
+               when the services were started. Named here it is visible in the
+               job's own metadata, where a run that went to the wrong place
+               can be seen to have done so. -->
+          <property name="PantoglossUrl" value="[PANTOGLOSS_URL]" envReplace="true"/>
           <!-- Env replaced like everything around it. Written in, this sent every
                run's output to whatever owns 8983, which on a machine running a
                second OODT stack is that stack's Solr: the posts 404 against a


### PR DESCRIPTION
Everything here came out of a clean install and a baseline run of the 10
test TSVs, on a machine already running DRAT and an ImageCat stack.

### The headline: BigTranslate assumed it owned the machine

Its defaults — **9000, 9001, 9002, 8080, 8983** — are the ones DRAT and any
stock RADiX deployment also use. Two stacks on one machine do not fail
loudly: the second one's clients reach the first one's services.

Run against a deployment moved onto its own ports, this happened:

- `bin/bigtranslate` checked a **neighbour's** ports and reported the
  services up
- the translate step posted **5,968 documents** to a neighbour's Solr,
  where the `bigtranslate` core does not exist, so every post 404'd and
  the translations were lost **with nothing reported**
- Gloss showed that neighbour's health as this deployment's — which is
  worse than showing nothing, because with the neighbour up it reads
  green while BigTranslate is down

Three separate places had ports written in: the driver script (4 URLs and
both port checks), `workflow/policy/tasks.xml` (`SolrUrl`), and Gloss
(`FileConstants` defaults plus five literal `portOpen` probes).

Ports are now the setting; URLs derive from them. The driver script reads
`setenv.sh` — the same file the services are started with — instead of
carrying its own copies.

### `bin/oodt` has never had a `restart`

The README has instructed `bin/oodt restart` for longer than the command
has existed. It fell through to the usage branch, quietly enough that a
config change made just beforehand **looked** applied while the services
were still running the old one. That is exactly how the 8983 posting
survived a "restart" during testing.

### `stop` did not wait

It returned once it had *asked* each service to stop. A `start` right
after found Solr still holding its port, failed with `Port ... is already
being used`, and left the deployment with **nothing running**. `stop` now
waits for the ports to go (180s), `start` waits for them to answer (120s).

### Gloss reported IDLE through every real translation

`ProcessBtWrapper` kept status in a field of the web application, set only
when a run started *through Gloss* — and runs start from the command line.
Same bug, same shape, as Proteus before DRAT#249. Both sides now write a
marker in the deployment, so the side that did not start the run can still
describe it, and a Tomcat restarted mid-run does not lose it.

### `pantogloss serve` was not installable

`bigtranslate-setup` installed Pantogloss without its `[server]` extra, so
`serve` existed as a subcommand and died with `No module named 'uvicorn'`
the first time it ran. It installs the extra now and *says* whether the
service is available, rather than leaving it to be found at run time.

### Tests

**231 passing.** `tests/test_port_isolation.py` is 7 new ones stated as a
rule rather than a port list: a port may be a *default*
(`${FILEMGR_PORT:-9000}`) or read from the environment, but may not be how
a component **addresses** a service. All 7 fail against the pre-fix source.

**One existing test changed, and it is worth a look.**
`test_cli_translate_still_exists_alongside_gloss` asserted the literal
string `8080/gloss` — it pinned the hardcoding in place. I kept its intent
(the CLI still points people at Gloss) and made it assert
`${TOMCAT_PORT}/gloss/`. Rewriting a test to match new behaviour is how a
real regression slips through, so I would rather it be reviewed than
assumed.

### Baseline this was measured against

A full cold run of the 10 TSVs after these fixes: **2,544s, 43,851
documents, 63 instances all FINISHED, 49 model loads**. Document count
matches the input rows exactly, per file, all 11 files.

### Not in this PR

The PGE rewrite onto `pantogloss serve` — those 49 model loads at ~29s
each are the next thing to remove.