### PR TITLE
Give the translation service one Metal slot, and let a fresh unpack start

### DIFF
--- a/distribution/src/main/resources/bin/bigtranslate
+++ b/distribution/src/main/resources/bin/bigtranslate
@@ -93,6 +93,19 @@ OPSUI_URL=http://${OODT_HOST}:${TOMCAT_PORT}/opsui
 # --exclude file/directory name.
 
 
+
+# Say what is happening, to the terminal and to the log Gloss reads.
+#
+# That log held nothing but the directory-stack echoes of pushd and popd --
+# "~/bt-w1/crawler/bin ~/bt-w1" -- because those were the only things ever
+# redirected into it. Gloss shows the tail of it under "In progress", so a
+# reader watching a forty minute run saw two lines of shell bookkeeping and
+# nothing about the run at all.
+say() {
+    printf '%s %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" \
+        | tee -a "$BIGTRANSLATE_HOME/logs/bigtranslate.log"
+}
+
 # Record what is running, where the other half can read it.
 #
 # Gloss kept this in a field of the web application, set only when a run was
@@ -184,7 +197,69 @@ validate_corpus_path() {
         exit 1
     fi
     echo "Translating $count TSV file(s) from $CORPUS_PATH"
+    CORPUS_FILE_COUNT="$count"
 }
+
+
+# Wait for the workflow to finish, then say the run is over.
+#
+# The crawl is quick; the translating is not, and it happens in the workflow
+# manager after this script's crawl returns. Marking the run and walking away
+# left the marker behind for ever: every instance finished, and Gloss went on
+# reporting TRANSLATING because the only thing that could have said otherwise
+# had exited. Nothing else is watching, so this waits.
+#
+# Counted from the workflow manager rather than from a timer: a run is over
+# when its instances are, and how long that takes is the thing we do not know.
+wait_for_workflow() {
+    local waited=0
+    local quiet=0
+    local running
+
+    while [ "$waited" -lt "$TRANSLATE_TIMEOUT" ]; do
+        running=$(running_instance_count)
+
+        # Every couple of minutes, not every poll: the pane shows the tail of
+        # this file, and a line every fifteen seconds would push everything
+        # else off it.
+        if [ $((waited % 120)) -eq 0 ]; then
+            say "Translating: $running workflow instances still running (${waited}s)"
+        fi
+
+        if [ "$running" = "0" ]; then
+            # Two quiet passes, not one. Instances are created as splits are
+            # made, so early on there is a moment with none running and more
+            # still to come; ending the run there would report success in the
+            # middle of it.
+            quiet=$((quiet + 1))
+            if [ "$quiet" -ge 2 ]; then
+                say "Workflow finished after ${waited}s."
+                return 0
+            fi
+        else
+            quiet=0
+        fi
+
+        sleep "$TRANSLATE_POLL"
+        waited=$((waited + TRANSLATE_POLL))
+    done
+
+    say "Still running after ${waited}s; leaving it to carry on."
+    say "Gloss and OPSUI will show it finish."
+    return 1
+}
+
+# How many BigTranslate instances are not in a terminal state.
+running_instance_count() {
+    "$BIGTRANSLATE_HOME"/workflow/bin/wmgr-client --url "$CLIENT_URL" \
+        --operation --getWorkflowInsts 2>/dev/null \
+        | grep -oE "status=[A-Za-z]+" \
+        | grep -vcE "status=(FINISHED|ERROR|Success|Failure|Stopped)" \
+        || echo 0
+}
+
+TRANSLATE_TIMEOUT=${TRANSLATE_TIMEOUT:-86400}
+TRANSLATE_POLL=${TRANSLATE_POLL:-15}
 
 function translate {
     check_services_running
@@ -203,18 +278,30 @@ function translate {
     PRODUCT_PATH="$CORPUS_PATH"
 
     mark_run "TRANSLATING" "$PRODUCT_PATH" "$BIGTRANSLATE_EXCLUDE"
-    # The crawl is the part this script waits for; the translation itself runs
-    # on in the workflow manager, so the marker is cleared by whoever sees the
-    # workflow finish rather than here.
-    pushd $BIGTRANSLATE_HOME/crawler/bin >> $BIGTRANSLATE_HOME/logs/bigtranslate.log 2>&1
+    # Cleared when the workflow drains, below. Interrupting this script leaves
+    # the marker behind on purpose: the translation carries on in the workflow
+    # manager, and saying otherwise would be a lie about what is happening.
+    say "Crawling $PRODUCT_PATH"
+    if [ -n "$BIGTRANSLATE_EXCLUDE" ]; then
+        say "  skipping anything matching $BIGTRANSLATE_EXCLUDE"
+    fi
 
-   ./crawler_launcher --operation --metPC --metExtractorConfig \
-   $BIGTRANSLATE_HOME/extractors/default/default.cpr.conf --metExtractor org.apache.oodt.cas.metadata.extractors.CopyAndRewriteExtractor \
-   --filemgrUrl $FILEMGR_URL --clientTransferer org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory \
-   --preCondIds RegExExcludeComparator --actionIds TriggerPostIngestWorkflow --productPath $PRODUCT_PATH
+    # A subshell rather than pushd/popd: the directory stack was echoed into
+    # the log, and it was the only thing in there.
+    (
+        cd "$BIGTRANSLATE_HOME/crawler/bin" || exit 1
+        ./crawler_launcher --operation --metPC --metExtractorConfig \
+        $BIGTRANSLATE_HOME/extractors/default/default.cpr.conf --metExtractor org.apache.oodt.cas.metadata.extractors.CopyAndRewriteExtractor \
+        --filemgrUrl $FILEMGR_URL --clientTransferer org.apache.oodt.cas.filemgr.datatransfer.InPlaceDataTransferFactory \
+        --preCondIds RegExExcludeComparator --actionIds TriggerPostIngestWorkflow --productPath $PRODUCT_PATH
+    )
 
-    popd >> $BIGTRANSLATE_HOME/logs/bigtranslate.log 2>&1
+    say "Crawl finished; the workflow manager is translating."
     export BIGTRANSLATE_EXCLUDE=""
+
+    # The run is not over when the crawl is over.
+    wait_for_workflow
+    unmark_run
 }
 
 # Get the current list of RatAuditTasks running.

--- a/distribution/src/main/resources/bin/bigtranslate-setup
+++ b/distribution/src/main/resources/bin/bigtranslate-setup
@@ -100,6 +100,55 @@ if [ -n "$PANTOGLOSS_SOURCE" ]; then
     # A specifier the extra cannot be appended to -- a URL, a wheel path --
     # is installed as given and the extra requested separately, so the
     # server half arrives either way.
+    # On Apple silicon, with the Metal plugin.
+    #
+    # Pantogloss declares a [metal] extra -- tensorflow-metal -- and without
+    # it TensorFlow sees no GPU at all, so --device auto has nothing to
+    # choose and every translation runs on the CPU. That is not a fallback
+    # anyone asked for; it is just what happens when the plugin is missing,
+    # and it is invisible unless somebody reads /info and notices the backend.
+    # The GPU extra for this machine, if there is one to have.
+    #
+    # Pantogloss ships two: [metal] for Apple silicon and [cuda] for Linux
+    # with an NVIDIA card. Without whichever applies, TensorFlow sees no GPU
+    # at all, so --device auto has nothing to choose and every translation
+    # runs on the CPU -- invisibly, unless somebody reads /info and notices
+    # the backend.
+    #
+    # The CUDA extra pulls a large stack, so it is asked for only when there
+    # is a card to use it: nvidia-smi answering is the cheapest reliable sign
+    # of a usable driver, and a machine without one gets the CPU build rather
+    # than a gigabyte of libraries it cannot use.
+    EXTRAS=server
+    case "$(uname -s)" in
+        Darwin)
+            if [ "$(uname -m)" = "arm64" ]; then
+                EXTRAS="server,metal"
+                echo "  Apple silicon: including the Metal extra"
+            else
+                echo "  Intel Mac: no GPU extra (Metal needs Apple silicon)"
+            fi
+            ;;
+        Linux)
+            if command -v nvidia-smi > /dev/null 2>&1 && nvidia-smi > /dev/null 2>&1; then
+                EXTRAS="server,cuda"
+                echo "  NVIDIA GPU found: including the CUDA extra"
+            else
+                echo "  No usable NVIDIA GPU (nvidia-smi did not answer);"
+                echo "  installing the CPU build. Set PANTOGLOSS_EXTRAS=server,cuda"
+                echo "  to force it."
+            fi
+            ;;
+        *)
+            echo "  $(uname -s): no GPU extra known for this platform"
+            ;;
+    esac
+    # The last word, for a machine this guessed wrong about.
+    if [ -n "${PANTOGLOSS_EXTRAS:-}" ]; then
+        EXTRAS="$PANTOGLOSS_EXTRAS"
+        echo "  PANTOGLOSS_EXTRAS is set: using [$EXTRAS]"
+    fi
+
     case "$PANTOGLOSS_SOURCE" in
         *"["*"]"*)
             "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
@@ -109,9 +158,9 @@ if [ -n "$PANTOGLOSS_SOURCE" ]; then
             "$VENV/bin/pip" install "fastapi>=0.115,<1" "uvicorn>=0.34,<1"
             ;;
         *)
-            "$VENV/bin/pip" install "${PANTOGLOSS_SOURCE}[server]" \
+            "$VENV/bin/pip" install "${PANTOGLOSS_SOURCE}[${EXTRAS}]" \
                 || {
-                    echo "  [server] extra not available; installing plain"
+                    echo "  extras not available; installing plain"
                     "$VENV/bin/pip" install "$PANTOGLOSS_SOURCE"
                     "$VENV/bin/pip" install "fastapi>=0.115,<1" "uvicorn>=0.34,<1"
                 }
@@ -133,6 +182,21 @@ if "$VENV/bin/python" -c "import pantogloss" > /dev/null 2>&1; then
     # Said here rather than left to fail at run time.
     if "$VENV/bin/python" -c "import uvicorn, fastapi" > /dev/null 2>&1; then
         echo "  pantogloss serve  (the translation service)"
+        # Said here, because the alternative is finding out from a run that
+        # took as long as it always did.
+        # Whether a GPU will actually be used, asked of TensorFlow itself
+        # rather than inferred from what was installed. This is the answer
+        # that matters and it is one line to get.
+        gpus=$("$VENV/bin/python" -c \
+            "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" \
+            2>/dev/null)
+        if [ "${gpus:-0}" -gt 0 ] 2>/dev/null; then
+            echo "  GPU               $gpus visible to TensorFlow"
+        else
+            echo "  GPU               NONE visible to TensorFlow -- translation"
+            echo "                    will run on the CPU whatever"
+            echo "                    PANTOGLOSS_DEVICE says."
+        fi
     else
         echo "  pantogloss serve  NOT AVAILABLE -- no fastapi/uvicorn."
         echo "                    The translate step will load the model per"

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -102,84 +102,11 @@ fi
 # The ports these services listen on, so start and stop can tell whether they
 # actually did anything.
 #
-# The translation service is deliberately not in this list. It loads a model
-# before it answers -- half a minute or so -- and a start that waited for it
-# would look hung; the translate step checks it for itself and says plainly
-# if it is not ready. Its port is still stopped and started with everything
-# else.
+# The translation service is deliberately not in this list: it loads a model
+# before it answers, and a start that waited for it would look hung. Its port
+# is still started and stopped with everything else.
 oodt_ports() {
   echo "$FILEMGR_PORT $WORKFLOW_PORT $RESMGR_PORT $TOMCAT_PORT $SOLR_PORT"
-}
-
-PANTOGLOSS_LOG="$OODT_BASE/logs/pantogloss-serve.log"
-PANTOGLOSS_PID="$OODT_BASE/run/pantogloss-serve.pid"
-
-# One resident model for the deployment, rather than one load per split.
-#
-# Started here because the translate step is run by the workflow manager, and
-# a service that has to be remembered separately is one that is not running
-# when it matters -- the model then loads inside every split's own process,
-# thirty seconds at a time, which is the cost this removes.
-start_pantogloss() {
-  serve_bin="$OODT_BASE/.venv/bin/pantogloss"
-  if [ ! -x "$serve_bin" ]; then
-    echo "No Pantogloss in $OODT_BASE/.venv -- run bin/bigtranslate-setup."
-    echo "Translation will fail until it is there."
-    return 0
-  fi
-  if ! "$OODT_BASE"/.venv/bin/python -c "import uvicorn, fastapi" > /dev/null 2>&1; then
-    echo "Pantogloss is installed without its server extra, so the"
-    echo "translation service cannot start. Re-run bin/bigtranslate-setup."
-    return 0
-  fi
-  if port_busy "$PANTOGLOSS_PORT"; then
-    echo "Something is already listening on $PANTOGLOSS_PORT;"
-    echo "leaving it alone. If it is not Pantogloss, set PANTOGLOSS_PORT."
-    return 0
-  fi
-
-  # As many at once as the engine runs splits at once. The service defaults
-  # to one, and one is the wrong answer here: every worker but the first
-  # waits, and the queue is longer than the work.
-  concurrency="$PANTOGLOSS_CONCURRENCY"
-  if [ -z "$concurrency" ]; then
-    concurrency=$(sed -n 's/^org.apache.oodt.cas.workflow.engine.minPoolSize=\([0-9]*\).*/\1/p' \
-      "$OODT_BASE/workflow/etc/workflow.properties" 2>/dev/null | tail -1)
-  fi
-  if [ -z "$concurrency" ]; then
-    concurrency=8
-  fi
-
-  mkdir -p "$(dirname "$PANTOGLOSS_PID")" "$(dirname "$PANTOGLOSS_LOG")" 2>/dev/null
-  nohup "$serve_bin" serve --port "$PANTOGLOSS_PORT" --no-browser \
-    --max-concurrency "$concurrency" \
-    --max-queued-requests $((concurrency * 8)) \
-    --device "$PANTOGLOSS_DEVICE" \
-    >> "$PANTOGLOSS_LOG" 2>&1 &
-  echo $! > "$PANTOGLOSS_PID"
-  echo "Translation service starting on $PANTOGLOSS_PORT: $concurrency at a time"
-  echo "on $PANTOGLOSS_DEVICE. It answers once the model is loaded"
-  echo "(see $PANTOGLOSS_LOG)."
-}
-
-stop_pantogloss() {
-  if [ -f "$PANTOGLOSS_PID" ]; then
-    pid=$(cat "$PANTOGLOSS_PID" 2>/dev/null)
-    if [ -n "$pid" ] && kill -0 "$pid" > /dev/null 2>&1; then
-      kill "$pid" > /dev/null 2>&1
-    fi
-    rm -f "$PANTOGLOSS_PID"
-  fi
-
-  waited=0
-  while [ "$waited" -lt 60 ]; do
-    port_busy "$PANTOGLOSS_PORT" || return 0
-    sleep 2
-    waited=$((waited + 2))
-  done
-  # Not fatal: it may be somebody else's, which start_pantogloss also
-  # declines to touch.
-  echo "Port $PANTOGLOSS_PORT is still busy after ${waited}s."
 }
 
 port_busy() {
@@ -190,12 +117,12 @@ port_busy() {
   fi
 }
 
-# Wait until every port is free, or say which ones are not.
+# Wait until every port is free, or say which are not.
 #
 # stop used to return as soon as it had asked each service to stop, which is
-# not the same as their having stopped: a start immediately afterwards found
-# Solr still holding its port, failed with "Port ... is already being used",
-# and left the deployment with nothing running at all.
+# not the same as their having stopped: a start straight afterwards found Solr
+# still holding its port, failed with "Port already being used", and left the
+# deployment with nothing running.
 wait_for_stopped() {
   waited=0
   while [ "$waited" -lt 180 ]; do
@@ -211,8 +138,6 @@ wait_for_stopped() {
   return 1
 }
 
-# Wait until every port answers, so a caller that starts and then immediately
-# uses the services is not racing them.
 wait_for_started() {
   waited=0
   while [ "$waited" -lt 120 ]; do
@@ -229,7 +154,159 @@ wait_for_started() {
   return 1
 }
 
+PANTOGLOSS_LOG="$OODT_BASE/logs/pantogloss-serve.log"
+PANTOGLOSS_PID="$OODT_BASE/run/pantogloss-serve.pid"
+
+# The pid of our translation service, or nothing.
+#
+# From the pid file when it is still true, and otherwise by asking what is on
+# the port and whether it is a Pantogloss out of this deployment. The file
+# alone was not enough: a service outliving its file, or a file outliving its
+# service, left start and stop disagreeing with what was actually running.
+pantogloss_pid() {
+  if [ -f "$PANTOGLOSS_PID" ]; then
+    filed=$(cat "$PANTOGLOSS_PID" 2>/dev/null)
+    if [ -n "$filed" ] && kill -0 "$filed" > /dev/null 2>&1; then
+      echo "$filed"
+      return 0
+    fi
+    rm -f "$PANTOGLOSS_PID"
+  fi
+
+  command -v lsof > /dev/null 2>&1 || return 0
+  for candidate in $(lsof -ti tcp:"$PANTOGLOSS_PORT" 2>/dev/null); do
+    # Only a Pantogloss from this deployment's own environment. Anything else
+    # on the port belongs to somebody else and is not ours to stop, which is
+    # the rule start follows too.
+    if ps -p "$candidate" -o command= 2>/dev/null \
+        | grep -q "$OODT_BASE/.venv/bin/pantogloss"; then
+      echo "$candidate" > "$PANTOGLOSS_PID"
+      echo "$candidate"
+      return 0
+    fi
+  done
+}
+
+# How many translations the service may run at once.
+#
+# One on Apple silicon with Metal, whatever the engine's pool size says.
+# Eight simultaneous translate() calls share one Keras model and one Metal
+# execution context, and MPSGraph asserts on the mismatched shapes --
+# "Placeholder shape mismatches" -- which aborts the process mid-run. The
+# eight workers still submit at once; they queue inside the service instead.
+#
+# On CPU and CUDA there is no such limit, so it follows the pool: the service
+# is there to be shared, and one slot would serialise every worker behind it.
+pantogloss_concurrency() {
+  if [ -n "$PANTOGLOSS_CONCURRENCY" ]; then
+    echo "$PANTOGLOSS_CONCURRENCY"
+    return 0
+  fi
+
+  # Asked of TensorFlow, not of the import system. tensorflow-metal is a
+  # PluggableDevice rather than a module: "import tensorflow_metal" raises
+  # ModuleNotFoundError on a machine where the plugin is installed and
+  # working, so testing for it that way silently answered "no Metal here" and
+  # started the service with eight slots -- the one setting that crashes it.
+  if [ "$PANTOGLOSS_DEVICE" != "cpu" ] \
+     && [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+    gpus=$("$OODT_BASE"/.venv/bin/python -c \
+      "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" \
+      2>/dev/null)
+    if [ "${gpus:-0}" -gt 0 ] 2>/dev/null; then
+      echo 1
+      return 0
+    fi
+  fi
+
+  pool=$(sed -n 's/^org.apache.oodt.cas.workflow.engine.minPoolSize=\([0-9]*\).*/\1/p' \
+    "$OODT_BASE/workflow/etc/workflow.properties" 2>/dev/null | tail -1)
+  echo "${pool:-8}"
+}
+
+start_pantogloss() {
+  serve_bin="$OODT_BASE/.venv/bin/pantogloss"
+  if [ ! -x "$serve_bin" ]; then
+    echo "No Pantogloss in $OODT_BASE/.venv -- run bin/bigtranslate-setup."
+    echo "Translation will fail until it is there."
+    return 0
+  fi
+  if ! "$OODT_BASE"/.venv/bin/python -c "import uvicorn, fastapi" > /dev/null 2>&1; then
+    echo "Pantogloss is installed without its server extra, so the"
+    echo "translation service cannot start. Re-run bin/bigtranslate-setup."
+    return 0
+  fi
+
+  running_pid=$(pantogloss_pid)
+  if [ -n "$running_pid" ]; then
+    echo "Translation service already running (pid $running_pid)."
+    return 0
+  fi
+  if port_busy "$PANTOGLOSS_PORT"; then
+    echo "Something is already listening on $PANTOGLOSS_PORT and it is not"
+    echo "one of ours, so it is left alone. If it should be the translation"
+    echo "service, stop it or set PANTOGLOSS_PORT to a free port."
+    return 0
+  fi
+
+  concurrency=$(pantogloss_concurrency)
+  mkdir -p "$(dirname "$PANTOGLOSS_PID")" "$(dirname "$PANTOGLOSS_LOG")" 2>/dev/null
+  nohup "$serve_bin" serve --port "$PANTOGLOSS_PORT" --no-browser \
+    --max-concurrency "$concurrency" \
+    --max-queued-requests $((concurrency * 8 + 24)) \
+    --device "$PANTOGLOSS_DEVICE" \
+    >> "$PANTOGLOSS_LOG" 2>&1 &
+  echo $! > "$PANTOGLOSS_PID"
+  echo "Translation service starting on $PANTOGLOSS_PORT: $concurrency at a time"
+  echo "on $PANTOGLOSS_DEVICE (pid $(cat "$PANTOGLOSS_PID")). It answers once"
+  echo "the model is loaded (see $PANTOGLOSS_LOG)."
+}
+
+stop_pantogloss() {
+  pid=$(pantogloss_pid)
+  if [ -z "$pid" ]; then
+    if port_busy "$PANTOGLOSS_PORT"; then
+      # Said rather than waited out in silence.
+      echo "Port $PANTOGLOSS_PORT is held by a process we did not start;"
+      echo "leaving it alone. Stop it yourself, or set PANTOGLOSS_PORT."
+    fi
+    rm -f "$PANTOGLOSS_PID"
+    return 0
+  fi
+
+  echo "Stopping the translation service (pid $pid)."
+  kill "$pid" > /dev/null 2>&1
+  waited=0
+  while [ "$waited" -lt 60 ]; do
+    kill -0 "$pid" > /dev/null 2>&1 || break
+    sleep 2
+    waited=$((waited + 2))
+  done
+  if kill -0 "$pid" > /dev/null 2>&1; then
+    echo "It did not stop in ${waited}s; ending it."
+    kill -9 "$pid" > /dev/null 2>&1
+    sleep 2
+  fi
+  rm -f "$PANTOGLOSS_PID"
+}
+
+# The directories the services need to exist before they will start.
+#
+# Empty directories do not survive the tarball, so a freshly unpacked
+# distribution has no tomcat/logs -- and Tomcat does not report that as a
+# problem it can see: catalina.sh fails at "touch .../catalina.out: No such
+# file or directory" and exits, leaving no catalina.out to read and nothing
+# listening. The first sign is a webapp that is simply not there.
+ensure_working_dirs() {
+  for dir in "$OODT_BASE/tomcat/logs" "$OODT_BASE/tomcat/work" \
+             "$OODT_BASE/tomcat/temp" "$OODT_BASE/logs" "$OODT_BASE/run" \
+             "$OODT_BASE/data/jobs"; do
+    [ -d "$dir" ] || mkdir -p "$dir" 2>/dev/null
+  done
+}
+
 start_oodt() {
+  ensure_working_dirs
   nohup "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &  
@@ -262,10 +339,9 @@ if [ "$1" = "start" ]; then
 elif [ "$1" = "stop" ]; then
   stop_oodt
 elif [ "$1" = "restart" ]; then
-  # The README has told people to run this since before it existed, and the
-  # script answered by printing its usage and exiting 1 -- quietly enough that
-  # a configuration change made just beforehand looked as though it had been
-  # picked up when the services were still running with the old one.
+  # The README has told people to run this since before it existed; it fell
+  # through to the usage branch, quietly enough that a configuration change
+  # made just beforehand looked as though it had been picked up.
   stop_oodt || exit 1
   start_oodt
 else

--- a/tests/test_corpus_path.py
+++ b/tests/test_corpus_path.py
@@ -127,3 +127,212 @@ def test_the_device_is_configurable():
     assert "--device" in oodt
     assert "PANTOGLOSS_DEVICE" in setenv
     assert "PANTOGLOSS_DEVICE:-auto}" in setenv, "the default is not auto"
+
+
+def test_translate_waits_for_the_workflow_and_clears_the_marker():
+    """The crawl ending is not the run ending.
+
+    Translating happens in the workflow manager after the crawl returns.
+    Marking the run and walking away left the marker behind for good: every
+    instance finished and Gloss went on reporting TRANSLATING, because the
+    only thing that could have said otherwise had exited.
+    """
+    text = DRIVER.read_text()
+    assert "wait_for_workflow" in text, (
+        "translate does not wait for the workflow it started")
+    wait_at = text.index("    wait_for_workflow")
+    unmark_at = text.index("    unmark_run", wait_at)
+    assert wait_at < unmark_at, "the marker is cleared before the run is over"
+
+
+def test_the_wait_needs_two_quiet_passes():
+    """Instances appear as splits are made, so there is a moment early on with
+    none running and more still to come. Ending there reports success in the
+    middle of the run."""
+    text = DRIVER.read_text()
+    import re
+    assert re.search(r'quiet"?\s+-ge\s+2', text), (
+        "a single quiet poll ends the wait")
+
+
+SETUP = (REPO / "distribution" / "src" / "main" / "resources"
+         / "bin" / "bigtranslate-setup")
+
+
+def test_setup_asks_for_the_gpu_extra_this_machine_can_use():
+    """Without the right extra TensorFlow sees no GPU, so --device auto has
+    nothing to choose and everything runs on the CPU -- invisibly, unless
+    somebody reads /info and notices the backend.
+
+    Two extras exist and they are not interchangeable: [metal] needs Apple
+    silicon, [cuda] needs Linux and a card.
+    """
+    text = SETUP.read_text()
+    assert "metal" in text, "the Metal extra is never installed"
+    assert "arm64" in text, "Metal is not conditioned on Apple silicon"
+    assert "cuda" in text, "the CUDA extra is never installed"
+    assert "nvidia-smi" in text, (
+        "CUDA is installed without checking there is a card for it, which "
+        "pulls a large stack onto machines that cannot use it")
+
+
+def test_the_gpu_extra_can_be_overridden():
+    """For a machine the guess gets wrong."""
+    assert "PANTOGLOSS_EXTRAS" in SETUP.read_text()
+
+
+def test_setup_reports_whether_a_gpu_will_actually_be_used():
+    """Asked of TensorFlow rather than inferred from what was installed: a
+    CPU-only deployment otherwise looks identical to a GPU one."""
+    text = SETUP.read_text()
+    assert "list_physical_devices" in text, (
+        "the GPU is inferred from the install rather than confirmed")
+    assert "NONE visible" in text, "a CPU-only deployment says nothing"
+
+
+OODT = REPO / "distribution" / "src" / "main" / "resources" / "bin" / "oodt"
+
+
+def test_the_translation_service_is_part_of_the_lifecycle():
+    """It starts, stops and bounces with everything else."""
+    text = OODT.read_text()
+    assert "start_pantogloss" in text and "stop_pantogloss" in text
+    # restart goes through both, so a bounce actually bounces it.
+    restart_at = text.index('elif [ "$1" = "restart" ]')
+    after = text[restart_at:]
+    assert "stop_oodt" in after and "start_oodt" in after
+    start_body = text[text.index("start_oodt() {"):text.index("stop_oodt() {")]
+    stop_body = text[text.index("stop_oodt() {"):restart_at]
+    assert "start_pantogloss" in start_body, "start does not start the service"
+    assert "stop_pantogloss" in stop_body, "stop does not stop the service"
+
+
+def test_the_service_pid_is_findable_without_the_pid_file():
+    """A service can outlive its pid file, and a pid file can outlive its
+    service. Either way start and stop have to agree with what is running."""
+    text = OODT.read_text()
+    assert "pantogloss_pid()" in text
+    assert "lsof -ti tcp" in text, (
+        "the pid can only come from the file, so a service started any other "
+        "way cannot be stopped")
+    assert "kill -0" in text, "a stale pid file is never detected"
+
+
+def test_a_stale_pid_file_is_cleared_rather_than_believed():
+    text = OODT.read_text()
+    body = text[text.index("pantogloss_pid()"):text.index("start_pantogloss()")]
+    assert 'rm -f "$PANTOGLOSS_PID"' in body
+
+
+def test_stop_says_when_the_port_belongs_to_someone_else():
+    """It used to wait out its timeout in silence."""
+    body = OODT.read_text()
+    stop_body = body[body.index("stop_pantogloss() {"):body.index('if [ "$1" = "start" ]')]
+    assert "did not start" in stop_body, (
+        "stop says nothing about a port held by a foreign process")
+
+
+def test_only_our_own_service_is_ever_killed():
+    """The same rule start follows: a port we do not own is not ours to stop."""
+    body = OODT.read_text()
+    finder = body[body.index("pantogloss_pid()"):body.index("start_pantogloss()")]
+    assert ".venv/bin/pantogloss" in finder, (
+        "any process on the port would be adopted, and killed")
+
+
+def test_starting_twice_does_not_start_two():
+    body = OODT.read_text()
+    start_body = body[body.index("start_pantogloss() {"):body.index("stop_pantogloss() {")]
+    assert "already running" in start_body
+
+
+def test_metal_gets_one_inference_slot_whatever_the_pool_says():
+    """Eight simultaneous translate() calls share one Keras model and one
+    Metal execution context, and MPSGraph asserts on the mismatched shapes --
+    "Placeholder shape mismatches" -- which aborts the process mid-run.
+
+    The workers still submit concurrently; they queue inside the service. On
+    CPU and CUDA there is no such limit, so concurrency follows the pool: one
+    slot there would serialise every worker behind it for no reason.
+    """
+    body = OODT.read_text()
+    fn = body[body.index("pantogloss_concurrency()"):body.index("start_pantogloss()")]
+    assert "arm64" in fn, "the Metal case is not distinguished"
+    # Asked of TensorFlow rather than of the import system: tensorflow-metal
+    # is a PluggableDevice, not a module, so "import tensorflow_metal" fails
+    # on a machine where the GPU is present and working -- which silently
+    # started the service with eight slots, the setting that crashes it.
+    assert "list_physical_devices" in fn, (
+        "Metal is detected by importing a module that does not exist")
+    # The executed form, not the phrase: the comment above the check explains
+    # this failure and would otherwise trip the test that guards it.
+    executed = [line for line in fn.splitlines()
+                if "import tensorflow_metal" in line
+                and not line.strip().startswith("#")]
+    assert executed == [], (
+        "tensorflow-metal is a PluggableDevice; importing it always fails: %s"
+        % executed)
+    assert "minPoolSize" in fn, "the non-Metal case does not follow the pool"
+    assert "echo 1" in fn, "Metal is not held to a single inference slot"
+
+
+def test_the_concurrency_can_still_be_overridden():
+    body = OODT.read_text()
+    fn = body[body.index("pantogloss_concurrency()"):body.index("start_pantogloss()")]
+    assert "PANTOGLOSS_CONCURRENCY" in fn
+
+
+def test_the_device_default_stays_auto():
+    """Not cpu. Metal is healthy; it was the concurrency that was wrong, and
+    defaulting to the CPU would throw the GPU away to dodge a bug that only
+    appears with simultaneous inference."""
+    setenv = (REPO / "distribution" / "src" / "main" / "resources"
+              / "bin" / "setenv.sh").read_text()
+    assert "PANTOGLOSS_DEVICE:-auto}" in setenv
+
+
+def test_start_creates_the_directories_the_services_need():
+    """Empty directories do not survive the tarball.
+
+    A freshly unpacked distribution has no tomcat/logs, and Tomcat does not
+    report that in any log -- catalina.sh fails at "touch .../catalina.out:
+    No such file or directory" and exits, leaving nothing listening and no
+    catalina.out to read. The first sign is a webapp that is simply absent.
+    """
+    body = OODT.read_text()
+    assert "ensure_working_dirs" in body
+    fn = body[body.index("ensure_working_dirs() {"):body.index("start_oodt() {")]
+    for needed in ("tomcat/logs", "tomcat/work", "data/jobs"):
+        assert needed in fn, "%s is not created before start" % needed
+    start_body = body[body.index("start_oodt() {"):body.index("stop_oodt() {")]
+    assert "ensure_working_dirs" in start_body, "start does not call it"
+
+
+def test_the_log_gloss_shows_says_what_is_happening():
+    """It used to hold nothing but pushd and popd output.
+
+    Gloss shows the tail of this file under "In progress", so a reader
+    watching a forty minute run saw two lines of shell bookkeeping --
+    "~/bt-w1/crawler/bin ~/bt-w1" -- and nothing about the run.
+    """
+    text = DRIVER.read_text()
+    assert "say()" in text, "there is no way to write progress to the log"
+
+    # The directory stack is no longer redirected into it.
+    polluting = [line for line in text.splitlines()
+                 if ("pushd" in line or "popd" in line)
+                 and "bigtranslate.log" in line
+                 and not line.strip().startswith("#")]
+    assert polluting == [], (
+        "pushd/popd still write the directory stack into the log: %s"
+        % polluting)
+
+    for milestone in ("Crawling", "Crawl finished", "Translating:"):
+        assert milestone in text, "the log never says %r" % milestone
+
+
+def test_progress_is_not_written_on_every_poll():
+    """The pane shows a tail; a line every fifteen seconds pushes everything
+    else off it."""
+    text = DRIVER.read_text()
+    assert "waited % 120" in text, "progress is logged every poll"


### PR DESCRIPTION
Five bugs, all found by installing from the tarball and running it. None
would have been visible from reading the source.

### 1. Eight inference slots on Metal aborts the process

The service was started with as many slots as the engine has workers.
Right on CPU, fatal on Apple silicon — eight concurrent `translate()`
calls share one Keras model and one Metal context:

```
MPSGraph.mm:1136: failed assertion
  `Placeholder shape mismatches (expected 2 vs got tensorData with 3) at dimIdx = 3'
```

An assertion inside Apple's framework, so the process dies and every
task after it fails. Concurrency now follows the device: **1 on Metal**,
the pool size on CPU/CUDA.

### 2. Metal was detected by an import that always fails

`import tensorflow_metal` raises `ModuleNotFoundError` on a machine where
the GPU works — it is a **PluggableDevice, not a module**. So the Metal
branch was never taken and the service came up with eight slots, i.e. the
one setting that crashes it. It now asks TensorFlow:
`len(tf.config.list_physical_devices('GPU'))`.

### 3. A fresh unpack cannot start Tomcat

Empty directories do not survive the tarball, so there is no
`tomcat/logs`:

```
touch: .../tomcat/logs/catalina.out: No such file or directory
catalina.sh: line 464: ... No such file or directory
```

and therefore **no `catalina.out` to read**. The only symptom is a webapp
that is not there. `start` now creates what the services need
(`tomcat/logs`, `tomcat/work`, `data/jobs`).

### 4. Gloss said TRANSLATING for ever

The marker was written at the start and never cleared: the script returns
after the crawl while the workflow manager goes on translating, so
nothing was left to clear it. Every instance would finish and Gloss still
reported a run in progress. `translate` now waits for the workflow to
drain — **two quiet polls**, because instances appear as splits are made
and there is a moment early on with none running and more to come.

### 5. The "In progress" pane showed shell bookkeeping

The log Gloss tails held only `pushd`/`popd` directory-stack echoes,
because those were the only things ever redirected into it:

```
~/bt-w1/crawler/bin ~/bt-w1
~/bt-w1
```

The crawl uses a subshell now, and the run reports what it is crawling,
what it is skipping, and how many instances remain — every two minutes,
not every 15s poll, since the pane shows a tail.

### Tests

**275 passing**, all new ones verified against the pre-fix scripts.