### PR TITLE
Let a deployment find itself

### DIFF
--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -11,6 +11,26 @@
 #
 ############################
 
+# Where this deployment is, worked out from where this file is rather than
+# assumed. The default used to be /usr/local/bigtranslate, so a deployment
+# unpacked anywhere else worked only if the caller had exported
+# BIGTRANSLATE_HOME first. The servers are always started through bin/oodt,
+# which does that, so the gap showed up only in the client scripts:
+#
+#   ./filemgr-client --url ... --operation --getNumProducts
+#   cd: /usr/local/bigtranslate/filemgr/bin: No such file or directory
+#   ClassNotFoundException: ...FileManagerClientMain
+#
+# which reads like a broken install rather than an unset variable.
+if [ -z "${BIGTRANSLATE_HOME:-}" ]; then
+  # ${BASH_SOURCE[0]} when sourced, $0 when run; either way this file.
+  _bt_setenv="${BASH_SOURCE[0]:-$0}"
+  _bt_bin=$(cd "$(dirname "$_bt_setenv")" 2>/dev/null && pwd)
+  if [ -n "$_bt_bin" ]; then
+    BIGTRANSLATE_HOME=$(cd "$_bt_bin/.." 2>/dev/null && pwd)
+  fi
+  unset _bt_setenv _bt_bin
+fi
 export BIGTRANSLATE_HOME=${BIGTRANSLATE_HOME:-/usr/local/bigtranslate}
 # Ports first, urls derived from them. The launchers bind FILEMGR_PORT and its
 # siblings while everything else looks up the urls, so setting only the urls

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -576,3 +576,45 @@ def test_every_declared_product_type_is_in_the_element_map():
               .iter("type") if n.get("id")}
     missing = sorted(ids - mapped)
     assert not missing, "product types absent from the element map: %s" % missing
+
+
+def test_the_deployment_finds_itself():
+    """setenv.sh must not assume where it was installed.
+
+    The default was /usr/local/bigtranslate, so a deployment unpacked
+    anywhere else worked only if the caller exported BIGTRANSLATE_HOME
+    first. bin/oodt does, which is why the servers were fine and only the
+    client scripts fell over:
+
+      ./filemgr-client --url ... --operation --getNumProducts
+      cd: /usr/local/bigtranslate/filemgr/bin: No such file or directory
+      ClassNotFoundException: ...FileManagerClientMain
+
+    which reads like a broken install rather than an unset variable.
+    """
+    env = (REPO / "distribution" / "src" / "main" / "resources"
+           / "bin" / "setenv.sh").read_text()
+    assert "BASH_SOURCE" in env, (
+        "setenv.sh does not work out where it is; a deployment outside "
+        "/usr/local/bigtranslate will not find its own jars")
+    assert "_bt_bin" in env
+
+
+def test_the_derived_home_is_the_directory_above_bin(tmp_path):
+    """Exercised, not asserted about: source it from elsewhere and look."""
+    import subprocess
+    home = tmp_path / "somewhere" / "else"
+    (home / "bin").mkdir(parents=True)
+    source = (REPO / "distribution" / "src" / "main" / "resources"
+              / "bin" / "setenv.sh").read_text()
+    # Only the block under test; the rest reaches for a live deployment.
+    block = source[:source.index("# Ports first")]
+    (home / "bin" / "setenv.sh").write_text(block)
+    result = subprocess.run(
+        ["bash", "-c",
+         'cd /tmp && unset BIGTRANSLATE_HOME && . "%s" && echo "$BIGTRANSLATE_HOME"'
+         % (home / "bin" / "setenv.sh")],
+        capture_output=True, text=True, timeout=60)
+    got = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
+    assert got == str(home), (
+        "sourced from /tmp it resolved to %r, wanted %r" % (got, str(home)))


### PR DESCRIPTION
`setenv.sh` defaulted `BIGTRANSLATE_HOME` to `/usr/local/bigtranslate`, so a deployment unpacked anywhere else only worked if the caller exported the variable first.

`bin/oodt` does export it — which is why the servers were always fine, and the gap showed up only in the client scripts:

```
./filemgr-client --url ... --operation --getNumProducts
cd: /usr/local/bigtranslate/filemgr/bin: No such file or directory
Error: Could not find or load main class ...FileManagerClientMain
```

That reads like a broken install rather than an unset variable, and it's reached by anyone who does the obvious thing and runs a client from the directory it lives in.

The home is now derived from where `setenv.sh` itself is — the one thing always known — using `${BASH_SOURCE[0]:-$0}` so it works sourced or executed. The old `/usr/local/bigtranslate` default remains as the final fallback, so any deployment that genuinely relied on it is unaffected.

**Verified** by running `filemgr-client` from `/tmp` with `BIGTRANSLATE_HOME`, `FILEMGR_HOME` and `OODT_HOME` all unset:

```
Type: [EmploymentTranslatedChunk], Num Products: [0]
```

337 tests pass, 2 new — one reading the script, one that writes a fake deployment to a temp directory, sources it from `/tmp`, and checks the resolved path.