### PR TITLE
Declare the product types the W2 stages write

### DIFF
--- a/filemgr/src/main/resources/policy/bigtranslate/product-type-element-map.xml
+++ b/filemgr/src/main/resources/policy/bigtranslate/product-type-element-map.xml
@@ -25,5 +25,8 @@ of elements between the types
   <type id="urn:bigtranslate:EmploymentJobAggregates" parent="urn:oodt:TraceableFile"/>
   <type id="urn:bigtranslate:EmploymentJob" parent="urn:oodt:TraceableFile"/>
   <type id="urn:bigtranslate:EmploymentJobTranslated" parent="urn:oodt:TraceableFile"/>
+  <type id="urn:bigtranslate:EmploymentStringChunk" parent="urn:oodt:TraceableFile"/>
+  <type id="urn:bigtranslate:EmploymentTranslatedChunk" parent="urn:oodt:TraceableFile"/>
+  <type id="urn:bigtranslate:EmploymentIndexedShard" parent="urn:oodt:TraceableFile"/>
 
 </cas:producttypemap>

--- a/filemgr/src/main/resources/policy/bigtranslate/product-types.xml
+++ b/filemgr/src/main/resources/policy/bigtranslate/product-types.xml
@@ -162,4 +162,73 @@ limitations under the License.
     </metExtractors>
   </type>
 
+
+  <type id="urn:bigtranslate:EmploymentStringChunk" name="EmploymentStringChunk">
+    <repository path="file://[BIGTRANSLATE_HOME]/data/strings"/>
+    <versioner class="org.apache.oodt.cas.filemgr.versioning.InPlaceVersioner"/>
+    <description>One chunk of distinct strings awaiting translation. The extract stage writes these; each one becomes a translate instance, and the translate stage looks its own file up here by name.</description>
+    <metExtractors>
+      <extractor
+        class="org.apache.oodt.cas.filemgr.metadata.extractors.CoreMetExtractor">
+        <configuration>
+          <property name="nsAware" value="true" />
+          <property name="elementNs" value="CAS" />
+          <property name="elements"
+            value="ProductReceivedTime,ProductName,ProductId" />
+        </configuration>
+      </extractor>
+      <extractor class="org.apache.oodt.cas.filemgr.metadata.extractors.examples.MimeTypeExtractor" />
+      <extractor class="org.apache.oodt.cas.filemgr.metadata.extractors.examples.FinalFileLocationExtractor">
+        <configuration>
+           <property name="replace" value="true"/>
+        </configuration>
+      </extractor>
+    </metExtractors>
+  </type>
+
+  <type id="urn:bigtranslate:EmploymentTranslatedChunk" name="EmploymentTranslatedChunk">
+    <repository path="file://[BIGTRANSLATE_HOME]/data/translated"/>
+    <versioner class="org.apache.oodt.cas.filemgr.versioning.InPlaceVersioner"/>
+    <description>One chunk of distinct strings, translated. The join stage reads every one of these into a single lookup.</description>
+    <metExtractors>
+      <extractor
+        class="org.apache.oodt.cas.filemgr.metadata.extractors.CoreMetExtractor">
+        <configuration>
+          <property name="nsAware" value="true" />
+          <property name="elementNs" value="CAS" />
+          <property name="elements"
+            value="ProductReceivedTime,ProductName,ProductId" />
+        </configuration>
+      </extractor>
+      <extractor class="org.apache.oodt.cas.filemgr.metadata.extractors.examples.MimeTypeExtractor" />
+      <extractor class="org.apache.oodt.cas.filemgr.metadata.extractors.examples.FinalFileLocationExtractor">
+        <configuration>
+           <property name="replace" value="true"/>
+        </configuration>
+      </extractor>
+    </metExtractors>
+  </type>
+
+  <type id="urn:bigtranslate:EmploymentIndexedShard" name="EmploymentIndexedShard">
+    <repository path="file://[BIGTRANSLATE_HOME]/data/jobs/join"/>
+    <versioner class="org.apache.oodt.cas.filemgr.versioning.InPlaceVersioner"/>
+    <description>A marker that one shard of the corpus has been joined against the translations and posted to Solr.</description>
+    <metExtractors>
+      <extractor
+        class="org.apache.oodt.cas.filemgr.metadata.extractors.CoreMetExtractor">
+        <configuration>
+          <property name="nsAware" value="true" />
+          <property name="elementNs" value="CAS" />
+          <property name="elements"
+            value="ProductReceivedTime,ProductName,ProductId" />
+        </configuration>
+      </extractor>
+      <extractor class="org.apache.oodt.cas.filemgr.metadata.extractors.examples.MimeTypeExtractor" />
+      <extractor class="org.apache.oodt.cas.filemgr.metadata.extractors.examples.FinalFileLocationExtractor">
+        <configuration>
+           <property name="replace" value="true"/>
+        </configuration>
+      </extractor>
+    </metExtractors>
+  </type>
 </cas:producttypes>

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -537,3 +537,42 @@ def test_an_index_off_the_deployment_is_told_through_data_home():
            / "bin" / "setenv.sh").read_text()
     assert "export SOLR_DATA_DIR=${SOLR_DATA_DIR:-}" in env, (
         "the index location cannot be set per deployment")
+
+
+def test_every_product_type_a_task_writes_is_declared():
+    """A task naming an undeclared type fails only when it runs.
+
+    The failure is "Unknown product type: EmploymentStringChunk" from the
+    catalog, thrown while the PGE builds its config, several layers away
+    from the tasks.xml line that named it.
+    """
+    import re
+    import xml.etree.ElementTree as ET
+    tasks = (WORKFLOW_POLICY / "tasks.xml").read_text()
+    named = set(re.findall(r'<property name="ProductType" value="([^"]+)"',
+                           tasks))
+    assert named, "no task declares a ProductType"
+    types = REPO / "filemgr" / "src" / "main" / "resources" / "policy"
+    declared = set()
+    for path in types.rglob("product-types.xml"):
+        for node in ET.parse(path).getroot().iter("type"):
+            if node.get("name"):
+                declared.add(node.get("name"))
+    missing = sorted(named - declared)
+    assert not missing, (
+        "tasks.xml names product types the file manager does not declare: %s"
+        % missing)
+
+
+def test_every_declared_product_type_is_in_the_element_map():
+    import xml.etree.ElementTree as ET
+    policy = (REPO / "filemgr" / "src" / "main" / "resources" / "policy"
+              / "bigtranslate")
+    ids = {n.get("id") for n in
+           ET.parse(policy / "product-types.xml").getroot().iter("type")
+           if n.get("id")}
+    mapped = {n.get("id") for n in
+              ET.parse(policy / "product-type-element-map.xml").getroot()
+              .iter("type") if n.get("id")}
+    missing = sorted(ids - mapped)
+    assert not missing, "product types absent from the element map: %s" % missing


### PR DESCRIPTION
The three W2 stages name `EmploymentStringChunk`, `EmploymentTranslatedChunk` and `EmploymentIndexedShard` — and the file manager had never heard of any of them. My oversight in #47.

Nothing reports it until a task actually runs, and then it surfaces as:

```
CatalogException: Unknown product type: EmploymentStringChunk
```

thrown from inside the PGE building its configuration, several layers away from the `tasks.xml` line that named the type.

Adds the three product types and their element-map entries, plus two tests that would each have caught it: every `ProductType` a task names must be declared, and every declared type must appear in the element map.

333 tests pass, 2 new.