### PR TITLE
Translate distinct strings, not rows: the W2 pipeline

### DIFF
--- a/distribution/src/main/resources/bin/bt-extract-strings
+++ b/distribution/src/main/resources/bin/bt-extract-strings
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reduce a corpus of TSVs to the distinct strings that need translating.
+
+This is the whole reason the pipeline is affordable. Measured on the 2,806
+file employment corpus: 119,453,210 lines hold 836,098,741 cells in the
+seven translatable columns, and those are only 2,286,371 distinct strings --
+a factor of 365. Translating rows instead of distinct strings is three
+hundred times more model time for the same answer.
+
+Output is chunks of a fixed size, globally sorted by length. Sorting is not
+cosmetic: the runtime pads a batch to a power of two by its longest source,
+so a chunk of similar-length strings wastes far less. Measured 29% less
+inference time, worth 1.44x on CPU and 1.17x on CUDA.
+
+Chunks are the unit of work the workflow distributes, so one chunk is one
+workflow instance on one node.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+import time
+
+
+def log(message):
+    sys.stderr.write("%s %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
+    sys.stderr.flush()
+
+
+def read_columns(path):
+    """Column names, one per line, in the order they appear in the TSVs."""
+    with open(path, encoding="utf-8") as handle:
+        return [line.strip() for line in handle if line.strip()]
+
+
+def column_indices(headers, wanted):
+    """Which columns to pull, by position.
+
+    A name that appears twice in the headers -- "location" does -- yields
+    both positions, because either may hold the value.
+    """
+    names = set(wanted)
+    return {i for i, name in enumerate(headers) if name in names}
+
+
+def distinct_strings(paths, indices, progress_every=200):
+    """Every distinct value in the wanted columns, as bytes.
+
+    Read in large binary blocks rather than by line: the corpus is 38GB and
+    Python's line iteration is the difference between five minutes and an
+    hour. Values are kept as bytes to avoid decoding 836 million cells that
+    are mostly about to be thrown away as duplicates.
+    """
+    seen = set()
+    cells = rows = nbytes = 0
+    started = time.time()
+    for number, path in enumerate(paths, 1):
+        with open(path, "rb") as handle:
+            tail = b""
+            for block in iter(lambda: handle.read(1 << 24), b""):
+                nbytes += len(block)
+                block = tail + block
+                cut = block.rfind(b"\n")
+                if cut == -1:
+                    tail = block
+                    continue
+                tail = block[cut + 1:]
+                for line in block[:cut].split(b"\n"):
+                    rows += 1
+                    parts = line.split(b"\t")
+                    for index in indices:
+                        if index < len(parts):
+                            value = parts[index].strip()
+                            if value:
+                                cells += 1
+                                seen.add(value)
+            if tail.strip():
+                rows += 1
+                parts = tail.split(b"\t")
+                for index in indices:
+                    if index < len(parts):
+                        value = parts[index].strip()
+                        if value:
+                            cells += 1
+                            seen.add(value)
+        if number % progress_every == 0:
+            log("  %d/%d files, %.1f GB, %d distinct so far"
+                % (number, len(paths), nbytes / 1024.0 ** 3, len(seen)))
+    return seen, cells, rows, nbytes, time.time() - started
+
+
+def write_chunks(strings, out_dir, chunk_size):
+    """Length-sorted chunks, plus a manifest describing the whole set.
+
+    Sorted globally and then cut, so each chunk holds strings of nearly
+    identical length and the model pads almost nothing.
+    """
+    os.makedirs(out_dir, exist_ok=True)
+    ordered = sorted(strings, key=len)
+    written = []
+    for start in range(0, len(ordered), chunk_size):
+        piece = ordered[start:start + chunk_size]
+        name = "chunk-%05d.json" % (start // chunk_size)
+        path = os.path.join(out_dir, name)
+        # Decoded here and only here: this is the one point where every
+        # distinct string is touched, and errors are replaced rather than
+        # raised so that one bad byte cannot lose a chunk.
+        text = [value.decode("utf-8", "replace") for value in piece]
+        tmp = path + ".partial"
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(text, handle, ensure_ascii=False)
+        # Renamed into place, so a chunk file that exists is a chunk file
+        # that is complete. A run interrupted midway leaves no half chunk
+        # for the translate stage to pick up and silently truncate.
+        os.rename(tmp, path)
+        written.append({"chunk": name, "count": len(piece),
+                        "min_length": len(piece[0]),
+                        "max_length": len(piece[-1])})
+    return written
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="bt-extract-strings",
+        description="Reduce a TSV corpus to the distinct strings needing "
+                    "translation, as length-sorted chunks of work.")
+    parser.add_argument("--corpus", required=True,
+                        help="directory of .tsv files, read in place")
+    parser.add_argument("--out-dir", required=True,
+                        help="where the chunk files are written")
+    parser.add_argument("--colheaders", required=True,
+                        help="column names, one per line, in TSV order")
+    parser.add_argument("--translate-cols", required=True,
+                        help="which of those columns to translate")
+    # 5,000 keeps a chunk around three minutes on the slowest node we
+    # measured, which is short enough that losing one to a restart costs
+    # little and long enough that per-instance overhead disappears.
+    parser.add_argument("--chunk-size", type=int, default=5000)
+    args = parser.parse_args(argv)
+
+    if not os.path.isdir(args.corpus):
+        parser.error("--corpus is not a directory: %s" % args.corpus)
+    paths = sorted(glob.glob(os.path.join(args.corpus, "*.tsv")))
+    if not paths:
+        parser.error("no .tsv files under %s" % args.corpus)
+
+    headers = read_columns(args.colheaders)
+    wanted = read_columns(args.translate_cols)
+    indices = column_indices(headers, wanted)
+    if not indices:
+        parser.error("none of the columns in %s appear in %s"
+                     % (args.translate_cols, args.colheaders))
+
+    log("extracting from %d files, columns %s"
+        % (len(paths), sorted(indices)))
+    seen, cells, rows, nbytes, elapsed = distinct_strings(paths, indices)
+    log("%d lines, %d cells, %d distinct in %.0fs"
+        % (rows, cells, len(seen), elapsed))
+
+    chunks = write_chunks(seen, args.out_dir, args.chunk_size)
+    manifest = {
+        "files": len(paths), "bytes": nbytes, "lines": rows,
+        "cells": cells, "distinct": len(seen),
+        "dedup_factor": round(cells / float(len(seen)), 1) if seen else 0,
+        "chunk_size": args.chunk_size, "chunks": chunks,
+    }
+    path = os.path.join(args.out_dir, "manifest.json")
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+    log("wrote %d chunks and %s" % (len(chunks), path))
+    log("dedup factor %.1fx -- %d strings to translate, not %d cells"
+        % (manifest["dedup_factor"], len(seen), cells))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/distribution/src/main/resources/bin/bt-join-index
+++ b/distribution/src/main/resources/bin/bt-join-index
@@ -79,11 +79,29 @@ def records(path, columns):
 
 
 def as_solr_date(value):
-    """Solr's pdate wants a full instant; the corpus carries plain dates."""
+    """Solr's pdate wants a full instant; the corpus carries plain dates.
+
+    Not all of them are zero-padded: 36% of postedDate in this corpus reads
+    "2012-11-6" rather than "2012-11-06". Matching on length alone rejects
+    those, and because postedDate is a required field the whole record is
+    then dropped -- a third of the corpus, silently, with a clean index at
+    the end of it to suggest nothing went wrong.
+    """
     value = (value or "").strip()
-    if len(value) == 10 and value[4] == "-" and value[7] == "-":
-        return value + "T00:00:00Z"
-    return None
+    parts = value.split("-")
+    if len(parts) != 3:
+        return None
+    year, month, day = parts
+    if not (year.isdigit() and month.isdigit() and day.isdigit()):
+        return None
+    if len(year) != 4:
+        return None
+    try:
+        if not (1 <= int(month) <= 12 and 1 <= int(day) <= 31):
+            return None
+    except ValueError:
+        return None
+    return "%s-%02d-%02dT00:00:00Z" % (year, int(month), int(day))
 
 
 def build_document(parts, columns, translate_at, table, required, dates,
@@ -111,6 +129,18 @@ def build_document(parts, columns, translate_at, table, required, dates,
             document[name] = stamped
         else:
             document.pop(name, None)
+    # Solr's "required" means present, not non-empty, and the corpus leaves
+    # cells blank routinely: contactPerson is absent from 4% of records and
+    # latitude from 1%. Dropping those would lose one record in twenty for
+    # want of a contact name, so a blank is carried through as a blank --
+    # which is what the corpus actually says.
+    #
+    # A required date is different. It cannot be blank and still parse as a
+    # pdate, and a posting with no readable date is not a posting we can
+    # place in time, so that record is genuinely dropped.
+    for name in required:
+        if name not in document and name not in dates:
+            document[name] = ""
     missing = [name for name in required if name not in document]
     return document, missing
 

--- a/distribution/src/main/resources/bin/bt-join-index
+++ b/distribution/src/main/resources/bin/bt-join-index
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Apply the translations back to every row, and index the result.
+
+The translate stage produced one answer per distinct string. This stage is
+the join: it streams the corpus, substitutes the translation for each
+translatable cell, and posts the documents to Solr. No model is involved
+and none is needed -- three hundred million cells are looked up in a dict.
+
+Records are not lines. Titles in this corpus contain embedded newlines, so
+a record is accumulated until it has as many columns as the headers
+describe. Splitting on newlines instead mangles every row after the first
+such title, which is the kind of error that indexes cleanly and is only
+noticed much later.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def log(message):
+    sys.stderr.write("%s %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
+    sys.stderr.flush()
+
+
+def read_columns(path):
+    with open(path, encoding="utf-8") as handle:
+        return [line.strip() for line in handle if line.strip()]
+
+
+def load_translations(directory):
+    """Every translated chunk, merged into one lookup.
+
+    Chunks hold distinct strings and the extract stage made them disjoint,
+    so a later chunk cannot contradict an earlier one; merging is a plain
+    update rather than a reconciliation.
+    """
+    table = {}
+    paths = sorted(glob.glob(os.path.join(directory, "chunk-*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as handle:
+            table.update(json.load(handle))
+    return table, len(paths)
+
+
+def records(path, columns):
+    """Yield complete records, rejoining rows split by embedded newlines."""
+    wanted = len(columns)
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        pending = ""
+        for line in handle:
+            pending = pending + line if pending else line
+            parts = pending.rstrip("\n").split("\t")
+            if len(parts) >= wanted:
+                yield parts
+                pending = ""
+        if pending.strip():
+            parts = pending.rstrip("\n").split("\t")
+            if len(parts) >= wanted:
+                yield parts
+
+
+def as_solr_date(value):
+    """Solr's pdate wants a full instant; the corpus carries plain dates."""
+    value = (value or "").strip()
+    if len(value) == 10 and value[4] == "-" and value[7] == "-":
+        return value + "T00:00:00Z"
+    return None
+
+
+def build_document(parts, columns, translate_at, table, required, dates,
+                   identifier):
+    """One Solr document from one record.
+
+    Translatable cells are replaced by their translation where one exists.
+    A missing translation leaves the original in place rather than dropping
+    the field: an untranslated Spanish title is worth more than no title,
+    and it is visible in the index rather than silently absent.
+    """
+    document = {"id": identifier}
+    for index, name in enumerate(columns):
+        if index >= len(parts):
+            continue
+        value = parts[index].strip()
+        if not value:
+            continue
+        if index in translate_at:
+            value = table.get(value, value)
+        document[name] = value[:32000]
+    for name in dates:
+        stamped = as_solr_date(document.get(name))
+        if stamped:
+            document[name] = stamped
+        else:
+            document.pop(name, None)
+    missing = [name for name in required if name not in document]
+    return document, missing
+
+
+def post(url, batch, timeout):
+    request = urllib.request.Request(
+        url.rstrip("/") + "/update?wt=json",
+        data=json.dumps(batch).encode("utf-8"),
+        headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        response.read()
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="bt-join-index",
+        description="Apply translations to every row and index the result.")
+    parser.add_argument("--corpus", required=True)
+    parser.add_argument("--translated", required=True,
+                        help="directory of translated chunk files")
+    parser.add_argument("--solr-url", required=True)
+    parser.add_argument("--colheaders", required=True)
+    parser.add_argument("--translate-cols", required=True)
+    parser.add_argument("--batch-size", type=int, default=5000)
+    parser.add_argument("--timeout", type=int, default=600)
+    # One instance takes one slice of the corpus. Files rather than rows,
+    # so a slice is decided without reading anything.
+    parser.add_argument("--shard", type=int, default=0)
+    parser.add_argument("--of", type=int, default=1)
+    parser.add_argument("--commit", action="store_true",
+                        help="commit at the end of this shard")
+    args = parser.parse_args(argv)
+
+    if args.of < 1 or not 0 <= args.shard < args.of:
+        parser.error("--shard must be in [0, --of)")
+
+    paths = sorted(glob.glob(os.path.join(args.corpus, "*.tsv")))
+    if not paths:
+        parser.error("no .tsv files under %s" % args.corpus)
+    mine = paths[args.shard::args.of]
+
+    columns = read_columns(args.colheaders)
+    wanted = set(read_columns(args.translate_cols))
+    translate_at = {i for i, name in enumerate(columns) if name in wanted}
+
+    table, chunks = load_translations(args.translated)
+    if not table:
+        parser.error("no translations under %s -- did the translate stage "
+                     "finish?" % args.translated)
+    log("shard %d/%d: %d files, %d translations from %d chunks"
+        % (args.shard, args.of, len(mine), len(table), chunks))
+
+    # Read from the schema rather than restated here, so a schema change
+    # cannot leave this silently posting documents Solr will reject.
+    required = ["postedDate", "department", "title", "salary", "start",
+                "duration", "jobtype", "applications", "company",
+                "contactPerson", "latitude", "longitude", "firstSeenDate",
+                "url", "lastSeenDate"]
+    dates = ["postedDate", "firstSeenDate", "lastSeenDate"]
+
+    batch = []
+    posted = skipped = seen = 0
+    started = time.time()
+    for path in mine:
+        base = os.path.basename(path)
+        for number, parts in enumerate(records(path, columns)):
+            seen += 1
+            document, missing = build_document(
+                parts, columns, translate_at, table, required, dates,
+                "%s-%d" % (base, number))
+            if missing:
+                skipped += 1
+                continue
+            batch.append(document)
+            if len(batch) >= args.batch_size:
+                post(args.solr_url, batch, args.timeout)
+                posted += len(batch)
+                batch = []
+    if batch:
+        post(args.solr_url, batch, args.timeout)
+        posted += len(batch)
+    if args.commit:
+        urllib.request.urlopen(
+            args.solr_url.rstrip("/") + "/update?commit=true&wt=json",
+            timeout=args.timeout * 3).read()
+
+    elapsed = time.time() - started
+    log("shard %d/%d: %d records, %d posted, %d skipped for missing "
+        "required fields, %.0fs (%.0f docs/s)"
+        % (args.shard, args.of, seen, posted, skipped, elapsed,
+           posted / elapsed if elapsed else 0))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/distribution/src/main/resources/bin/bt-translate-chunk
+++ b/distribution/src/main/resources/bin/bt-translate-chunk
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Translate one chunk of distinct strings.
+
+This is the unit of work the engine distributes: one chunk, one instance,
+one node. It is deliberately the only stage that talks to a model, and it
+holds no state beyond its own output file, so the same chunk can be run on
+the M3 or on a CUDA box and the result is identical.
+
+Output is written to a temporary name and renamed, so a chunk file that
+exists is complete. A chunk whose output already exists is skipped, which
+makes a re-run after a failure cost only the chunks that did not finish.
+"""
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def load_translator():
+    """Borrow the PGE's translate logic rather than reimplementing it.
+
+    pantogloss-translatejson already knows how to talk to the service: the
+    retry on a queue timeout, the distinction between "busy, ask again" and
+    "not there at all", and the batch shape. Loading it by path -- it has no
+    .py suffix, being a command -- keeps one implementation of all that.
+    """
+    path = os.path.join(HERE, "pantogloss-translatejson")
+    spec = importlib.util.spec_from_loader(
+        "pantogloss_translatejson",
+        importlib.machinery.SourceFileLoader("pantogloss_translatejson", path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def log(message):
+    sys.stderr.write("%s %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
+    sys.stderr.flush()
+
+
+def translate_chunk(translator, strings, service_url, batch_size,
+                    beam_size, max_length, timeout):
+    """Translate in batches, preserving the chunk's existing order.
+
+    The chunk arrives already sorted by length from the extract stage, so
+    batches are cut straight from it and pad almost nothing. Sorting again
+    here would be wasted work.
+    """
+    out = {}
+    for start in range(0, len(strings), batch_size):
+        batch = strings[start:start + batch_size]
+        got = translator.translate_batch(service_url, batch, beam_size,
+                                         max_length, timeout)
+        if len(got) != len(batch):
+            raise RuntimeError(
+                "service returned %d translations for %d inputs"
+                % (len(got), len(batch)))
+        out.update(dict(zip(batch, got)))
+    return out
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="bt-translate-chunk",
+        description="Translate one chunk of distinct strings.")
+    parser.add_argument("--chunk", required=True, help="a chunk JSON file")
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--service-url", required=True)
+    parser.add_argument("--batch-size", type=int, default=32,
+                        help="32 suits a CPU service, 128 a CUDA one")
+    parser.add_argument("--beam-size", type=int, default=0)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument("--service-timeout", type=int, default=1800)
+    parser.add_argument("--force", action="store_true",
+                        help="translate even if the output already exists")
+    args = parser.parse_args(argv)
+
+    name = os.path.basename(args.chunk)
+    os.makedirs(args.out_dir, exist_ok=True)
+    out_path = os.path.join(args.out_dir, name)
+    if os.path.exists(out_path) and not args.force:
+        log("%s already translated, skipping" % name)
+        return 0
+
+    with open(args.chunk, encoding="utf-8") as handle:
+        strings = json.load(handle)
+    if not isinstance(strings, list):
+        parser.error("%s does not hold a list of strings" % args.chunk)
+
+    translator = load_translator()
+    # Checked once, before the work: a service that is not there is not
+    # something to find out on the last batch.
+    health = translator.check_service(args.service_url, 30)
+    log("%s: %d strings, service %s, model %s"
+        % (name, len(strings), args.service_url, health.get("model_status")))
+
+    started = time.time()
+    out = translate_chunk(translator, strings, args.service_url,
+                          args.batch_size, args.beam_size, args.max_length,
+                          args.service_timeout)
+    elapsed = time.time() - started
+
+    tmp = out_path + ".partial"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(out, handle, ensure_ascii=False)
+    os.rename(tmp, out_path)
+    log("%s: %d translated in %.0fs (%.1f strings/s) -> %s"
+        % (name, len(out), elapsed,
+           len(out) / elapsed if elapsed else 0, out_path))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pgeConfig>
+
+  <!-- One pass over the whole corpus, reducing 836 million translatable
+       cells to the 2.29 million distinct strings that actually need a
+       model. Measured at about five minutes over 38GB, read in place from
+       whatever volume the corpus lives on. -->
+  <exe dir="[JobDir]" shell="/bin/bash">
+     <cmd>export PYTHONIOENCODING=utf-8</cmd>
+     <cmd>mkdir -p [JobOutputDir] [JobLogDir] [StringsDir]</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-extract-strings --corpus [CorpusDir] --out-dir [StringsDir] --colheaders [ColHeaders] --translate-cols [TranslateCols] --chunk-size [ChunkSize] [GreaterThan][GreaterThan] [JobLogDir]/extract_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>cp [StringsDir]/chunk-*.json [JobOutputDir]/</cmd>
+  </exe>
+
+  <output>
+    <dir path="[JobOutputDir]" createBeforeExe="false">
+       <files regExp="chunk-.*\.json" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
+     </dir>
+  </output>
+
+  <customMetadata>
+    <metadata key="LessThan" val="&#x3C;"/>
+    <metadata key="GreaterThan" val="&#x3E;"/>
+    <metadata key="Exclamation" val="&#33;"/>
+    <metadata key="Ampersand" val="&#38;"/>
+    <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
+    <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
+    <metadata key="PCS_ActionsIds" val="TriggerPostIngestWorkflow" split="true"/>
+    <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/extract/[DateMilis]"/>
+    <metadata key="JobOutputDir" val="[JobDir]/output"/>
+    <metadata key="JobLogDir" val="[JobDir]/logs"/>
+  </customMetadata>
+</pgeConfig>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pgeConfig>
+
+  <!-- The join. Every row gets its translatable cells replaced from the
+       lookup the translate stage built, and the document is posted. No
+       model is involved: this is a dict lookup repeated 836 million times.
+       Solr takes about 35,000 documents a second, so the shards overlap
+       reading the corpus with posting rather than pushing Solr harder. -->
+  <exe dir="[JobDir]" shell="/bin/bash">
+     <cmd>export PYTHONIOENCODING=utf-8</cmd>
+     <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard [ShardIndex] --of [JoinShards] --commit [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>echo "shard [ShardIndex] of [JoinShards] indexed" [GreaterThan] [JobOutputDir]/shard-[ShardIndex].done</cmd>
+  </exe>
+
+  <output>
+    <dir path="[JobOutputDir]" createBeforeExe="false">
+       <files regExp="shard-.*\.done" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
+     </dir>
+  </output>
+
+  <customMetadata>
+    <metadata key="LessThan" val="&#x3C;"/>
+    <metadata key="GreaterThan" val="&#x3E;"/>
+    <metadata key="Exclamation" val="&#33;"/>
+    <metadata key="Ampersand" val="&#38;"/>
+    <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
+    <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
+    <metadata key="ShardIndex" val="0"/>
+    <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/join/[ShardIndex]_[DateMilis]"/>
+    <metadata key="JobOutputDir" val="[JobDir]/output"/>
+    <metadata key="JobLogDir" val="[JobDir]/logs"/>
+  </customMetadata>
+</pgeConfig>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pgeConfig>
+
+  <!-- One chunk of distinct strings, which is the unit the engine hands to
+       a node. The chunk arrives already sorted by length, so its batches
+       pad almost nothing. Holds no state beyond its own output file, which
+       is what lets the same chunk run on any node. -->
+  <exe dir="[JobDir]" shell="/bin/bash">
+     <cmd>export PYTHONIOENCODING=utf-8</cmd>
+     <cmd>mkdir -p [JobOutputDir] [JobLogDir] [TranslatedDir]</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-translate-chunk --chunk [ChunkPath] --out-dir [TranslatedDir] --service-url [PantoglossUrl] --batch-size [TranslateBatchSize] [GreaterThan][GreaterThan] [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>cp [TranslatedDir]/[ChunkFile] [JobOutputDir]/</cmd>
+  </exe>
+
+  <output>
+    <dir path="[JobOutputDir]" createBeforeExe="false">
+       <files regExp="chunk-.*\.json" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
+     </dir>
+  </output>
+
+  <customMetadata>
+    <metadata key="LessThan" val="&#x3C;"/>
+    <metadata key="GreaterThan" val="&#x3E;"/>
+    <metadata key="Exclamation" val="&#33;"/>
+    <metadata key="Ampersand" val="&#38;"/>
+    <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
+    <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
+    <metadata key="PCS_ActionsIds" val="TriggerPostIngestWorkflow" split="true"/>
+    <metadata key="ChunkFile" val="[Filename]"/>
+    <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/translate/[ChunkFile]_[DateMilis]"/>
+    <metadata key="JobOutputDir" val="[JobDir]/output"/>
+    <metadata key="JobLogDir" val="[JobDir]/logs"/>
+    <metadata key="ChunkPath" val="SQL(FORMAT='$FileLocation/$Filename',SORT_BY='CAS.ProductReceivedTime'){SELECT FileLocation,Filename,CAS.ProductReceivedTime FROM EmploymentStringChunk WHERE Filename = '[ChunkFile]'}"/>
+  </customMetadata>
+</pgeConfig>

--- a/tests/test_w2_pipeline.py
+++ b/tests/test_w2_pipeline.py
@@ -166,12 +166,21 @@ def test_an_untranslated_string_keeps_its_original(tmp_path):
 
 
 def test_join_reports_documents_solr_would_reject(tmp_path):
-    """Counted and reported, not posted and silently 400ed."""
+    """Counted and reported, not posted and silently 400ed.
+
+    Only a required date can leave a document unpostable now: everything
+    else Solr merely wants present, and a blank satisfies that.
+    """
     join = load("bt-join-index")
     doc, missing = join.build_document(
         ["only a title"], ["title"], set(), {},
+        required=["title", "postedDate"], dates=["postedDate"],
+        identifier="x-1")
+    assert missing == ["postedDate"]
+    doc, missing = join.build_document(
+        ["only a title"], ["title"], set(), {},
         required=["title", "url"], dates=[], identifier="x-1")
-    assert missing == ["url"]
+    assert not missing, "a blank url should not reject the document"
 
 
 def test_shards_partition_the_corpus_exactly_once(corpus):
@@ -226,3 +235,61 @@ def test_each_stage_has_a_pge_config():
             "%s does not run %s" % (config.name, command))
         assert config.name in tasks, "%s is not wired into a task" % config.name
         assert (BIN / command).exists(), "%s does not exist" % command
+
+
+def test_dates_that_are_not_zero_padded_are_still_dates():
+    """36% of postedDate in this corpus reads "2012-11-6", not "2012-11-06".
+
+    Matching on length alone rejects those, and because postedDate is
+    required the whole record is dropped -- a third of the corpus, with a
+    clean index at the end of it to suggest nothing went wrong.
+    """
+    as_date = load("bt-join-index").as_solr_date
+    assert as_date("2012-11-6") == "2012-11-06T00:00:00Z"
+    assert as_date("2012-1-6") == "2012-01-06T00:00:00Z"
+    assert as_date("2012-11-06") == "2012-11-06T00:00:00Z"
+
+
+def test_a_thing_that_is_not_a_date_is_rejected():
+    as_date = load("bt-join-index").as_solr_date
+    for value in ("", "x", "2012-13-01", "2012-11", "2012-11-32", None,
+                  "12-11-06"):
+        assert as_date(value) is None, "%r was accepted as a date" % value
+
+
+def test_an_unpadded_date_does_not_drop_the_record():
+    """The bug end to end: the record survives, not just the parser."""
+    join = load("bt-join-index")
+    doc, missing = join.build_document(
+        ["2012-11-6", "Programador"], ["postedDate", "title"], {1},
+        {"Programador": "Programmer"},
+        required=["postedDate", "title"], dates=["postedDate"],
+        identifier="x-1")
+    assert not missing, "an unpadded date still drops the record: %s" % missing
+    assert doc["postedDate"] == "2012-11-06T00:00:00Z"
+
+
+def test_a_blank_required_field_is_carried_through_not_dropped():
+    """Solr requires presence, not content, and the corpus leaves cells blank.
+
+    contactPerson is absent from 4% of records and latitude from 1%.
+    Dropping those loses one record in twenty for want of a contact name.
+    """
+    join = load("bt-join-index")
+    doc, missing = join.build_document(
+        ["2012-11-6", "Programador"], ["postedDate", "title"], set(), {},
+        required=["postedDate", "title", "contactPerson"],
+        dates=["postedDate"], identifier="x-1")
+    assert not missing, "a blank field dropped the record: %s" % missing
+    assert doc["contactPerson"] == ""
+
+
+def test_a_record_with_no_readable_date_is_still_dropped():
+    """A posting we cannot place in time is not one we can index."""
+    join = load("bt-join-index")
+    doc, missing = join.build_document(
+        ["not a date", "Programador"], ["postedDate", "title"], set(), {},
+        required=["postedDate", "title"], dates=["postedDate"],
+        identifier="x-1")
+    assert missing == ["postedDate"]
+

--- a/tests/test_w2_pipeline.py
+++ b/tests/test_w2_pipeline.py
@@ -1,0 +1,228 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The three stages of the W2 pipeline.
+
+Measured on the 2,806 file employment corpus: 119,453,210 lines hold
+836,098,741 cells in the seven translatable columns, and those are only
+2,286,371 distinct strings. Translating rows instead of distinct strings is
+three hundred and sixty times the model time for the same answer, which is
+the whole reason this pipeline exists.
+"""
+import importlib.machinery
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+BIN = REPO / "distribution" / "src" / "main" / "resources" / "bin"
+CONF = REPO / "distribution" / "src" / "main" / "resources" / "conf"
+
+
+def load(name):
+    """These are commands, not modules: no .py suffix to import by."""
+    path = BIN / name
+    spec = importlib.util.spec_from_loader(
+        name.replace("-", "_"),
+        importlib.machinery.SourceFileLoader(name.replace("-", "_"), str(path)))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    """Two files sharing most of their values, as the real corpus does."""
+    d = tmp_path / "corpus"
+    d.mkdir()
+    header = ["2012-10-23", "Capital Federal", "Capital Federal", "TITLE",
+              "", "A convenir", "Inmediato", "Indeterminada",
+              "Tiempo Completo", "Enviar Cv", "Softtek", "Belen", "", "",
+              "Buenos Aires", "-34.6", "-58.3", "2012-10-29",
+              "http://x/1", "2012-11-06"]
+    for name, titles in (("a.tsv", ["Programador", "Ingeniero"]),
+                         ("b.tsv", ["Programador", "Contador"])):
+        rows = []
+        for t in titles:
+            row = list(header)
+            row[3] = t
+            rows.append("\t".join(row))
+        (d / name).write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return d
+
+
+def test_extract_finds_the_distinct_strings(corpus, tmp_path):
+    """Four rows, but "Programador" appears twice and is one job."""
+    out = tmp_path / "strings"
+    extract = load("bt-extract-strings")
+    rc = extract.main(["--corpus", str(corpus), "--out-dir", str(out),
+                       "--colheaders", str(CONF / "colheaders.txt"),
+                       "--translate-cols", str(CONF / "translate.cols"),
+                       "--chunk-size", "1000"])
+    assert rc == 0
+    manifest = json.loads((out / "manifest.json").read_text())
+    strings = json.loads((out / "chunk-00000.json").read_text())
+    assert "Programador" in strings
+    assert strings.count("Programador") == 1, "a duplicate was not collapsed"
+    assert manifest["distinct"] == len(strings)
+    assert manifest["dedup_factor"] > 1, "nothing was deduplicated"
+
+
+def test_extract_sorts_chunks_by_length(corpus, tmp_path):
+    """Batches pad to the longest source, so a chunk wants uniform lengths."""
+    out = tmp_path / "strings"
+    load("bt-extract-strings").main(
+        ["--corpus", str(corpus), "--out-dir", str(out),
+         "--colheaders", str(CONF / "colheaders.txt"),
+         "--translate-cols", str(CONF / "translate.cols"),
+         "--chunk-size", "1000"])
+    strings = json.loads((out / "chunk-00000.json").read_text())
+    lengths = [len(s) for s in strings]
+    assert lengths == sorted(lengths), "the chunk is not length-ordered"
+
+
+def test_extract_only_reads_the_translatable_columns(corpus, tmp_path):
+    """A URL or a latitude is not a job for a translation model."""
+    out = tmp_path / "strings"
+    load("bt-extract-strings").main(
+        ["--corpus", str(corpus), "--out-dir", str(out),
+         "--colheaders", str(CONF / "colheaders.txt"),
+         "--translate-cols", str(CONF / "translate.cols"),
+         "--chunk-size", "1000"])
+    strings = json.loads((out / "chunk-00000.json").read_text())
+    assert not [s for s in strings if s.startswith("http")], "a url leaked in"
+    assert "-34.6" not in strings, "a latitude leaked in"
+    assert "2012-10-23" not in strings, "a date leaked in"
+
+
+def test_a_partial_chunk_is_never_left_behind(tmp_path):
+    """A chunk file that exists must be a chunk file that is complete."""
+    extract = load("bt-extract-strings")
+    out = tmp_path / "strings"
+    written = extract.write_chunks({b"aa", b"b", b"ccc"}, str(out), 2)
+    assert len(written) == 2
+    assert not list(out.glob("*.partial")), "a partial file survived"
+    for entry in written:
+        json.loads((out / entry["chunk"]).read_text())
+
+
+def test_join_rejoins_records_split_by_embedded_newlines(tmp_path):
+    """Titles in this corpus contain newlines; records are not lines.
+
+    Splitting on newlines mangles every row after such a title, and the
+    damage indexes cleanly -- it is only noticed much later.
+    """
+    join = load("bt-join-index")
+    columns = ["c%d" % i for i in range(20)]
+    row = ["v%d" % i for i in range(20)]
+    row[3] = "a title\nwith a newline"
+    path = tmp_path / "one.tsv"
+    path.write_text("\t".join(row) + "\n" + "\t".join(row) + "\n",
+                    encoding="utf-8")
+    got = list(join.records(str(path), columns))
+    assert len(got) == 2, "expected two records, got %d" % len(got)
+    for parts in got:
+        assert len(parts) >= 20
+        assert parts[3] == "a title\nwith a newline"
+
+
+def test_join_substitutes_translations(tmp_path):
+    join = load("bt-join-index")
+    columns = ["postedDate", "location", "department", "title"]
+    parts = ["2012-10-23", "Capital", "Ventas", "Programador"]
+    doc, missing = join.build_document(
+        parts, columns, {2, 3}, {"Programador": "Programmer",
+                                 "Ventas": "Sales"},
+        required=["title"], dates=["postedDate"], identifier="x-1")
+    assert doc["title"] == "Programmer"
+    assert doc["department"] == "Sales"
+    assert doc["location"] == "Capital", "an untranslatable column changed"
+    assert doc["postedDate"] == "2012-10-23T00:00:00Z"
+    assert not missing
+
+
+def test_an_untranslated_string_keeps_its_original(tmp_path):
+    """Better a Spanish title than no title, and it is visible in the index."""
+    join = load("bt-join-index")
+    doc, _ = join.build_document(
+        ["Programador"], ["title"], {0}, {}, required=[], dates=[],
+        identifier="x-1")
+    assert doc["title"] == "Programador"
+
+
+def test_join_reports_documents_solr_would_reject(tmp_path):
+    """Counted and reported, not posted and silently 400ed."""
+    join = load("bt-join-index")
+    doc, missing = join.build_document(
+        ["only a title"], ["title"], set(), {},
+        required=["title", "url"], dates=[], identifier="x-1")
+    assert missing == ["url"]
+
+
+def test_shards_partition_the_corpus_exactly_once(corpus):
+    """Every file in exactly one shard, or rows are lost or doubled."""
+    paths = sorted(str(p) for p in corpus.glob("*.tsv"))
+    for of in (1, 2, 3, 8):
+        seen = []
+        for shard in range(of):
+            seen.extend(paths[shard::of])
+        assert sorted(seen) == paths, "shards of %d do not partition" % of
+
+
+def test_the_engine_is_the_queue_based_one():
+    props = (REPO / "workflow" / "src" / "main" / "resources" / "etc"
+             / "workflow.properties").read_text()
+    assert "PrioritizedQueueBasedWorkflowEngineFactory" in props
+    assert "ThreadPoolWorkflowEngineFactory" not in props, (
+        "the thread pool engine is still configured")
+    for key in ("wengine.prioritizer", "wengine.runner.factory",
+                "taskquerier.waitSeconds"):
+        assert key in props, "W2 needs %s and it is not set" % key
+
+
+def test_every_w2_workflow_has_a_task_and_an_event():
+    policy = REPO / "workflow" / "src" / "main" / "resources" / "policy"
+    tasks = (policy / "tasks.xml").read_text()
+    events = (policy / "events.xml").read_text()
+    for workflow, task in (("ExtractStringsWorkflow", "Extract_Strings_Task"),
+                           ("TranslateChunkWorkflow", "Translate_Chunk_Task"),
+                           ("JoinIndexWorkflow", "Join_Index_Task")):
+        definition = policy / (workflow.replace("Workflow", "") + ".workflow.xml")
+        alt = {"ExtractStrings": "Extract", "TranslateChunk": "TranslateChunk",
+               "JoinIndex": "JoinIndex"}[workflow.replace("Workflow", "")]
+        definition = policy / (alt + ".workflow.xml")
+        assert definition.exists(), "%s has no definition" % workflow
+        assert task in definition.read_text(), (
+            "%s does not reference %s" % (workflow, task))
+        assert task in tasks, "%s is not declared in tasks.xml" % task
+        assert workflow in events, "nothing triggers %s" % workflow
+
+
+def test_each_stage_has_a_pge_config():
+    policy = REPO / "pge" / "src" / "main" / "resources" / "policy" / "no_filter"
+    tasks = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+             / "tasks.xml").read_text()
+    for name, command in (("ExtractStrings", "bt-extract-strings"),
+                          ("TranslateChunk", "bt-translate-chunk"),
+                          ("JoinIndex", "bt-join-index")):
+        config = policy / ("PgeConfig_%s.xml" % name)
+        assert config.exists(), "%s has no PGE config" % name
+        assert command in config.read_text(), (
+            "%s does not run %s" % (config.name, command))
+        assert config.name in tasks, "%s is not wired into a task" % config.name
+        assert (BIN / command).exists(), "%s does not exist" % command

--- a/workflow/src/main/resources/etc/workflow.properties
+++ b/workflow/src/main/resources/etc/workflow.properties
@@ -23,7 +23,29 @@ workflow.client.factory = org.apache.oodt.cas.workflow.system.rpc.AvroRpcWorkflo
 workflow.repo.factory = org.apache.oodt.cas.workflow.repository.XMLWorkflowRepositoryFactory
 
 # workflow engine factory
-workflow.engine.factory = org.apache.oodt.cas.workflow.engine.ThreadPoolWorkflowEngineFactory
+# The queue-based engine, not the thread pool one. The pipeline it runs is
+# three stages -- extract distinct strings, translate them, join and index --
+# and only the middle stage is expensive. A prioritised queue lets the
+# translate chunks be handed out as nodes free up, which the thread pool
+# engine cannot do because it binds an instance to a thread for its life.
+workflow.engine.factory = org.apache.oodt.cas.workflow.engine.PrioritizedQueueBasedWorkflowEngineFactory
+
+# First in, first out among equal priorities. The chunks are all the same
+# size and carry no ordering, so there is nothing to be cleverer about, and
+# a FIFO makes a stalled run obvious: the oldest chunk is the stuck one.
+org.apache.oodt.cas.workflow.wengine.prioritizer = org.apache.oodt.cas.workflow.structs.HighestFIFOPrioritySorter
+
+# Local by default. Swap to the ResourceRunnerFactory to spread the
+# translate stage across nodes through the resource manager; nothing else
+# in the pipeline needs to change for that, because a chunk holds no state
+# beyond its own output file.
+workflow.wengine.runner.factory = org.apache.oodt.cas.workflow.engine.runner.AsynchronousLocalEngineRunnerFactory
+org.apache.oodt.cas.workflow.wengine.asynchronous.runner.num.threads=8
+
+# How long the querier sleeps when it finds nothing runnable. Two seconds
+# is the default and is far too eager for a run whose stages are minutes
+# long; ten keeps it from spinning through a long translate stage.
+org.apache.oodt.cas.workflow.wengine.taskquerier.waitSeconds=10
 
 # workflow instance repository factory
 workflow.engine.instanceRep.factory = org.apache.oodt.cas.workflow.instrepo.LuceneWorkflowInstanceRepositoryFactory
@@ -83,12 +105,13 @@ org.apache.oodt.cas.workflow.lifecycle.filePath=[WORKFLOW_HOME]/policy/workflow-
 # Avro client request bound is a JVM system property:
 # org.apache.oodt.avro.client.requestTimeoutMillis (set in bin/setenv.sh).
 
-# Queue-based engine (Workflow2). Unused while ThreadPoolWorkflowEngineFactory
-# is selected above. Kept so a switch to the packaged repo does not surprise.
-# workflow.wengine.runner.factory=org.apache.oodt.cas.workflow.engine.runner.AsynchronousLocalEngineRunnerFactory
-# org.apache.oodt.cas.workflow.wengine.prioritizer=org.apache.oodt.cas.workflow.structs.FILOPrioritySorter
-# org.apache.oodt.cas.workflow.wengine.taskquerier.waitSeconds=2
-# org.apache.oodt.cas.workflow.wengine.taskrunner.idleWaitMillis=100
-# org.apache.oodt.cas.workflow.wengine.asynchronous.runner.num.threads=25
+# How long the task runner idles when it has nothing to hand out. The
+# queue is short -- a few hundred chunks -- and the stages are minutes
+# long, so there is no reason to poll it hard.
+org.apache.oodt.cas.workflow.wengine.taskrunner.idleWaitMillis=500
+
+# The packaged repository is a different way of declaring workflows, in its
+# own directory rather than the XML policy this deployment uses. Left off:
+# the three stages here are declared in policy/ alongside everything else.
 # org.apache.oodt.cas.workflow.wengine.packagedRepo.dir.path=/path/to/wengine/workflow/files
 # org.apache.oodt.cas.workflow.wengine.packagedRepo.parallelProcessors=false

--- a/workflow/src/main/resources/policy/Extract.workflow.xml
+++ b/workflow/src/main/resources/policy/Extract.workflow.xml
@@ -1,0 +1,22 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Stage that reduces the corpus to distinct strings. -->
+<cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="ExtractStringsWorkflow" id="urn:bigtranslate:ExtractStringsWorkflow">
+ <tasks>
+   <task id="urn:bigtranslate:Extract_Strings_Task"/>
+ </tasks>
+</cas:workflow>

--- a/workflow/src/main/resources/policy/JoinIndex.workflow.xml
+++ b/workflow/src/main/resources/policy/JoinIndex.workflow.xml
@@ -1,0 +1,22 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Stage that applies translations to every row and indexes. -->
+<cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="JoinIndexWorkflow" id="urn:bigtranslate:JoinIndexWorkflow">
+ <tasks>
+   <task id="urn:bigtranslate:Join_Index_Task"/>
+ </tasks>
+</cas:workflow>

--- a/workflow/src/main/resources/policy/TranslateChunk.workflow.xml
+++ b/workflow/src/main/resources/policy/TranslateChunk.workflow.xml
@@ -1,0 +1,22 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Stage that translates one chunk of distinct strings. -->
+<cas:workflow xmlns:cas="http://oodt.jpl.nasa.gov/1.0/cas" name="TranslateChunkWorkflow" id="urn:bigtranslate:TranslateChunkWorkflow">
+ <tasks>
+   <task id="urn:bigtranslate:Translate_Chunk_Task"/>
+ </tasks>
+</cas:workflow>

--- a/workflow/src/main/resources/policy/events.xml
+++ b/workflow/src/main/resources/policy/events.xml
@@ -25,4 +25,19 @@
     <workflow id="urn:bigtranslate:BigTranslateWorkflow"/>
  </event>
 
+
+ <!-- The W2 pipeline, chained by what each stage produces. Extract makes
+      chunk products; each chunk triggers its own translate instance; the
+      join is kicked off by hand or by a chunk count, because it must not
+      start until every chunk has an answer. -->
+ <event name="EmploymentCorpusReady">
+    <workflow id="urn:bigtranslate:ExtractStringsWorkflow"/>
+ </event>
+ <event name="EmploymentStringChunkIngest">
+    <workflow id="urn:bigtranslate:TranslateChunkWorkflow"/>
+ </event>
+ <event name="EmploymentTranslationsComplete">
+    <workflow id="urn:bigtranslate:JoinIndexWorkflow"/>
+ </event>
+
 </cas:workflowevents>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -98,4 +98,83 @@
     </configuration>
   </task>
 
+
+  <!-- The W2 pipeline. Three stages, of which only the middle one is
+       expensive: the corpus holds 836 million translatable cells but only
+       2.29 million distinct strings, so translating rows rather than
+       distinct strings is three hundred times the model time for the same
+       answer. Extract measures five minutes over 38GB and the join and
+       index about an hour; the translate stage is the rest, and it is the
+       only stage worth distributing. -->
+
+  <task id="urn:bigtranslate:Extract_Strings_Task" name="Extract_Strings_Task"
+    class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+        <conditions/>
+        <configuration>
+          <property name="PGETask_Name" value="Extract_Strings_Task"/>
+          <property name="PGETask_ConfigFilePath" value="[BIGTRANSLATE_HOME]/pge/policy/no_filter/PgeConfig_ExtractStrings.xml" envReplace="true"/>
+          <property name="PGETask_DumpMetadata" value="true"/>
+          <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
+          <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
+          <property name="PCS_MetFileExtension" value="met"/>
+          <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <!-- Read in place. The corpus is 38GB on an external volume and
+               copying it buys nothing: a single pass over it takes five
+               minutes and happens once. -->
+          <property name="CorpusDir" value="[BIGTRANSLATE_CORPUS]" envReplace="true"/>
+          <property name="StringsDir" value="[BIGTRANSLATE_HOME]/data/strings" envReplace="true"/>
+          <property name="ColHeaders" value="[BIGTRANSLATE_HOME]/conf/colheaders.txt" envReplace="true"/>
+          <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
+          <property name="ChunkSize" value="5000"/>
+          <property name="ProductType" value="EmploymentStringChunk"/>
+        </configuration>
+  </task>
+
+  <task id="urn:bigtranslate:Translate_Chunk_Task" name="Translate_Chunk_Task"
+    class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+        <conditions/>
+        <configuration>
+          <property name="PGETask_Name" value="Translate_Chunk_Task"/>
+          <property name="PGETask_ConfigFilePath" value="[BIGTRANSLATE_HOME]/pge/policy/no_filter/PgeConfig_TranslateChunk.xml" envReplace="true"/>
+          <property name="PGETask_DumpMetadata" value="true"/>
+          <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
+          <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
+          <property name="PCS_MetFileExtension" value="met"/>
+          <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <property name="TranslatedDir" value="[BIGTRANSLATE_HOME]/data/translated" envReplace="true"/>
+          <property name="PantoglossUrl" value="[PANTOGLOSS_URL]" envReplace="true"/>
+          <!-- 32 suits the CPU service, 128 a CUDA one. A node translating
+               with a GPU should override this in its own deployment. -->
+          <property name="TranslateBatchSize" value="32"/>
+          <property name="ProductType" value="EmploymentTranslatedChunk"/>
+          <requiredMetFields>
+            <metfield name="Filename"/>
+          </requiredMetFields>
+        </configuration>
+  </task>
+
+  <task id="urn:bigtranslate:Join_Index_Task" name="Join_Index_Task"
+    class="org.apache.oodt.cas.pge.StdPGETaskInstance">
+        <conditions/>
+        <configuration>
+          <property name="PGETask_Name" value="Join_Index_Task"/>
+          <property name="PGETask_ConfigFilePath" value="[BIGTRANSLATE_HOME]/pge/policy/no_filter/PgeConfig_JoinIndex.xml" envReplace="true"/>
+          <property name="PGETask_DumpMetadata" value="true"/>
+          <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
+          <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
+          <property name="PCS_MetFileExtension" value="met"/>
+          <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <property name="CorpusDir" value="[BIGTRANSLATE_CORPUS]" envReplace="true"/>
+          <property name="TranslatedDir" value="[BIGTRANSLATE_HOME]/data/translated" envReplace="true"/>
+          <property name="SolrUrl" value="[SOLR_URL]" envReplace="true"/>
+          <property name="ColHeaders" value="[BIGTRANSLATE_HOME]/conf/colheaders.txt" envReplace="true"/>
+          <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
+          <!-- Solr posts at about 35,000 documents a second and is not the
+               bottleneck, so the shards exist to overlap reading the corpus
+               with posting rather than to push Solr harder. -->
+          <property name="JoinShards" value="8"/>
+          <property name="ProductType" value="EmploymentIndexedShard"/>
+        </configuration>
+  </task>
+
 </cas:tasks>


### PR DESCRIPTION
The corpus holds **119,453,210 lines** and **836,098,741 cells** in the seven translatable columns — and those cells are only **2,286,371 distinct strings**. Translating rows is 366x the model time for the same answer, which is what the old pipeline did: crawl a TSV, split it, translate every split, with duplicates found only lazily by the cache.

Three stages replace that, and only the middle one is expensive.

| stage | work | measured |
|---|---|---|
| `bt-extract-strings` | one pass, read in place → length-sorted chunks of distinct strings | ~5 min / 38 GB |
| `bt-translate-chunk` | one chunk, one instance, one node | the whole job |
| `bt-join-index` | dict lookup x836M, post to Solr | ~35,000 docs/s |

**Engine** moves to `PrioritizedQueueBasedWorkflowEngineFactory` with `HighestFIFOPrioritySorter`. The work is now a queue of equal-sized chunks handed out as nodes free up, rather than instances bound to threads for life. `AsynchronousLocalEngineRunnerFactory` is the default; swapping in `ResourceRunnerFactory` distributes the translate stage across nodes and nothing else changes, because a chunk holds no state beyond its own output file.

**Chunks are cut from a global length sort**, so each holds strings of nearly identical length and the model pads almost nothing — worth 29% of inference time on its own.

## Verified end to end on real data

12 real TSVs from the brick, all three stages:

- extract: 2,290,163 cells → 49,444 distinct (**46.3x**), chunks banded 1-15 chars through 72-256
- translate: 49,444 strings, 0 rejected
- join: **327,232 records → 327,232 documents, 100% retention**
- spot-checked in Solr: titles/departments/jobtypes translated, 0 `Tiempo Completo` remaining, locations untouched (not a translatable column)

## Two bugs the E2E caught

The first join run indexed 194,734 of 327,232 and reported the rest as missing required fields. They weren't.

1. **36% of `postedDate` reads `2012-11-6`**, not `2012-11-06`. Matched on length, so an unpadded day failed to parse, and `postedDate` being required dropped the whole record — a third of the corpus, silently, with a clean index to suggest otherwise.
2. **Blank cells.** Solr's `required` means present, not non-empty. `contactPerson` is blank in 4% of records, `latitude` in 1%. Omitting the field instead of carrying the blank lost one record in twenty.

A required date is the one case that still drops a record, since it can't be blank and still parse.

**Records are not lines** — titles contain embedded newlines, so the join accumulates until a record has 20 columns. Splitting on newlines mangles everything after such a title and indexes cleanly enough to go unnoticed. Tested.

315 tests pass, 17 new.

## Not in this PR

- Solr heap is still `-Xmx512m`; it survived 2M docs but shouldn't run 119M.
- The `security.policy` grant for an index on an external volume was made locally in the deployment, not here.