### PR TITLE
Take Pantogloss 0.19 and stop clamping Metal to one slot

### DIFF
--- a/distribution/src/main/resources/bin/bigtranslate
+++ b/distribution/src/main/resources/bin/bigtranslate
@@ -223,7 +223,11 @@ wait_for_workflow() {
         # this file, and a line every fifteen seconds would push everything
         # else off it.
         if [ $((waited % 120)) -eq 0 ]; then
-            say "Translating: $running workflow instances still running (${waited}s)"
+            if [ "$running" = "unknown" ]; then
+                say "Translating: the workflow manager did not answer (${waited}s)"
+            else
+                say "Translating: $running workflow instances still running (${waited}s)"
+            fi
         fi
 
         if [ "$running" = "0" ]; then
@@ -251,11 +255,33 @@ wait_for_workflow() {
 
 # How many BigTranslate instances are not in a terminal state.
 running_instance_count() {
-    "$BIGTRANSLATE_HOME"/workflow/bin/wmgr-client --url "$CLIENT_URL" \
-        --operation --getWorkflowInsts 2>/dev/null \
+    local instances count
+
+    instances=$("$BIGTRANSLATE_HOME"/workflow/bin/wmgr-client --url "$CLIENT_URL" \
+        --operation --getWorkflowInsts 2>/dev/null)
+
+    # No answer at all is not the same as nothing running, and saying "0"
+    # here would end a run that is still going because the manager happened
+    # to be unreachable for one poll.
+    if [ -z "$instances" ]; then
+        echo unknown
+        return 0
+    fi
+
+    # The count comes from grep's output, never from its exit status: "grep
+    # -c" exits 1 when it counts nothing, so an "|| echo 0" fallback fires on
+    # precisely the case it exists to report and appends a second line. The
+    # caller then compares "0\n0" against "0", never matches, and waits out
+    # a finished run -- which is what it did, for three hours, after the work
+    # had actually completed in forty-eight minutes.
+    count=$(printf '%s\n' "$instances" \
         | grep -oE "status=[A-Za-z]+" \
-        | grep -vcE "status=(FINISHED|ERROR|Success|Failure|Stopped)" \
-        || echo 0
+        | grep -vcE "status=(FINISHED|ERROR|Success|Failure|Stopped)")
+
+    case "$count" in
+        '' | *[!0-9]*) echo 0 ;;
+        *) echo "$count" ;;
+    esac
 }
 
 TRANSLATE_TIMEOUT=${TRANSLATE_TIMEOUT:-86400}

--- a/distribution/src/main/resources/bin/bigtranslate-setup
+++ b/distribution/src/main/resources/bin/bigtranslate-setup
@@ -84,20 +84,28 @@ echo "Installing from $REQUIREMENTS"
 # bin/pantogloss-translatejson through "#!/usr/bin/env python3" and that
 # resolves to whichever interpreter is first on PATH, which is this one.
 #
-# Point PANTOGLOSS_SOURCE at a checkout, a wheel, or any pip specifier:
+# Pantogloss is on PyPI, so the default is simply its name and the release
+# pip resolves is the one that arrives. Point PANTOGLOSS_SOURCE at a
+# checkout, a wheel, or any other pip specifier to override that:
 #   PANTOGLOSS_SOURCE=~/git/pantogloss bin/bigtranslate-setup
 #
-# The version matters, so it is checked after installing rather than asked
-# for in the specifier: Pantogloss is not published, so PANTOGLOSS_SOURCE is
-# usually a working checkout and pip has no version to resolve against. What
-# it lands on is whatever that checkout is on, which is worth knowing.
+# The version is checked after installing rather than asked for in the
+# specifier, because PANTOGLOSS_SOURCE is often a working checkout that pip
+# has no version to resolve against. What it lands on is whatever that
+# checkout is on, which is worth knowing -- and an editable checkout reports
+# the version in its pyproject, which can trail the release it contains.
 #
-# 0.18.0 is the floor. It defaults the server to one inference slot, which is
-# the only safe setting on Apple silicon: eight concurrent translate() calls
-# share one Keras model and one Metal execution context, and MPSGraph aborts
-# the process on the mismatched shapes. It also fixes the server's queue
-# timeouts on Python 3.10.
-PANTOGLOSS_REQUIRED=${PANTOGLOSS_REQUIRED:-0.18.0}
+# 0.19.0 is the floor. It admits concurrent callers on Apple silicon and
+# serialises them into the model itself, combining those already waiting
+# into one call; before it, concurrent translate() calls shared one Keras
+# model and one Metal execution context and MPSGraph aborted the process.
+# 0.18.0 avoided that with a single inference slot, which was safe and left
+# the queue far longer than the work it guarded. 0.19 also memory-maps the
+# tokenizer caches, which takes a warm start from about 5.4s to about 0.2s.
+PANTOGLOSS_REQUIRED=${PANTOGLOSS_REQUIRED:-0.19.0}
+# The name alone, so the extras are appended to it below and pip resolves the
+# newest release. The floor is enforced afterwards either way.
+PANTOGLOSS_SOURCE=${PANTOGLOSS_SOURCE:-pantogloss}
 if [ -n "$PANTOGLOSS_SOURCE" ]; then
     echo
     echo "Installing Pantogloss from $PANTOGLOSS_SOURCE"
@@ -210,10 +218,11 @@ VERSION
             echo "  pantogloss $installed"
         else
             echo "  pantogloss $installed  TOO OLD, wanted $PANTOGLOSS_REQUIRED or"
-            echo "                    later. Older servers default to more than one"
-            echo "                    inference slot, which aborts the process on"
-            echo "                    Apple silicon. Check out v$PANTOGLOSS_REQUIRED or"
-            echo "                    later in \$PANTOGLOSS_SOURCE and run this again."
+            echo "                    later. Older servers cannot batch concurrent"
+            echo "                    callers into one model call, so on Apple"
+            echo "                    silicon they run one translation at a time."
+            echo "                    Check out v$PANTOGLOSS_REQUIRED or later in"
+            echo "                    \$PANTOGLOSS_SOURCE and run this again."
         fi
     fi
     if "$VENV/bin/python" -c "import uvicorn, fastapi" > /dev/null 2>&1; then

--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -218,19 +218,53 @@ pantogloss_queue_timeout() {
   echo 600
 }
 
+# Whether the installed Pantogloss serialises concurrent callers into the
+# model for us, which 0.19 does and earlier versions do not. Read from the
+# package metadata rather than by running the CLI: "serve --help" imports
+# TensorFlow, which costs seconds every time the stack starts.
+pantogloss_batches_dynamically() {
+  "$OODT_BASE"/.venv/bin/python - <<'VERSION' 2>/dev/null
+import sys
+from importlib.metadata import version
+def parts(v):
+    out = []
+    for piece in v.split(".")[:3]:
+        digits = "".join(c for c in piece if c.isdigit())
+        out.append(int(digits) if digits else 0)
+    while len(out) < 3:
+        out.append(0)
+    return tuple(out)
+try:
+    sys.exit(0 if parts(version("pantogloss")) >= (0, 19, 0) else 1)
+except Exception:
+    sys.exit(1)
+VERSION
+}
+
 pantogloss_concurrency() {
   if [ -n "$PANTOGLOSS_CONCURRENCY" ]; then
     echo "$PANTOGLOSS_CONCURRENCY"
     return 0
   fi
 
-  # Asked of TensorFlow, not of the import system. tensorflow-metal is a
-  # PluggableDevice rather than a module: "import tensorflow_metal" raises
-  # ModuleNotFoundError on a machine where the plugin is installed and
-  # working, so testing for it that way silently answered "no Metal here" and
-  # started the service with eight slots -- the one setting that crashes it.
+  # Pantogloss 0.19 admits concurrent callers on Metal and funnels them
+  # through one TensorFlow worker itself, combining those that are waiting
+  # into a single model call. Before it, the server ran each caller straight
+  # into a shared Keras model and MPSGraph aborted the process, so the only
+  # safe answer on Apple silicon was a single slot -- and that single slot
+  # was what left the queue six times longer than the inference it guarded.
+  #
+  # The clamp therefore belongs to the old server, not to Metal, and it is
+  # asked of the installed version rather than the platform.
   if [ "$PANTOGLOSS_DEVICE" != "cpu" ] \
-     && [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+     && [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ] \
+     && ! pantogloss_batches_dynamically; then
+    # Asked of TensorFlow, not of the import system. tensorflow-metal is a
+    # PluggableDevice rather than a module: "import tensorflow_metal" raises
+    # ModuleNotFoundError on a machine where the plugin is installed and
+    # working, so testing for it that way silently answered "no Metal here"
+    # and started the service with eight slots -- the one setting that
+    # crashes it.
     gpus=$("$OODT_BASE"/.venv/bin/python -c \
       "import tensorflow as tf; print(len(tf.config.list_physical_devices('GPU')))" \
       2>/dev/null)
@@ -273,15 +307,26 @@ start_pantogloss() {
   concurrency=$(pantogloss_concurrency)
   PANTOGLOSS_QUEUE_TIMEOUT=$(pantogloss_queue_timeout)
   mkdir -p "$(dirname "$PANTOGLOSS_PID")" "$(dirname "$PANTOGLOSS_LOG")" 2>/dev/null
+  # Dynamic batching is 0.19's, and asking an older server for it is a
+  # startup failure rather than an ignored flag, so the flags go on only
+  # when the installed server has them.
+  batching=""
+  if pantogloss_batches_dynamically; then
+    batching="--dynamic-batch-wait-ms $PANTOGLOSS_BATCH_WAIT_MS"
+    batching="$batching --max-coalesced-batch-size $PANTOGLOSS_COALESCED_BATCH"
+    batching="$batching --max-coalesced-input-characters $PANTOGLOSS_COALESCED_CHARS"
+  fi
   nohup "$serve_bin" serve --port "$PANTOGLOSS_PORT" --no-browser \
     --max-concurrency "$concurrency" \
     --max-queued-requests $((concurrency * 8 + 24)) \
     --queue-timeout "$PANTOGLOSS_QUEUE_TIMEOUT" \
     --device "$PANTOGLOSS_DEVICE" \
+    $batching \
     >> "$PANTOGLOSS_LOG" 2>&1 &
   echo $! > "$PANTOGLOSS_PID"
   echo "Translation service starting on $PANTOGLOSS_PORT: $concurrency at a time"
-  echo "on $PANTOGLOSS_DEVICE (pid $(cat "$PANTOGLOSS_PID")). It answers once"
+  echo "on $PANTOGLOSS_DEVICE${batching:+, batching waiting callers together}"
+  echo "(pid $(cat "$PANTOGLOSS_PID")). It answers once"
   echo "the model is loaded (see $PANTOGLOSS_LOG)."
 }
 

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -67,6 +67,19 @@ export PANTOGLOSS_DEVICE=${PANTOGLOSS_DEVICE:-auto}
 # deployment's own default, which allows for a full queue draining through a
 # single slot; the service's thirty second default assumes a slot per caller.
 export PANTOGLOSS_QUEUE_TIMEOUT=${PANTOGLOSS_QUEUE_TIMEOUT:-}
+
+# How long the server collects arriving translations before running them
+# through the model together, and how large the combined call may get.
+#
+# Ten milliseconds is Pantogloss's own default and costs a lightly loaded
+# caller almost nothing. It buys less than it looks like it should here: the
+# PGE already sends thirty-two strings per request and a combined call holds
+# sixty-four, so at most two of our requests ever merge. A longer window
+# fills those pairs more reliably at the price of latency on a quiet queue.
+# Ignored by servers older than 0.19, which have no such flag.
+export PANTOGLOSS_BATCH_WAIT_MS=${PANTOGLOSS_BATCH_WAIT_MS:-10}
+export PANTOGLOSS_COALESCED_BATCH=${PANTOGLOSS_COALESCED_BATCH:-64}
+export PANTOGLOSS_COALESCED_CHARS=${PANTOGLOSS_COALESCED_CHARS:-200000}
 export FILEMGR_HOME=$BIGTRANSLATE_HOME/filemgr
 export PGE_HOME=$BIGTRANSLATE_HOME/pge
 export PCS_HOME=$BIGTRANSLATE_HOME/pcs

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@
 # (hirlite) is not required.
 etllib @ git+https://github.com/chrismattmann/etllib.git
 
-# Pantogloss is not listed here because it is not published: bigtranslate-setup
-# installs it from PANTOGLOSS_SOURCE, with the [server] extra and, on a machine
-# with a GPU, [metal] or [cuda]. It must be 0.18.0 or later; the setup script
-# checks what it landed on and says so if it is older. Earlier servers default
-# to more than one inference slot, which aborts the process on Apple silicon.
+# Pantogloss is not listed here because the extras it needs depend on the
+# machine: bigtranslate-setup installs it with the [server] extra and, where
+# there is a GPU, [metal] or [cuda]. It must be 0.19.0 or later; the setup
+# script checks what it landed on and says so if it is older. Earlier servers
+# cannot batch concurrent callers into one model call, so on Apple silicon
+# they translate one request at a time.

--- a/tests/test_translate_service.py
+++ b/tests/test_translate_service.py
@@ -175,20 +175,19 @@ def test_the_model_is_not_loaded_in_this_process():
 
 
 def test_setup_requires_a_pantogloss_new_enough_to_be_safe():
-    """0.18.0 defaults the server to one inference slot.
+    """0.19.0 serialises concurrent callers into the model itself.
 
-    Earlier ones default to more, and more than one is what aborts the process
-    on Apple silicon: concurrent translate() calls share a Keras model and a
-    Metal execution context, and MPSGraph asserts on the mismatched shapes.
-    Pantogloss is not published, so PANTOGLOSS_SOURCE is usually a working
-    checkout and pip has no version to resolve against; what it lands on is
-    whatever that checkout is on, which is why this is checked afterwards
-    rather than asked for in the specifier.
+    Earlier servers ran them straight into a shared Keras model and Metal
+    execution context, and MPSGraph aborted the process on the mismatched
+    shapes; 0.18.0 avoided that by allowing only one at a time. The version
+    is checked after installing rather than asked for in the specifier
+    because PANTOGLOSS_SOURCE may be a working checkout, whose reported
+    version is whatever its pyproject says.
     """
     setup = (REPO / "distribution" / "src" / "main" / "resources"
              / "bin" / "bigtranslate-setup").read_text()
     assert "PANTOGLOSS_REQUIRED" in setup, "no version floor is declared"
-    assert "0.18.0" in setup, "the floor is not 0.18.0"
+    assert "0.19.0" in setup, "the floor is not 0.19.0"
     assert "importlib.metadata" in setup, (
         "the installed version is never read, so the floor is not enforced")
     assert "TOO OLD" in setup, "an older Pantogloss is installed silently"
@@ -197,7 +196,51 @@ def test_setup_requires_a_pantogloss_new_enough_to_be_safe():
 def test_the_floor_can_be_overridden():
     setup = (REPO / "distribution" / "src" / "main" / "resources"
              / "bin" / "bigtranslate-setup").read_text()
-    assert "${PANTOGLOSS_REQUIRED:-0.18.0}" in setup
+    assert "${PANTOGLOSS_REQUIRED:-0.19.0}" in setup
+
+
+def test_pantogloss_is_installed_from_pypi_by_default():
+    """It is published now, so setup no longer needs a checkout to point at."""
+    setup = (REPO / "distribution" / "src" / "main" / "resources"
+             / "bin" / "bigtranslate-setup").read_text()
+    assert "PANTOGLOSS_SOURCE=${PANTOGLOSS_SOURCE:-pantogloss}" in setup, (
+        "without a source the setup installs no Pantogloss at all")
+
+
+def test_the_metal_single_slot_clamp_is_gated_on_the_version():
+    """The clamp belongs to the old server, not to Apple silicon.
+
+    0.19 admits callers concurrently and funnels them through one TensorFlow
+    worker, so pinning Metal to a single slot there reintroduces exactly the
+    queue the single slot caused: on the ten-file corpus it left 26,921
+    summed queue seconds against 3,973 of inference.
+    """
+    oodt = (REPO / "distribution" / "src" / "main" / "resources"
+            / "bin" / "oodt").read_text()
+    assert "pantogloss_batches_dynamically" in oodt, (
+        "nothing asks whether the server can batch for us")
+    assert "! pantogloss_batches_dynamically" in oodt, (
+        "the single-slot clamp is not gated on the version")
+
+
+def test_dynamic_batching_flags_are_only_sent_to_servers_that_have_them():
+    """An older server treats them as unknown arguments and refuses to start."""
+    oodt = (REPO / "distribution" / "src" / "main" / "resources"
+            / "bin" / "oodt").read_text()
+    assert "--dynamic-batch-wait-ms" in oodt, "the collection window is never set"
+    assert "--max-coalesced-batch-size" in oodt
+    body = oodt[oodt.index("batching=\"\""):oodt.index("--dynamic-batch-wait-ms")]
+    assert "pantogloss_batches_dynamically" in body, (
+        "the flags are sent unconditionally")
+
+
+def test_the_batching_window_is_configurable():
+    env = (REPO / "distribution" / "src" / "main" / "resources"
+           / "bin" / "setenv.sh").read_text()
+    for name in ("PANTOGLOSS_BATCH_WAIT_MS", "PANTOGLOSS_COALESCED_BATCH",
+                 "PANTOGLOSS_COALESCED_CHARS"):
+        assert "export %s=${%s:-" % (name, name) in env, (
+            "%s cannot be overridden" % name)
 
 
 class _Busy(_Handler):

--- a/tests/test_workflow_wait.py
+++ b/tests/test_workflow_wait.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The run ends when the work does.
+
+"grep -c" exits 1 when it counts nothing, so a "|| echo 0" fallback fires on
+exactly the case it was written to report and appends a second line. The
+count became "0\\n0", the caller compared it against "0", and a run whose
+translations had finished in forty-eight minutes sat in its wait loop for
+another three hours announcing "0 workflow instances still running".
+"""
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DRIVER = REPO / "distribution" / "src" / "main" / "resources" / "bin" / "bigtranslate"
+
+
+def count_with(instance_listing):
+    """Run running_instance_count against a stub wmgr-client."""
+    body = subprocess.run(
+        ["sed", "-n", "/^running_instance_count() {/,/^}/p", str(DRIVER)],
+        capture_output=True, text=True, check=True).stdout
+    assert body.strip(), "running_instance_count is not in the driver script"
+    stub = (
+        'BIGTRANSLATE_HOME=$PWD\n'
+        'CLIENT_URL=stub\n'
+        'mkdir -p workflow/bin\n'
+        'cat > workflow/bin/wmgr-client <<"STUB"\n'
+        '#!/bin/bash\n'
+        'cat <<"LISTING"\n'
+        + instance_listing +
+        '\nLISTING\n'
+        'STUB\n'
+        'chmod +x workflow/bin/wmgr-client\n'
+    )
+    result = subprocess.run(["bash", "-c", stub + body + "\nrunning_instance_count\n"],
+                            capture_output=True, text=True, cwd="/tmp")
+    return result.stdout
+
+
+def test_nothing_running_counts_as_zero_on_one_line():
+    """The whole bug: the answer has to be usable by "=" against "0"."""
+    out = count_with("id=a status=FINISHED\nid=b status=FINISHED")
+    assert out == "0\n", (
+        "expected a single '0', got %r -- a caller comparing this to '0' "
+        "never matches and waits out a finished run" % out)
+
+
+def test_running_instances_are_counted():
+    out = count_with(
+        "id=a status=FINISHED\nid=b status=PGE\nid=c status=QUEUED")
+    assert out == "2\n", "expected '2', got %r" % out
+
+
+def test_every_terminal_status_is_excluded():
+    out = count_with("\n".join(
+        "id=%d status=%s" % (i, s) for i, s in enumerate(
+            ["FINISHED", "ERROR", "Success", "Failure", "Stopped"])))
+    assert out == "0\n", "a terminal status is being counted as running"
+
+
+def test_an_unanswered_manager_is_not_reported_as_finished():
+    """Silence is not completion.
+
+    Reporting zero for an unreachable manager ends the run early and calls a
+    partial corpus a finished one.
+    """
+    out = count_with("")
+    assert out.strip() == "unknown", (
+        "an empty answer reported as %r; a run would end on one bad poll"
+        % out.strip())
+
+
+def test_the_wait_loop_stops_on_a_clean_zero():
+    """The fix is only useful if the loop it feeds actually exits."""
+    source = DRIVER.read_text()
+    body = source[source.index("wait_for_workflow() {"):]
+    body = body[:body.index("\n}\n") + 3]
+    script = (
+        'TRANSLATE_TIMEOUT=100\nTRANSLATE_POLL=1\n'
+        'say() { echo "$@"; }\n'
+        # A file, not a variable: the caller reads this through $(...), and
+        # a subshell's increment is lost the moment it exits.
+        'C=$(mktemp)\n'
+        'echo 0 > "$C"\n'
+        'running_instance_count() {\n'
+        '  n=$(( $(cat "$C") + 1 )); echo "$n" > "$C"\n'
+        '  if [ "$n" -le 2 ]; then echo 3; else echo 0; fi\n'
+        '}\n'
+        + body +
+        '\nwait_for_workflow && echo EXITED_CLEANLY\n'
+    )
+    result = subprocess.run(["bash", "-c", script],
+                            capture_output=True, text=True, timeout=60)
+    assert "EXITED_CLEANLY" in result.stdout, (
+        "the wait loop never returned:\n%s" % result.stdout[-500:])
+    assert "Workflow finished" in result.stdout
+
+
+def test_the_wait_loop_does_not_stop_while_the_manager_is_silent():
+    source = DRIVER.read_text()
+    body = source[source.index("wait_for_workflow() {"):]
+    body = body[:body.index("\n}\n") + 3]
+    script = (
+        'TRANSLATE_TIMEOUT=4\nTRANSLATE_POLL=1\n'
+        'say() { echo "$@"; }\n'
+        'running_instance_count() { echo unknown; }\n'
+        + body +
+        '\nwait_for_workflow && echo EXITED_CLEANLY\n'
+    )
+    result = subprocess.run(["bash", "-c", script],
+                            capture_output=True, text=True, timeout=60)
+    assert "EXITED_CLEANLY" not in result.stdout, (
+        "a silent manager ended the run as though it had finished")


### PR DESCRIPTION
0.19 serialises concurrent callers into the model itself and combines those already waiting into one call, which is what 0.18 could not do. Our single-slot workaround was safe and extremely slow: on the ten-file corpus it accumulated 26,921 summed queue seconds against 3,973 of inference, and the run was abandoned at 1,125 of 43,851 documents.

**What changes**

- The Metal single-slot clamp is gated on the installed version rather than on the platform, so 0.19 gets the workflow pool size (8) like the CPU does.
- `--dynamic-batch-wait-ms`, `--max-coalesced-batch-size` and `--max-coalesced-input-characters` are passed only to servers that have them; an older server rejects unknown arguments at startup rather than ignoring them.
- Three new overridable settings in `setenv.sh`, defaulting to Pantogloss's own 10ms window, 64, and 200000.
- Floor raised to 0.19.0, and since Pantogloss is on PyPI now, `PANTOGLOSS_SOURCE` defaults to its name instead of requiring a checkout.

**What this does not claim**

It does not show Metal is faster than CPU for our shape. Metal measured 9.03s per 32-string batch against the CPU's 2.82s; batching addresses the queue, not the device. Coalescing is also timing-dependent, and with 32-input requests against a 64-input combined call at most two of ours ever merge. The matched comparison is the next run.

286 tests pass, 4 of them new.