### PR TITLE
Stop a needless ingest from failing a stage that worked

### DIFF
--- a/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
@@ -14,7 +14,7 @@
 
   <output>
     <dir path="[JobOutputDir]" createBeforeExe="false">
-       <files regExp="chunk-.*\.json" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
+       <files regExp="chunk-[0-9]+\.json" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
      </dir>
   </output>
 

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -13,10 +13,9 @@
      <cmd>echo "shard [ShardIndex] of [JoinShards] indexed" [GreaterThan] [JobOutputDir]/shard-[ShardIndex].done</cmd>
   </exe>
 
+  <!-- Nothing to ingest. The documents are in Solr; the shard marker is for
+       the log, not the catalog. -->
   <output>
-    <dir path="[JobOutputDir]" createBeforeExe="false">
-       <files regExp="shard-.*\.done" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
-     </dir>
   </output>
 
   <customMetadata>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
@@ -12,10 +12,12 @@
      <cmd>cp [TranslatedDir]/[ChunkFile] [JobOutputDir]/</cmd>
   </exe>
 
+  <!-- Nothing to ingest. The join stage reads this directory directly, so
+       cataloguing every translated chunk would add a product per chunk that
+       nothing ever queries. An ingest that fails also takes a translation
+       that succeeded down with it, reporting Failure for work that is on
+       disk and correct. -->
   <output>
-    <dir path="[JobOutputDir]" createBeforeExe="false">
-       <files regExp="chunk-.*\.json" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
-     </dir>
   </output>
 
   <customMetadata>

--- a/tests/test_w2_pipeline.py
+++ b/tests/test_w2_pipeline.py
@@ -454,3 +454,42 @@ def test_each_command_runs_in_a_clean_interpreter():
         assert result.returncode == 0, (
             "%s cannot reach --help:\n%s" % (name, result.stderr[-600:]))
         assert "usage:" in result.stdout.lower()
+
+
+def test_only_the_stage_whose_output_is_needed_ingests_it():
+    """An ingest that fails takes a successful stage down with it.
+
+    The PGE marks the whole task failed if any declared output cannot be
+    catalogued, so a translate that wrote all 5,000 pairs to disk was
+    recorded as Failure because the file manager declined the file. Over a
+    four hour run that is the difference between a result you can trust
+    and one you have to go and check by hand.
+
+    Extract is the one stage whose products are genuinely needed: each
+    chunk it catalogues is what triggers a translate. The join reads the
+    translated directory directly, and the shard marker is for the log.
+    """
+    policy = REPO / "pge" / "src" / "main" / "resources" / "policy" / "no_filter"
+    extract = (policy / "PgeConfig_ExtractStrings.xml").read_text()
+    assert "<files regExp=" in extract, (
+        "extract must catalogue its chunks; nothing else starts a translate")
+
+    for name in ("TranslateChunk", "JoinIndex"):
+        config = (policy / ("PgeConfig_%s.xml" % name)).read_text()
+        block = config[config.index("<output>"):config.index("</output>")]
+        assert "<files" not in block and "<dir" not in block, (
+            "%s declares an output to ingest; a failure there would mark "
+            "work that succeeded as failed" % name)
+
+
+def test_the_chunk_pattern_cannot_match_its_own_met_file():
+    """"chunk-.*\\.json" also matches "chunk-00003.json.met"."""
+    import re
+    policy = REPO / "pge" / "src" / "main" / "resources" / "policy" / "no_filter"
+    extract = (policy / "PgeConfig_ExtractStrings.xml").read_text()
+    pattern = re.search(r'<files regExp="([^"]+)"', extract).group(1)
+    compiled = re.compile(pattern)
+    assert compiled.match("chunk-00003.json"), (
+        "the pattern no longer matches a chunk: %s" % pattern)
+    assert not compiled.fullmatch("chunk-00003.json.met"), (
+        "the pattern also matches the met file written beside the chunk")


### PR DESCRIPTION
The PGE marks a task failed if any output it declares cannot be catalogued. Both the translate and join stages declared theirs, so a translate that had written **all 5,000 pairs correctly to disk** was recorded as `Failure`:

```
Ingest wasn't successful: Failed to ingest product [...chunk-00003.json]
PGETask FAILED!!! : Failed to ingest product
```

The work was done. Over a four-hour run that's the difference between a result you can trust and one you have to verify by hand, file by file.

**Neither product is wanted.** The join reads the `translated/` directory directly rather than querying the catalog, and the shard marker exists for the log. So they no longer declare outputs — which is what the existing `PgeConfig_BigTranslate.xml` already does (its `<output>` block is empty).

**Extract keeps its output**, because it's the one stage whose products are genuinely needed: each chunk it catalogues is what starts a translate. Its pattern is tightened too — `chunk-.*\.json` also matches `chunk-00003.json.met`, the met file written beside the chunk.

337 tests pass, 2 new: one asserting only extract declares an output, one compiling the extract pattern and checking it matches a chunk but not the chunk's own met file.

## Note on scope

This removes a *false* failure. It does not yet prove the extract → translate chain runs end to end — that needs the crawler's post-ingest trigger, which is Mnemosyne #308. Verifying that chain is the last thing before the full E2E.