### PR TITLE
Give Solr a heap and somewhere to put an 88GB index

### DIFF
--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -279,6 +279,20 @@ pantogloss_concurrency() {
   echo "${pool:-8}"
 }
 
+# Where Solr keeps its index.
+#
+# Told through solr.data.home rather than a dataDir in core.properties,
+# because Solr runs under a security manager whose policy grants file
+# access to ${solr.data.home} and its children by name. A core pointed
+# somewhere the policy has never heard of fails to load with an
+# AccessControlException naming a file inside the directory it was just
+# told to use, which reads like corruption rather than a permission.
+solr_index_policy() {
+  if [ -n "${SOLR_DATA_DIR:-}" ]; then
+    echo "-Dsolr.data.home=$SOLR_DATA_DIR"
+  fi
+}
+
 start_pantogloss() {
   serve_bin="$OODT_BASE/.venv/bin/pantogloss"
   if [ ! -x "$serve_bin" ]; then
@@ -383,6 +397,8 @@ start_oodt() {
   # war inside Tomcat. --solr-home points it at the bigtranslate core;
   # --user-managed keeps it out of SolrCloud, which BigTranslate does not use.
   if [ -x "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" ]; then
+    SOLR_JAVA_MEM="-Xms$SOLR_HEAP -Xmx$SOLR_HEAP" \
+    SOLR_OPTS="${SOLR_OPTS:-} $(solr_index_policy)" \
     nohup "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" start -p "$SOLR_PORT" \
       --solr-home "$OODT_BASE"/solr --user-managed >> "$OODT_OUT" 2>&1 &
   fi

--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -77,6 +77,32 @@ export PANTOGLOSS_QUEUE_TIMEOUT=${PANTOGLOSS_QUEUE_TIMEOUT:-}
 # sixty-four, so at most two of our requests ever merge. A longer window
 # fills those pairs more reliably at the price of latency on a quiet queue.
 # Ignored by servers older than 0.19, which have no such flag.
+# How much heap Solr gets.
+#
+# Solr's own default is 512m, which is ample for the tens of thousands of
+# documents a test run posts and is not what this corpus asks for: the
+# employment set indexes 119,453,210 documents into an 88GB index, and the
+# merging that goes with it is where a small heap stops being survivable.
+# Two gigabytes carried a two million document benchmark comfortably; four
+# is the number to start a full run with.
+export SOLR_HEAP=${SOLR_HEAP:-4g}
+
+# Where the index goes, if not under the deployment. An 88GB index does
+# not have to live beside the code.
+#
+# This is a data *root*, not the index directory: Solr is told through
+# solr.data.home, and the security policy it runs under grants that path
+# and its children by name. Naming a subdirectory of the volume instead
+# fails, because Solr reads the parent on the way in and the parent is not
+# what was granted -- "access denied (FilePermission /Volumes/X read)"
+# while pointed at /Volumes/X/something. Give it the root.
+#
+# The volume needs real filesystem semantics. exFAT has no hard links, no
+# journalling and is case-insensitive; Lucene wants all three, and the
+# failure mode is a corrupt index after a crash rather than an error at
+# startup. A disk image formatted APFS or HFS+ on that volume is fine.
+export SOLR_DATA_DIR=${SOLR_DATA_DIR:-}
+
 export PANTOGLOSS_BATCH_WAIT_MS=${PANTOGLOSS_BATCH_WAIT_MS:-10}
 export PANTOGLOSS_COALESCED_BATCH=${PANTOGLOSS_COALESCED_BATCH:-64}
 export PANTOGLOSS_COALESCED_CHARS=${PANTOGLOSS_COALESCED_CHARS:-200000}

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -476,3 +476,39 @@ class TestShippedScripts:
         path = BIN / "pantogloss-translatejson"
         assert path.is_file()
         assert path.stat().st_mode & 0o111, "shim must ship executable"
+
+
+def test_solr_gets_a_heap_a_full_run_can_use():
+    """Solr's own default is 512m.
+
+    Ample for a test run's tens of thousands of documents, and not what
+    this corpus asks for: the employment set indexes 119,453,210 documents
+    into an 88GB index, and the merging that goes with it is where a small
+    heap stops being survivable.
+    """
+    env = (REPO / "distribution" / "src" / "main" / "resources"
+           / "bin" / "setenv.sh").read_text()
+    assert "export SOLR_HEAP=${SOLR_HEAP:-" in env, "the heap is not settable"
+    oodt = (REPO / "distribution" / "src" / "main" / "resources"
+            / "bin" / "oodt").read_text()
+    assert "SOLR_JAVA_MEM=" in oodt and "$SOLR_HEAP" in oodt, (
+        "SOLR_HEAP is declared but never reaches Solr")
+
+
+def test_an_index_off_the_deployment_is_told_through_data_home():
+    """Not through a dataDir in core.properties.
+
+    Solr runs under a security manager whose policy grants file access to
+    ${solr.data.home} and its children by name. A core pointed anywhere
+    else fails to load with an AccessControlException naming a file inside
+    the directory it was just told to use.
+    """
+    oodt = (REPO / "distribution" / "src" / "main" / "resources"
+            / "bin" / "oodt").read_text()
+    assert "-Dsolr.data.home=" in oodt, (
+        "the index location never reaches Solr's security policy")
+    assert "SOLR_DATA_DIR" in oodt
+    env = (REPO / "distribution" / "src" / "main" / "resources"
+           / "bin" / "setenv.sh").read_text()
+    assert "export SOLR_DATA_DIR=${SOLR_DATA_DIR:-}" in env, (
+        "the index location cannot be set per deployment")


### PR DESCRIPTION
Two settings the full run needs, both found by yesterday's Solr benchmark.

**Heap.** Solr's default is `512m`. That carried a 2M-document benchmark without complaint, which is exactly why it's worth changing *before* the full run: the employment corpus indexes 119,453,210 documents into an 88GB index, and the merging is where a small heap stops being survivable. Now `SOLR_HEAP`, defaulting to `4g`.

**Index location.** An 88GB index doesn't have to live beside the code. `SOLR_DATA_DIR` points it elsewhere, and the launcher passes it as `solr.data.home`.

That last detail matters and cost me an afternoon. Solr runs under a security manager whose policy grants file access to `${solr.data.home}` and its children *by name*. Setting `dataDir` in `core.properties` instead — the obvious move — fails at core load with:

```
access denied ("java.io.FilePermission" "/Volumes/BTSOLR/snapshot_metadata" "read")
```

which reads like corruption rather than a permission problem. It must also be the **volume root**: naming a subdirectory fails the same way, because Solr reads the parent on the way in and the parent isn't what was granted.

**Verified properly** — I removed the hand-added policy grant and the `core.properties` dataDir from the running deployment and started it from these settings alone. Core loads, index lands on the external volume, heap reads `4g`.

Also documented: the volume needs real filesystem semantics. exFAT has no hard links, no journalling and is case-insensitive; Lucene wants all three, and the failure mode is a corrupt index after a crash rather than an error at startup. A disk image formatted APFS or HFS+ on such a drive is fine.

300 tests pass on this branch, 2 new. (The W2 pipeline's 17 tests are on #47, which this branch does not include.)