### PR TITLE
Require a Pantogloss new enough to serve safely

### DIFF
--- a/distribution/src/main/resources/bin/bigtranslate-setup
+++ b/distribution/src/main/resources/bin/bigtranslate-setup
@@ -86,6 +86,18 @@ echo "Installing from $REQUIREMENTS"
 #
 # Point PANTOGLOSS_SOURCE at a checkout, a wheel, or any pip specifier:
 #   PANTOGLOSS_SOURCE=~/git/pantogloss bin/bigtranslate-setup
+#
+# The version matters, so it is checked after installing rather than asked
+# for in the specifier: Pantogloss is not published, so PANTOGLOSS_SOURCE is
+# usually a working checkout and pip has no version to resolve against. What
+# it lands on is whatever that checkout is on, which is worth knowing.
+#
+# 0.18.0 is the floor. It defaults the server to one inference slot, which is
+# the only safe setting on Apple silicon: eight concurrent translate() calls
+# share one Keras model and one Metal execution context, and MPSGraph aborts
+# the process on the mismatched shapes. It also fixes the server's queue
+# timeouts on Python 3.10.
+PANTOGLOSS_REQUIRED=${PANTOGLOSS_REQUIRED:-0.18.0}
 if [ -n "$PANTOGLOSS_SOURCE" ]; then
     echo
     echo "Installing Pantogloss from $PANTOGLOSS_SOURCE"
@@ -129,8 +141,32 @@ for tool in tsvtojson repackage poster; do
     fi
 done
 if "$VENV/bin/python" -c "import pantogloss" > /dev/null 2>&1; then
-    echo "  pantogloss"
     # Said here rather than left to fail at run time.
+    installed=$("$VENV/bin/python" -c \
+        "import importlib.metadata as m; print(m.version('pantogloss'))" 2>/dev/null)
+    if [ -n "$installed" ]; then
+        if "$VENV/bin/python" - "$installed" "$PANTOGLOSS_REQUIRED" <<'VERSION'
+import sys
+def parts(v):
+    out = []
+    for piece in v.split(".")[:3]:
+        digits = "".join(c for c in piece if c.isdigit())
+        out.append(int(digits) if digits else 0)
+    while len(out) < 3:
+        out.append(0)
+    return tuple(out)
+sys.exit(0 if parts(sys.argv[1]) >= parts(sys.argv[2]) else 1)
+VERSION
+        then
+            echo "  pantogloss $installed"
+        else
+            echo "  pantogloss $installed  TOO OLD, wanted $PANTOGLOSS_REQUIRED or"
+            echo "                    later. Older servers default to more than one"
+            echo "                    inference slot, which aborts the process on"
+            echo "                    Apple silicon. Check out v$PANTOGLOSS_REQUIRED or"
+            echo "                    later in \$PANTOGLOSS_SOURCE and run this again."
+        fi
+    fi
     if "$VENV/bin/python" -c "import uvicorn, fastapi" > /dev/null 2>&1; then
         echo "  pantogloss serve  (the translation service)"
     else

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,9 @@
 # etllib. Translation is pantogloss-translatejson, so the [translate] extra
 # (hirlite) is not required.
 etllib @ git+https://github.com/chrismattmann/etllib.git
+
+# Pantogloss is not listed here because it is not published: bigtranslate-setup
+# installs it from PANTOGLOSS_SOURCE, with the [server] extra and, on a machine
+# with a GPU, [metal] or [cuda]. It must be 0.18.0 or later; the setup script
+# checks what it landed on and says so if it is older. Earlier servers default
+# to more than one inference slot, which aborts the process on Apple silicon.

--- a/tests/test_translate_service.py
+++ b/tests/test_translate_service.py
@@ -172,3 +172,29 @@ def test_the_model_is_not_loaded_in_this_process():
     assert "Translator.from_pretrained" not in source, (
         "the PGE still loads the model itself")
     assert "DEFAULT_SERVICE_URL" in source
+
+
+def test_setup_requires_a_pantogloss_new_enough_to_be_safe():
+    """0.18.0 defaults the server to one inference slot.
+
+    Earlier ones default to more, and more than one is what aborts the process
+    on Apple silicon: concurrent translate() calls share a Keras model and a
+    Metal execution context, and MPSGraph asserts on the mismatched shapes.
+    Pantogloss is not published, so PANTOGLOSS_SOURCE is usually a working
+    checkout and pip has no version to resolve against; what it lands on is
+    whatever that checkout is on, which is why this is checked afterwards
+    rather than asked for in the specifier.
+    """
+    setup = (REPO / "distribution" / "src" / "main" / "resources"
+             / "bin" / "bigtranslate-setup").read_text()
+    assert "PANTOGLOSS_REQUIRED" in setup, "no version floor is declared"
+    assert "0.18.0" in setup, "the floor is not 0.18.0"
+    assert "importlib.metadata" in setup, (
+        "the installed version is never read, so the floor is not enforced")
+    assert "TOO OLD" in setup, "an older Pantogloss is installed silently"
+
+
+def test_the_floor_can_be_overridden():
+    setup = (REPO / "distribution" / "src" / "main" / "resources"
+             / "bin" / "bigtranslate-setup").read_text()
+    assert "${PANTOGLOSS_REQUIRED:-0.18.0}" in setup


### PR DESCRIPTION
The deployment was running **0.17.0** while the code assumed the server
would hold itself to one inference slot. It does not — that default
arrived in **0.18.0**.

On 0.17.0 the service starts with eight slots, and eight concurrent
`translate()` calls share one Keras model and one Metal execution
context:

```
MPSGraph.mm:1136: failed assertion
  `Placeholder shape mismatches (expected 2 vs got tensorData with 3) at dimIdx = 3'
```

That is an assertion inside Apple's framework, so it aborts the process:
the service dies mid-run and every PGE after it fails. 0.18.0 also fixes
the server's queue timeouts on Python 3.10.

### Checked, not specified

Pantogloss is not published, so `PANTOGLOSS_SOURCE` is normally a working
checkout and pip has no version to resolve against — whatever that
checkout is on is what you get. So `bigtranslate-setup` reads the
installed version afterwards and reports it:

```
  pantogloss 0.18.0
  pantogloss serve  (the translation service)
  GPU               1 visible to TensorFlow
```

and when it is older:

```
  pantogloss 0.17.0  TOO OLD, wanted 0.18.0 or
                    later. Older servers default to more than one
                    inference slot, which aborts the process on
                    Apple silicon.
```

That is the moment somebody can still act on it, rather than finding out
from a run that dies partway through — which is how we found it.

`PANTOGLOSS_REQUIRED` overrides the floor for anyone deliberately testing
against something else.

### Tests

**255 passing**, two new. Both fail against the unpinned script. The
version comparison was checked directly: `0.17.0` and `0.9.0` rejected,
`0.18.0`, `0.18.1`, `0.19.0` and `1.0.0` accepted.