### PR TITLE
Wait for the queue instead of losing the split

### DIFF
--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -197,6 +197,27 @@ pantogloss_pid() {
 #
 # On CPU and CUDA there is no such limit, so it follows the pool: the service
 # is there to be shared, and one slot would serialise every worker behind it.
+# How long a request may wait for a slot.
+#
+# The service's own default is thirty seconds, which suits a server with as
+# many slots as callers. It is the wrong number for this one: on Metal there
+# is a single inference slot by necessity, eight workers submit into it, and
+# waiting is the normal path rather than a fault. At thirty seconds the
+# service began refusing batches with "translation queue wait timed out",
+# each refusal losing a whole split, and a run finished with 1,546 of 43,851
+# postings and no other sign of trouble.
+#
+# Sized from the queue: a batch takes a couple of seconds, so a full queue
+# drains in a couple of minutes. Ten gives room for a slow batch without
+# waiting forever on a service that has actually stopped answering.
+pantogloss_queue_timeout() {
+  if [ -n "$PANTOGLOSS_QUEUE_TIMEOUT" ]; then
+    echo "$PANTOGLOSS_QUEUE_TIMEOUT"
+    return 0
+  fi
+  echo 600
+}
+
 pantogloss_concurrency() {
   if [ -n "$PANTOGLOSS_CONCURRENCY" ]; then
     echo "$PANTOGLOSS_CONCURRENCY"
@@ -250,10 +271,12 @@ start_pantogloss() {
   fi
 
   concurrency=$(pantogloss_concurrency)
+  PANTOGLOSS_QUEUE_TIMEOUT=$(pantogloss_queue_timeout)
   mkdir -p "$(dirname "$PANTOGLOSS_PID")" "$(dirname "$PANTOGLOSS_LOG")" 2>/dev/null
   nohup "$serve_bin" serve --port "$PANTOGLOSS_PORT" --no-browser \
     --max-concurrency "$concurrency" \
     --max-queued-requests $((concurrency * 8 + 24)) \
+    --queue-timeout "$PANTOGLOSS_QUEUE_TIMEOUT" \
     --device "$PANTOGLOSS_DEVICE" \
     >> "$PANTOGLOSS_LOG" 2>&1 &
   echo $! > "$PANTOGLOSS_PID"

--- a/distribution/src/main/resources/bin/pantogloss-translatejson
+++ b/distribution/src/main/resources/bin/pantogloss-translatejson
@@ -47,6 +47,7 @@ import json
 import os
 import sqlite3
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -81,6 +82,10 @@ DEFAULT_SERVICE_URL = "http://127.0.0.1:8765"
 
 class ServiceUnavailable(Exception):
     """The service is not there, is not ready, or is not Pantogloss."""
+
+
+class ServiceBusy(Exception):
+    """The service is there and working, but its queue is full right now."""
 
 
 def _get_json(url, timeout):
@@ -137,8 +142,40 @@ def check_service(base_url, timeout=10):
     return payload
 
 
+# A queue timeout is not a fault, it is a queue.
+#
+# With one inference slot and eight workers submitting into it -- which is the
+# only safe arrangement on Metal -- waiting is the normal path. The service
+# answers 503 queue_timeout when a request has waited longer than it allows,
+# and treating that as fatal loses a whole split: a run finished with 1,546 of
+# 43,851 postings, every missing one belonging to a batch that had been told
+# to come back later and was not asked again.
+#
+# This is the one condition worth retrying. A service that is absent, or is
+# not Pantogloss, or has no model, will still be absent on the next attempt;
+# a busy one will not.
+QUEUE_TIMEOUT_ATTEMPTS = 6
+QUEUE_TIMEOUT_BACKOFF = 10
+
+
 def translate_batch(base_url, texts, beam_size, max_length, timeout):
     """One batch through the service, answered in the order it was given."""
+    for attempt in range(QUEUE_TIMEOUT_ATTEMPTS):
+        try:
+            return _translate_once(base_url, texts, beam_size, max_length,
+                                   timeout)
+        except ServiceBusy as busy:
+            if attempt == QUEUE_TIMEOUT_ATTEMPTS - 1:
+                raise ServiceUnavailable(
+                    "the translation service at %s kept its queue full for "
+                    "%d attempts (%s). Nothing has been written for this "
+                    "batch." % (base_url, QUEUE_TIMEOUT_ATTEMPTS, busy))
+            wait = QUEUE_TIMEOUT_BACKOFF * (attempt + 1)
+            log("  service busy, waiting %ds and trying again" % wait)
+            time.sleep(wait)
+
+
+def _translate_once(base_url, texts, beam_size, max_length, timeout):
     body = {"text": list(texts), "max_length": max_length}
     if beam_size and beam_size > 1:
         body["beam_size"] = beam_size
@@ -156,12 +193,16 @@ def translate_batch(base_url, texts, beam_size, max_length, timeout):
     except urllib.error.HTTPError as e:
         detail = ""
         try:
-            detail = ": " + e.read().decode("utf-8")[:200]
+            detail = e.read().decode("utf-8")[:200]
         except Exception:
             pass
+        # 503 with a queue timeout means "busy, ask again", which is a
+        # different thing from a refusal.
+        if e.code == 503 and "queue" in detail.lower():
+            raise ServiceBusy(detail.strip() or "queue wait timed out")
         raise ServiceUnavailable(
             "the translation service at %s refused a batch of %d (HTTP %s)%s"
-            % (base_url, len(texts), e.code, detail))
+            % (base_url, len(texts), e.code, (": " + detail) if detail else ""))
     except urllib.error.URLError as e:
         raise ServiceUnavailable(
             "the translation service at %s stopped answering partway through "

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -62,6 +62,11 @@ export PANTOGLOSS_CONCURRENCY=${PANTOGLOSS_CONCURRENCY:-}
 # on Linux -- and falls back to the CPU when there is none. Set "cpu" to keep
 # the GPU free for something else.
 export PANTOGLOSS_DEVICE=${PANTOGLOSS_DEVICE:-auto}
+
+# How long a translation may wait for an inference slot. Empty takes the
+# deployment's own default, which allows for a full queue draining through a
+# single slot; the service's thirty second default assumes a slot per caller.
+export PANTOGLOSS_QUEUE_TIMEOUT=${PANTOGLOSS_QUEUE_TIMEOUT:-}
 export FILEMGR_HOME=$BIGTRANSLATE_HOME/filemgr
 export PGE_HOME=$BIGTRANSLATE_HOME/pge
 export PCS_HOME=$BIGTRANSLATE_HOME/pcs

--- a/tests/test_translate_service.py
+++ b/tests/test_translate_service.py
@@ -198,3 +198,76 @@ def test_the_floor_can_be_overridden():
     setup = (REPO / "distribution" / "src" / "main" / "resources"
              / "bin" / "bigtranslate-setup").read_text()
     assert "${PANTOGLOSS_REQUIRED:-0.18.0}" in setup
+
+
+class _Busy(_Handler):
+    """Answers 503 queue_timeout a few times, then succeeds.
+
+    This is what a single inference slot does when eight workers submit into
+    it: the service is healthy and the request is fine, it simply waited
+    longer than the server allows.
+    """
+
+    refusals = 2
+    seen = 0
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        asked = json.loads(self.rfile.read(length))
+        type(self).seen += 1
+        if type(self).seen <= type(self).refusals:
+            self._send(503, {"detail": {"code": "queue_timeout",
+                                        "message": "translation queue wait timed out"}})
+            return
+        self._send(200, {"translation": ["EN:" + t for t in asked["text"]]})
+
+
+def test_a_busy_queue_is_waited_out_not_treated_as_a_failure(server, monkeypatch):
+    """Losing a split to a queue timeout cost 42 batches on one run, which
+    finished with 1,546 of 43,851 postings and no other sign of trouble."""
+    monkeypatch.setattr(tj, "QUEUE_TIMEOUT_BACKOFF", 0)
+    _Busy.seen = 0
+    url = server(_Busy)
+
+    out = tj.translate_batch(url, ["uno", "dos"], 1, 50, 10)
+
+    assert out == ["EN:uno", "EN:dos"], "the batch was lost to a busy queue"
+    assert _Busy.seen == 3, "it did not retry twice before succeeding"
+
+
+def test_a_queue_that_never_clears_eventually_gives_up(server, monkeypatch):
+    """Retrying is for a queue that drains; a service wedged for good should
+    still say so rather than hanging on it."""
+    monkeypatch.setattr(tj, "QUEUE_TIMEOUT_BACKOFF", 0)
+
+    class Always(_Busy):
+        refusals = 10 ** 6
+        seen = 0
+
+    url = server(Always)
+    with pytest.raises(tj.ServiceUnavailable) as raised:
+        tj.translate_batch(url, ["uno"], 1, 50, 10)
+    assert "queue full" in str(raised.value)
+
+
+def test_other_refusals_are_still_fatal(server):
+    """Only a queue timeout is worth retrying. A service that is absent, or
+    not Pantogloss, or has no model, will be the same on the next attempt."""
+    class Broken(_Handler):
+        def do_POST(self):
+            self._send(413, {"detail": {"code": "batch_too_large"}})
+
+    url = server(Broken)
+    with pytest.raises(tj.ServiceUnavailable) as raised:
+        tj.translate_batch(url, ["uno"], 1, 50, 10)
+    said = str(raised.value)
+    assert "refused" in said and "413" in said
+
+
+def test_the_service_is_given_a_queue_wait_that_suits_one_slot():
+    """Thirty seconds is the service's own default and assumes a slot per
+    caller. With one slot and eight workers, waiting is the normal path."""
+    oodt = (REPO / "distribution" / "src" / "main" / "resources"
+            / "bin" / "oodt").read_text()
+    assert "--queue-timeout" in oodt, "the service keeps its 30s default"
+    assert "pantogloss_queue_timeout" in oodt


### PR DESCRIPTION
A run finished with **1,546 of 43,851 postings** and no other sign of
trouble:

```
service: 240 completed, 0 failed, 42 REJECTED
pantogloss-translatejson: refused a batch of 32 (HTTP 503):
  {"code":"queue_timeout","message":"translation queue wait timed out"}
```

Forty-two batches refused, each one losing a whole split.

### Nothing was broken; the timeout was wrong

On Metal there is one inference slot **by necessity** (concurrent
`translate()` calls abort the process), eight workers submit into it, and
waiting is the normal path. Pantogloss's own queue timeout is **30s**,
which suits a server with a slot per caller. A full queue does not drain
in 30s through a single slot.

It is now sized from the queue, with `PANTOGLOSS_QUEUE_TIMEOUT` for a
deployment that wants otherwise.

### Which failures deserve a retry

A service that is absent, is not Pantogloss, or has no model will be the
same on the next attempt — stopping is right, and that is why there is
still no fallback to loading the model in-task.

A **queue timeout is not that**. It is the service saying *busy, ask
again*. Batches refused that way are retried with a widening wait
(6 attempts) before being given up on; everything else stays fatal.

### This is a floor, not the fix

Serialising eight workers behind one slot gives back most of what a
resident model is for. The real answer is the request coalescing
Pantogloss is building for **0.19** — eight requests combined into fewer
model calls against the one safe slot, per its gate:

> retain Metal placement; report physical TensorFlow concurrency of one;
> combine requests into fewer than eight model calls; preserve all 256
> translations and their response boundaries

When that lands, `PANTOGLOSS_CONCURRENCY` goes back to the pool size and
this timeout stops mattering. The retry stays useful either way.

### Tests

**281 passing**, five new. The retry tests fail against the current code:
a busy queue currently loses the batch.