### PR TITLE
Make the pipeline run itself, correctly, unattended

### DIFF
--- a/distribution/src/main/resources/bin/bigtranslate
+++ b/distribution/src/main/resources/bin/bigtranslate
@@ -116,8 +116,29 @@ RUN_MARKER="$BIGTRANSLATE_HOME/data/run"
 
 mark_run() {
     mkdir -p "$(dirname "$RUN_MARKER")" 2>/dev/null
-    printf '{"status":"%s","startedBy":"cli","path":"%s","exclude":"%s","startedAt":%s}\n' \
-        "$1" "${2//\"/}" "${3//\"/}" "$(($(date +%s) * 1000))" > "$RUN_MARKER" 2>/dev/null
+    RUN_MARKER_STATUS="$1"
+    RUN_MARKER_PATH="${2//\"/}"
+    RUN_MARKER_EXCLUDE="${3//\"/}"
+    RUN_MARKER_STARTED="$(($(date +%s) * 1000))"
+    beat_run
+}
+
+# The marker carries a heartbeat as well as a start time, refreshed for as
+# long as the run is actually being waited on.
+#
+# Without it the file is only ever evidence that a run once began. A run
+# that died, or whose script was killed, leaves a marker nobody clears, and
+# Gloss reports a translation in progress for as long as the file sits
+# there -- it showed one for a day, naming a corpus path from the previous
+# afternoon, while a different run was genuinely under way.
+#
+# A reader can tell the difference: a heartbeat that stopped is a run that
+# stopped.
+beat_run() {
+    [ -n "${RUN_MARKER_STATUS:-}" ] || return 0
+    printf '{"status":"%s","startedBy":"cli","path":"%s","exclude":"%s","startedAt":%s,"heartbeatAt":%s}\n' \
+        "$RUN_MARKER_STATUS" "$RUN_MARKER_PATH" "$RUN_MARKER_EXCLUDE" \
+        "$RUN_MARKER_STARTED" "$(($(date +%s) * 1000))" > "$RUN_MARKER" 2>/dev/null
 }
 
 unmark_run() {
@@ -244,6 +265,7 @@ wait_for_workflow() {
             quiet=0
         fi
 
+        beat_run
         sleep "$TRANSLATE_POLL"
         waited=$((waited + TRANSLATE_POLL))
     done

--- a/distribution/src/main/resources/bin/bt-join-index
+++ b/distribution/src/main/resources/bin/bt-join-index
@@ -78,6 +78,25 @@ def records(path, columns):
                 yield parts
 
 
+def count_chunks(directory):
+    return len(glob.glob(os.path.join(directory, "chunk-*.json")))
+
+
+def wait_for_chunks(directory, expected, timeout, poll=15):
+    """Block until every chunk has a translation, or give up saying so.
+
+    Chunks are written to a temporary name and renamed, so one that exists
+    is one that is finished; counting them is enough.
+    """
+    started = time.time()
+    seen = count_chunks(directory)
+    while seen < expected and time.time() - started < timeout:
+        log("  waiting: %d of %d chunks translated" % (seen, expected))
+        time.sleep(poll)
+        seen = count_chunks(directory)
+    return seen
+
+
 def as_solr_date(value):
     """Solr's pdate wants a full instant; the corpus carries plain dates.
 
@@ -172,10 +191,31 @@ def main(argv=None):
     parser.add_argument("--of", type=int, default=1)
     parser.add_argument("--commit", action="store_true",
                         help="commit at the end of this shard")
+    # One commit for the whole corpus, not one per shard: a commit is
+    # expensive and eight of them in parallel is eight merges competing.
+    parser.add_argument("--commit-only", action="store_true",
+                        help="commit what is already posted and do nothing "
+                             "else")
+    # The join must not start on a partial set. A quiet period is a guess:
+    # chunks are length sorted, so the last ones take the longest, and a
+    # gap between two of them looks exactly like the end of the run. One
+    # join ran on seven chunks of ten and indexed every record, reporting
+    # success, with the longest strings left in Spanish.
+    parser.add_argument("--expect", type=int, default=0,
+                        help="wait until this many translated chunks exist")
+    parser.add_argument("--expect-timeout", type=int, default=14400,
+                        help="give up waiting after this many seconds")
     args = parser.parse_args(argv)
 
     if args.of < 1 or not 0 <= args.shard < args.of:
         parser.error("--shard must be in [0, --of)")
+
+    if args.commit_only:
+        urllib.request.urlopen(
+            args.solr_url.rstrip("/") + "/update?commit=true&wt=json",
+            timeout=args.timeout * 6).read()
+        log("committed")
+        return 0
 
     paths = sorted(glob.glob(os.path.join(args.corpus, "*.tsv")))
     if not paths:
@@ -185,6 +225,17 @@ def main(argv=None):
     columns = read_columns(args.colheaders)
     wanted = set(read_columns(args.translate_cols))
     translate_at = {i for i, name in enumerate(columns) if name in wanted}
+
+    if args.expect:
+        waited = wait_for_chunks(args.translated, args.expect,
+                                 args.expect_timeout)
+        if waited < args.expect:
+            raise SystemExit(
+                "only %d of %d translated chunks after %ds; refusing to "
+                "index a partial translation. The documents would all be "
+                "there and some of them would still be in the source "
+                "language."
+                % (waited, args.expect, args.expect_timeout))
 
     table, chunks = load_translations(args.translated)
     if not table:

--- a/distribution/src/main/resources/bin/bt-run-marker
+++ b/distribution/src/main/resources/bin/bt-run-marker
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Record that a run is happening, for anything that wants to show it.
+
+bin/bigtranslate writes this marker for a run it starts itself. A run the
+engine drives has no such caller: the stages are started by events, and
+Gloss reported IDLE for the whole of one because nothing had written the
+file. So the stages write it too -- extract begins it, each translated
+chunk beats it, and the join clears it.
+
+The beat is what separates a run from the wreckage of one. Without it a
+marker is only evidence that something once started, and a run that died
+leaves Gloss reporting a translation in progress until somebody notices.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+
+def marker_path():
+    home = os.environ.get("BIGTRANSLATE_HOME")
+    if not home:
+        return None
+    return os.path.join(home, "data", "run")
+
+
+def read(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+    except Exception:
+        return {}
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="bt-run-marker",
+        description="Write, refresh or clear the marker that says a run is "
+                    "in progress.")
+    parser.add_argument("action", choices=["start", "beat", "clear"])
+    parser.add_argument("--status", default="TRANSLATING")
+    parser.add_argument("--path", default="")
+    parser.add_argument("--started-by", default="workflow")
+    args = parser.parse_args(argv)
+
+    path = marker_path()
+    if not path:
+        # Not being able to say so is not worth failing a stage over.
+        sys.stderr.write("BIGTRANSLATE_HOME unset; not recording the run\n")
+        return 0
+
+    if args.action == "clear":
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            sys.stderr.write("could not clear the run marker: %s\n" % e)
+        return 0
+
+    now = int(time.time() * 1000)
+    existing = read(path) if args.action == "beat" else {}
+    if args.action == "beat" and not existing:
+        # Nothing to refresh. A beat is not a reason to invent a run.
+        return 0
+
+    record = {
+        "status": existing.get("status", args.status),
+        "startedBy": existing.get("startedBy", args.started_by),
+        "path": existing.get("path", args.path) if args.action == "beat"
+                else args.path,
+        "exclude": existing.get("exclude", ""),
+        "startedAt": existing.get("startedAt", now),
+        "heartbeatAt": now,
+    }
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".partial"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(record, handle)
+    os.replace(tmp, path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/filemgr/src/main/resources/bin/filemgr
+++ b/filemgr/src/main/resources/bin/filemgr
@@ -69,10 +69,20 @@ if $cygwin; then
 fi
 
 if [ "$1" = "start" ]; then
+  # A pid file whose process is gone is not a running service. It is what
+  # a crash or a kill -9 leaves behind, and treating it as "still running"
+  # means the next start refuses for as long as the file sits there, with a
+  # message that sends you looking for a process that does not exist.
   if [ ! -z "$FILEMGR_PID" ]; then
     if [ -f "$FILEMGR_PID" ]; then
-      echo "PID file ($FILEMGR_PID) found. Is File Manager still running? Start aborted."
-      exit 1
+      _pid=`cat "$FILEMGR_PID" 2>/dev/null`
+      if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+        echo "File Manager is already running (pid $_pid). Start aborted."
+        exit 1
+      fi
+      echo "Removing stale pid file ($FILEMGR_PID); no process $_pid is running."
+      rm -f "$FILEMGR_PID"
+      unset _pid
     fi
   fi
 

--- a/filemgr/src/main/resources/policy/bigtranslate/product-types.xml
+++ b/filemgr/src/main/resources/policy/bigtranslate/product-types.xml
@@ -165,7 +165,12 @@ limitations under the License.
 
   <type id="urn:bigtranslate:EmploymentStringChunk" name="EmploymentStringChunk">
     <repository path="file://[BIGTRANSLATE_HOME]/data/strings"/>
-    <versioner class="org.apache.oodt.cas.filemgr.versioning.InPlaceVersioner"/>
+    <!-- Not InPlaceVersioner: the chunks are written to a job directory and
+         this repository is where the ingest puts them. Leaving them in
+         place while naming this as the repository asks the transfer to
+         move a file onto itself, which fails with "File canonical paths
+         are equal" and catalogues nothing. -->
+    <versioner class="org.apache.oodt.cas.filemgr.versioning.BasicVersioner"/>
     <description>One chunk of distinct strings awaiting translation. The extract stage writes these; each one becomes a translate instance, and the translate stage looks its own file up here by name.</description>
     <metExtractors>
       <extractor
@@ -187,8 +192,11 @@ limitations under the License.
   </type>
 
   <type id="urn:bigtranslate:EmploymentTranslatedChunk" name="EmploymentTranslatedChunk">
-    <repository path="file://[BIGTRANSLATE_HOME]/data/translated"/>
-    <versioner class="org.apache.oodt.cas.filemgr.versioning.InPlaceVersioner"/>
+    <repository path="file://[BIGTRANSLATE_HOME]/data/translated-catalog"/>
+    <!-- Its own repository, apart from the flat directory the join reads:
+         this versioner nests each product in a directory named after it,
+         which would leave the join globbing an empty level. -->
+    <versioner class="org.apache.oodt.cas.filemgr.versioning.BasicVersioner"/>
     <description>One chunk of distinct strings, translated. The join stage reads every one of these into a single lookup.</description>
     <metExtractors>
       <extractor

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
@@ -7,9 +7,15 @@
        whatever volume the corpus lives on. -->
   <exe dir="[JobDir]" shell="/bin/bash">
      <cmd>export PYTHONIOENCODING=utf-8</cmd>
-     <cmd>mkdir -p [JobOutputDir] [JobLogDir] [StringsDir]</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-extract-strings --corpus [CorpusDir] --out-dir [StringsDir] --colheaders [ColHeaders] --translate-cols [TranslateCols] --chunk-size [ChunkSize] [GreaterThan][GreaterThan] [JobLogDir]/extract_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
-     <cmd>cp [StringsDir]/chunk-*.json [JobOutputDir]/</cmd>
+     <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker start --path [CorpusDir] --started-by workflow</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-extract-strings --corpus [CorpusDir] --out-dir [JobOutputDir] --colheaders [ColHeaders] --translate-cols [TranslateCols] --chunk-size [ChunkSize] [GreaterThan][GreaterThan] [JobLogDir]/extract_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <!-- Start the join once, here, rather than once per chunk. It waits
+          on TranslationsSettled, so it sits until every chunk has an
+          answer and then runs a single time. Triggering it from each
+          catalogued chunk instead would create one join per chunk, all
+          waiting on the same condition and then all doing the same work. -->
+     <cmd>[BIGTRANSLATE_HOME]/workflow/bin/wmgr-client --url [PCS_WorkflowManagerUrl] --operation --sendEvent --eventName EmploymentTranslationsComplete [GreaterThan][GreaterThan] [JobLogDir]/extract_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
   </exe>
 
   <output>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -9,9 +9,20 @@
   <exe dir="[JobDir]" shell="/bin/bash">
      <cmd>export PYTHONIOENCODING=utf-8</cmd>
      <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard [ShardIndex] --of [JoinShards] --commit [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <!-- Every shard, from this one instance. JoinShards said eight and
+          only shard zero ever ran, because nothing created instances for
+          the other seven: a corpus was indexed one eighth of the way and
+          reported success. Running them here keeps the parallelism without
+          needing an instance apiece. -->
+     <!-- How many chunks there are to wait for, counted from the chunk
+          repository rather than guessed. The settled condition stops the
+          join beginning absurdly early; this stops it beginning early at
+          all. -->
+     <cmd>EXPECTED=$(ls -d [StringsDir]/chunk-*.json 2>/dev/null | wc -l | tr -d " ")</cmd>
+     <cmd>for s in $(seq 0 $(([JoinShards] - 1))); do [BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard $s --of [JoinShards] --expect $EXPECTED [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1 [Ampersand] done; wait</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard 0 --of [JoinShards] --commit-only [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker clear</cmd>
-     <cmd>echo "shard [ShardIndex] of [JoinShards] indexed" [GreaterThan] [JobOutputDir]/shard-[ShardIndex].done</cmd>
+     <cmd>echo "[JoinShards] shards indexed" [GreaterThan] [JobOutputDir]/join.done</cmd>
   </exe>
 
   <!-- Nothing to ingest. The documents are in Solr; the shard marker is for
@@ -27,6 +38,7 @@
     <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
     <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
     <metadata key="ShardIndex" val="0"/>
+    <metadata key="StringsDir" val="[BIGTRANSLATE_HOME]/data/strings"/>
     <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/join/[ShardIndex]_[DateMilis]"/>
     <metadata key="JobOutputDir" val="[JobDir]/output"/>
     <metadata key="JobLogDir" val="[JobDir]/logs"/>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -10,6 +10,7 @@
      <cmd>export PYTHONIOENCODING=utf-8</cmd>
      <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard [ShardIndex] --of [JoinShards] --commit [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker clear</cmd>
      <cmd>echo "shard [ShardIndex] of [JoinShards] indexed" [GreaterThan] [JobOutputDir]/shard-[ShardIndex].done</cmd>
   </exe>
 

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
@@ -10,14 +10,19 @@
      <cmd>mkdir -p [JobOutputDir] [JobLogDir] [TranslatedDir]</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-translate-chunk --chunk [ChunkPath] --out-dir [TranslatedDir] --service-url [PantoglossUrl] --batch-size [TranslateBatchSize] [GreaterThan][GreaterThan] [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>cp [TranslatedDir]/[ChunkFile] [JobOutputDir]/</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker beat</cmd>
   </exe>
 
-  <!-- Nothing to ingest. The join stage reads this directory directly, so
-       cataloguing every translated chunk would add a product per chunk that
-       nothing ever queries. An ingest that fails also takes a translation
-       that succeeded down with it, reporting Failure for work that is on
-       disk and correct. -->
+  <!-- The chunk is catalogued so that something can count them. The join
+       cannot start until every chunk has an answer, and a product count
+       that has stopped rising is how it knows. The file the join actually
+       reads stays in the flat translated directory; this is a catalogued
+       copy, in a repository of its own so the versioner's nesting cannot
+       disturb the directory the join globs. -->
   <output>
+    <dir path="[JobOutputDir]" createBeforeExe="false">
+       <files regExp="chunk-[0-9]+\.json" metFileWriterClass="org.apache.oodt.cas.pge.writers.metlist.MetadataListPcsMetFileWriter" args="[BIGTRANSLATE_HOME]/pge/policy/metout/generic_metout.xml"/>
+     </dir>
   </output>
 
   <customMetadata>

--- a/resmgr/src/main/resources/bin/resmgr
+++ b/resmgr/src/main/resources/bin/resmgr
@@ -76,10 +76,20 @@ if $cygwin; then
 fi
 
 if [ "$1" = "start" ]; then
+  # A pid file whose process is gone is not a running service. It is what
+  # a crash or a kill -9 leaves behind, and treating it as "still running"
+  # means the next start refuses for as long as the file sits there, with a
+  # message that sends you looking for a process that does not exist.
   if [ ! -z "$RESMGR_PID" ]; then
     if [ -f "$RESMGR_PID" ]; then
-      echo "PID file ($RESMGR_PID) found. Is Resource Manager still running? Start aborted."
-      exit 1
+      _pid=`cat "$RESMGR_PID" 2>/dev/null`
+      if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+        echo "Resource Manager is already running (pid $_pid). Start aborted."
+        exit 1
+      fi
+      echo "Removing stale pid file ($RESMGR_PID); no process $_pid is running."
+      rm -f "$RESMGR_PID"
+      unset _pid
     fi
   fi
 

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -618,3 +618,53 @@ def test_the_derived_home_is_the_directory_above_bin(tmp_path):
     got = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else ""
     assert got == str(home), (
         "sourced from /tmp it resolved to %r, wanted %r" % (got, str(home)))
+
+
+def test_a_stale_pid_file_does_not_block_a_start():
+    """A pid file whose process is gone is not a running service.
+
+    It is what a crash or a kill -9 leaves behind. Treating its mere
+    existence as "still running" means every later start refuses, with a
+    message that sends you looking for a process that does not exist. The
+    resource manager sat down for an hour this way.
+    """
+    launchers = [
+        (REPO / "resmgr" / "src" / "main" / "resources" / "bin" / "resmgr"),
+        (REPO / "workflow" / "src" / "main" / "resources" / "bin" / "wmgr"),
+        (REPO / "filemgr" / "src" / "main" / "resources" / "bin" / "filemgr"),
+    ]
+    for path in launchers:
+        source = path.read_text()
+        assert "kill -0" in source, (
+            "%s decides a service is running from a file rather than from "
+            "the process" % path.name)
+        assert "stale pid file" in source.lower(), (
+            "%s does not clear a stale pid file" % path.name)
+
+
+def test_the_stale_pid_guard_actually_works(tmp_path):
+    """Exercised: a pid file naming a dead process must not stop a start."""
+    import subprocess
+    pid_file = tmp_path / "svc.pid"
+    # A pid that has certainly exited: spawn one and wait for it.
+    dead = subprocess.run(["bash", "-c", "echo $$"], capture_output=True,
+                          text=True).stdout.strip()
+    pid_file.write_text(dead)
+    guard = '''
+      RESMGR_PID="%s"
+      if [ ! -z "$RESMGR_PID" ]; then
+        if [ -f "$RESMGR_PID" ]; then
+          _pid=`cat "$RESMGR_PID" 2>/dev/null`
+          if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+            echo BLOCKED; exit 1
+          fi
+          rm -f "$RESMGR_PID"
+        fi
+      fi
+      echo STARTED
+    ''' % pid_file
+    result = subprocess.run(["bash", "-c", guard], capture_output=True,
+                            text=True, timeout=60)
+    assert "STARTED" in result.stdout, (
+        "a dead pid still blocked the start: %s" % result.stdout)
+    assert not pid_file.exists(), "the stale file was not removed"

--- a/tests/test_w2_pipeline.py
+++ b/tests/test_w2_pipeline.py
@@ -474,12 +474,21 @@ def test_only_the_stage_whose_output_is_needed_ingests_it():
     assert "<files regExp=" in extract, (
         "extract must catalogue its chunks; nothing else starts a translate")
 
-    for name in ("TranslateChunk", "JoinIndex"):
-        config = (policy / ("PgeConfig_%s.xml" % name)).read_text()
-        block = config[config.index("<output>"):config.index("</output>")]
-        assert "<files" not in block and "<dir" not in block, (
-            "%s declares an output to ingest; a failure there would mark "
-            "work that succeeded as failed" % name)
+    # Translate catalogues its chunk again, because the join needs a count
+    # to wait on. That ingest was what marked successful work as Failure,
+    # but the cause was a versioner writing into the directory it read
+    # from, not the ingest itself.
+    translate = (policy / "PgeConfig_TranslateChunk.xml").read_text()
+    assert "<files regExp=" in translate, (
+        "nothing counts the translated chunks, so the join cannot know "
+        "when they are all done")
+
+    # The join's shard markers are for the log; nothing queries them.
+    join = (policy / "PgeConfig_JoinIndex.xml").read_text()
+    block = join[join.index("<output>"):join.index("</output>")]
+    assert "<files" not in block and "<dir" not in block, (
+        "the join declares an output to ingest; a failure there would "
+        "mark work that succeeded as failed")
 
 
 def test_the_chunk_pattern_cannot_match_its_own_met_file():
@@ -493,3 +502,123 @@ def test_the_chunk_pattern_cannot_match_its_own_met_file():
         "the pattern no longer matches a chunk: %s" % pattern)
     assert not compiled.fullmatch("chunk-00003.json.met"), (
         "the pattern also matches the met file written beside the chunk")
+
+
+def test_every_stage_can_resolve_its_crawler_actions():
+    """PCS_ActionsIds names beans; PCS_ActionRepoFile says where they are.
+
+    Without the repo file the named action cannot be resolved, so the post
+    ingest trigger never runs. The products are catalogued and the stage
+    that should follow them is simply never started -- nothing fails, and
+    nothing is logged. The chain just stops.
+    """
+    tasks = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+             / "tasks.xml").read_text()
+    for name in ("Extract_Strings_Task", "Translate_Chunk_Task",
+                 "Join_Index_Task"):
+        start = tasks.index('<task id="urn:bigtranslate:%s"' % name)
+        block = tasks[start:tasks.index("</task>", start)]
+        if "PCS_ActionsIds" in block or name == "Extract_Strings_Task":
+            assert "PCS_ActionRepoFile" in block, (
+                "%s cannot resolve crawler actions" % name)
+
+
+def test_the_stage_that_catalogues_chunks_triggers_the_next_one():
+    """Extract's products are what start the translates."""
+    pge = (REPO / "pge" / "src" / "main" / "resources" / "policy"
+           / "no_filter" / "PgeConfig_ExtractStrings.xml").read_text()
+    assert "TriggerPostIngestWorkflow" in pge, (
+        "nothing starts a translate when a chunk is catalogued")
+    events = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+              / "events.xml").read_text()
+    # The crawler fires [ProductType]Ingest, so that is the name that has
+    # to be mapped, not the workflow's own id.
+    assert "EmploymentStringChunkIngest" in events, (
+        "the event the crawler fires is not mapped to any workflow")
+
+
+def test_extract_does_not_write_into_the_repository_it_ingests_into():
+    """Writing there first and then ingesting into it moves a file onto
+    itself: "File canonical paths are equal", and nothing is catalogued."""
+    pge = (REPO / "pge" / "src" / "main" / "resources" / "policy"
+           / "no_filter" / "PgeConfig_ExtractStrings.xml").read_text()
+    assert "--out-dir [JobOutputDir]" in pge, (
+        "extract writes chunks somewhere other than its job output dir")
+    # The class the element declares, not any mention of it: the comment
+    # explaining the choice names the wrong versioner on purpose.
+    import xml.etree.ElementTree as ET
+    types = ET.parse(REPO / "filemgr" / "src" / "main" / "resources"
+                     / "policy" / "bigtranslate" / "product-types.xml")
+    for node in types.getroot().iter("type"):
+        if node.get("name") == "EmploymentStringChunk":
+            versioner = node.find("versioner")
+            assert versioner is not None
+            assert "InPlaceVersioner" not in versioner.get("class", ""), (
+                "an in place versioner cannot move a chunk into its "
+                "repository; the transfer is asked to move a file onto "
+                "itself and nothing is catalogued")
+            break
+    else:
+        raise AssertionError("EmploymentStringChunk is not declared")
+
+
+def test_the_join_starts_itself():
+    """Nobody should have to watch for the moment to fire stage three.
+
+    Over a run of several hours that is a person sitting with it. The join
+    is created once by extract and held by a condition until every chunk
+    has an answer.
+    """
+    conditions = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+                  / "conditions.xml").read_text()
+    assert "ProductCountSettledCondition" in conditions, (
+        "nothing waits for the translations to finish")
+    assert "EmploymentTranslatedChunk" in conditions, (
+        "the condition counts the wrong thing")
+
+    tasks = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+             / "tasks.xml").read_text()
+    start = tasks.index('<task id="urn:bigtranslate:Join_Index_Task"')
+    block = tasks[start:tasks.index("</task>", start)]
+    assert "TranslationsSettled" in block, (
+        "the join is not held by the condition, so it would run against a "
+        "partial set of translations")
+
+    extract = (REPO / "pge" / "src" / "main" / "resources" / "policy"
+               / "no_filter" / "PgeConfig_ExtractStrings.xml").read_text()
+    assert "EmploymentTranslationsComplete" in extract, (
+        "nothing ever creates the join instance")
+
+
+def test_the_join_is_started_once_not_once_per_chunk():
+    """Triggering it from each catalogued chunk makes one join per chunk."""
+    events = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+              / "events.xml").read_text()
+    assert "EmploymentTranslatedChunkIngest" not in events, (
+        "a translated chunk starts a join, so every chunk starts one")
+
+
+def test_the_translated_chunks_are_counted_without_disturbing_the_join():
+    """The join globs a flat directory; the versioner nests what it stores."""
+    import xml.etree.ElementTree as ET
+    types = ET.parse(REPO / "filemgr" / "src" / "main" / "resources"
+                     / "policy" / "bigtranslate" / "product-types.xml")
+    for node in types.getroot().iter("type"):
+        if node.get("name") == "EmploymentTranslatedChunk":
+            repo = node.find("repository").get("path")
+            assert repo.rstrip("/").endswith("translated-catalog"), (
+                "the catalogued copies share the directory the join globs, "
+                "so the versioner's nesting would hide them: %s" % repo)
+            return
+    raise AssertionError("EmploymentTranslatedChunk is not declared")
+
+
+def test_an_engine_driven_run_is_visible():
+    """bin/bigtranslate writes the marker for a run it starts. A run the
+    engine drives has no such caller, and Gloss showed IDLE throughout one."""
+    policy = REPO / "pge" / "src" / "main" / "resources" / "policy" / "no_filter"
+    assert "bt-run-marker start" in (policy / "PgeConfig_ExtractStrings.xml").read_text()
+    assert "bt-run-marker beat" in (policy / "PgeConfig_TranslateChunk.xml").read_text()
+    assert "bt-run-marker clear" in (policy / "PgeConfig_JoinIndex.xml").read_text()
+    assert (REPO / "distribution" / "src" / "main" / "resources" / "bin"
+            / "bt-run-marker").exists()

--- a/tests/test_w2_pipeline.py
+++ b/tests/test_w2_pipeline.py
@@ -622,3 +622,75 @@ def test_an_engine_driven_run_is_visible():
     assert "bt-run-marker clear" in (policy / "PgeConfig_JoinIndex.xml").read_text()
     assert (REPO / "distribution" / "src" / "main" / "resources" / "bin"
             / "bt-run-marker").exists()
+
+
+def test_the_join_covers_the_whole_corpus():
+    """JoinShards said eight and only shard zero ever ran.
+
+    Nothing created instances for the other seven, so a corpus was indexed
+    one eighth of the way and the run reported Success: 54,634 documents
+    out of 327,232, with every workflow instance green. A wrong answer
+    that looks right is worse than a failure.
+    """
+    join = (REPO / "pge" / "src" / "main" / "resources" / "policy"
+            / "no_filter" / "PgeConfig_JoinIndex.xml").read_text()
+    assert "seq 0" in join and "[JoinShards]" in join, (
+        "the join still runs a single hardcoded shard")
+    assert "--commit-only" in join, (
+        "no single commit after the shards; committing per shard sets "
+        "eight merges competing")
+
+
+def test_commit_only_does_not_also_reindex():
+    source = (REPO / "distribution" / "src" / "main" / "resources" / "bin"
+              / "bt-join-index").read_text()
+    assert "if args.commit_only:" in source
+    body = source[source.index("if args.commit_only:"):]
+    body = body[:body.index("paths = sorted")]
+    assert "return 0" in body, (
+        "commit-only falls through and indexes the corpus again")
+
+
+def test_the_join_refuses_a_partial_translation():
+    """The worst failure this pipeline can produce.
+
+    A quiet period is a guess. Chunks are length sorted, so the last ones
+    take the longest and a gap between two of them looks exactly like the
+    end of the run. One join started on seven chunks of ten and indexed
+    every record: 327,232 of 327,232 documents, every workflow instance
+    green, the run marker cleared -- and the longest strings still in
+    Spanish. A wrong answer that looks right.
+    """
+    source = (REPO / "distribution" / "src" / "main" / "resources" / "bin"
+              / "bt-join-index").read_text()
+    assert "def wait_for_chunks(" in source, (
+        "the join does not wait for the chunks it needs")
+    assert "refusing to" in source, (
+        "the join proceeds on a partial set rather than refusing")
+    join = (REPO / "pge" / "src" / "main" / "resources" / "policy"
+            / "no_filter" / "PgeConfig_JoinIndex.xml").read_text()
+    assert "--expect" in join, "the join is never told how many to expect"
+    assert "EXPECTED=" in join, (
+        "the expected count is hardcoded rather than counted")
+
+
+def test_waiting_for_chunks_counts_what_is_there(tmp_path):
+    """Exercised, since the consequence of getting it wrong is silent."""
+    import importlib.machinery
+    import importlib.util
+    path = BIN / "bt-join-index"
+    spec = importlib.util.spec_from_loader(
+        "bt_join_index",
+        importlib.machinery.SourceFileLoader("bt_join_index", str(path)))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    d = tmp_path / "translated"
+    d.mkdir()
+    assert module.count_chunks(str(d)) == 0
+    for i in range(3):
+        (d / ("chunk-%05d.json" % i)).write_text("{}")
+    assert module.count_chunks(str(d)) == 3
+    # A partial set must time out rather than be accepted.
+    got = module.wait_for_chunks(str(d), 5, timeout=1, poll=1)
+    assert got == 3, "waiting invented chunks that are not there"

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
@@ -35,6 +35,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.oodt.cas.filemgr.structs.Product;
@@ -52,6 +53,13 @@ public class ProcessBtWrapper {
 
   public static final String IDLE = "IDLE";
   public static final String TRANSLATING = "TRANSLATING";
+
+  /**
+   * How long a marker may go unrefreshed before it counts as dead. The
+   * writer beats it every poll, so this is many polls: a slow machine
+   * should not be mistaken for a stopped run.
+   */
+  static final long STALE_AFTER_MILLIS = 10L * 60L * 1000L;
   public static final String RESETTING = "RESETTING";
   public static final String ERROR = "ERROR";
 
@@ -93,6 +101,15 @@ public class ProcessBtWrapper {
     Map<String, Object> snap = new LinkedHashMap<String, Object>();
 
     Map<String, Object> recorded = RunMarker.read();
+    if (isStale(recorded)) {
+      // A marker whose heartbeat stopped is a run that stopped. Left alone
+      // it is reported as in progress for as long as the file exists: one
+      // sat for a day naming the previous afternoon's corpus while a
+      // different run was genuinely under way.
+      LOG.log(Level.INFO, "Clearing a run marker whose heartbeat stopped");
+      RunMarker.clear();
+      recorded = null;
+    }
     if (recorded != null && !TRANSLATING.equals(status)
         && !RESETTING.equals(status)) {
       // Something is running and it was not started here.
@@ -110,6 +127,30 @@ public class ProcessBtWrapper {
     snap.put("message", message);
     snap.put("startedAt", startedAt == 0 ? null : Long.valueOf(startedAt));
     return snap;
+  }
+
+  /**
+   * Whether a recorded run has stopped being refreshed.
+   *
+   * <p>The writer beats the marker on every poll of its wait loop, so a
+   * heartbeat older than many polls means nothing is tending it. A marker
+   * with no heartbeat at all was written by an older version and is
+   * trusted, there being nothing better to go on.</p>
+   */
+  static boolean isStale(Map<String, Object> recorded) {
+    if (recorded == null) {
+      return false;
+    }
+    Object beat = recorded.get("heartbeatAt");
+    if (beat == null) {
+      return false;
+    }
+    try {
+      long last = Long.parseLong(String.valueOf(beat).trim());
+      return System.currentTimeMillis() - last > STALE_AFTER_MILLIS;
+    } catch (NumberFormatException e) {
+      return false;
+    }
   }
 
   private static String asText(Object value, String fallback) {

--- a/webapps/gloss-services/src/test/java/org/bigtranslate/gloss/TestStaleRunMarker.java
+++ b/webapps/gloss-services/src/test/java/org/bigtranslate/gloss/TestStaleRunMarker.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bigtranslate.gloss;
+
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Telling a running translation from one that stopped.
+ *
+ * <p>The marker used to be evidence only that a run had once begun. A run
+ * whose script died left one behind, and Gloss reported a translation in
+ * progress for as long as the file existed: one sat for a day, naming the
+ * previous afternoon's corpus, while a different run was genuinely under
+ * way and invisible.</p>
+ */
+public class TestStaleRunMarker {
+
+  private Map<String, Object> marker(Long heartbeatAt) {
+    Map<String, Object> recorded = new LinkedHashMap<String, Object>();
+    recorded.put("status", "TRANSLATING");
+    recorded.put("path", "/corpus");
+    recorded.put("startedAt", Long.valueOf(1L));
+    if (heartbeatAt != null) {
+      recorded.put("heartbeatAt", heartbeatAt);
+    }
+    return recorded;
+  }
+
+  @Test
+  public void testAFreshHeartbeatIsARunningTranslation() {
+    assertFalse(ProcessBtWrapper.isStale(
+        marker(Long.valueOf(System.currentTimeMillis()))));
+  }
+
+  @Test
+  public void testAHeartbeatThatStoppedIsNotARunningTranslation() {
+    long longAgo = System.currentTimeMillis()
+        - ProcessBtWrapper.STALE_AFTER_MILLIS - 1000L;
+    assertTrue("a marker nobody is tending must not read as in progress",
+        ProcessBtWrapper.isStale(marker(Long.valueOf(longAgo))));
+  }
+
+  @Test
+  public void testAMarkerFromAnOlderVersionIsTrusted() {
+    // No heartbeat at all: written before this existed. There is nothing
+    // better to go on, so it is taken at face value as it always was.
+    assertFalse(ProcessBtWrapper.isStale(marker(null)));
+  }
+
+  @Test
+  public void testNoMarkerIsNotStale() {
+    assertFalse(ProcessBtWrapper.isStale(null));
+  }
+
+  @Test
+  public void testAnUnreadableHeartbeatIsTrusted() {
+    Map<String, Object> recorded = marker(null);
+    recorded.put("heartbeatAt", "not a number");
+    assertFalse("a marker we cannot read is not evidence of a dead run",
+        ProcessBtWrapper.isStale(recorded));
+  }
+}

--- a/workflow/src/main/resources/bin/wmgr
+++ b/workflow/src/main/resources/bin/wmgr
@@ -69,10 +69,20 @@ if $cygwin; then
 fi
 
 if [ "$1" = "start" ]; then
+  # A pid file whose process is gone is not a running service. It is what
+  # a crash or a kill -9 leaves behind, and treating it as "still running"
+  # means the next start refuses for as long as the file sits there, with a
+  # message that sends you looking for a process that does not exist.
   if [ ! -z "$WORKFLOW_PID" ]; then
     if [ -f "$WORKFLOW_PID" ]; then
-      echo "PID file ($WORKFLOW_PID) found. Is Workflow Manager still running? Start aborted."
-      exit 1
+      _pid=`cat "$WORKFLOW_PID" 2>/dev/null`
+      if [ -n "$_pid" ] && kill -0 "$_pid" 2>/dev/null; then
+        echo "Workflow Manager is already running (pid $_pid). Start aborted."
+        exit 1
+      fi
+      echo "Removing stale pid file ($WORKFLOW_PID); no process $_pid is running."
+      rm -f "$WORKFLOW_PID"
+      unset _pid
     fi
   fi
 

--- a/workflow/src/main/resources/policy/conditions.xml
+++ b/workflow/src/main/resources/policy/conditions.xml
@@ -18,4 +18,25 @@
 <!--
   TODO: Add some examples
 -->
+
+  <!-- The join must not start until every chunk has an answer.
+       A count that has stopped rising is how it knows: translated chunks
+       are catalogued as they are produced, and when no new one has arrived
+       for a while there are no more coming.
+
+       Without this the join has to be started by hand, which over a run of
+       several hours means somebody watching for the moment to do it. -->
+  <condition id="urn:bigtranslate:TranslationsSettled" name="Translations Settled"
+             class="org.apache.oodt.cas.pge.condition.ProductCountSettledCondition">
+    <configuration>
+      <property name="FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
+      <property name="ProductTypeName" value="EmploymentTranslatedChunk"/>
+      <!-- At least one, so the join cannot run against nothing at all. -->
+      <property name="MinCount" value="1"/>
+      <!-- A chunk takes minutes, so a couple of minutes of quiet is a real
+           pause rather than the gap between two of them. -->
+      <property name="QuietSeconds" value="120"/>
+    </configuration>
+  </condition>
+
 </cas:conditions>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -126,6 +126,12 @@
           <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
           <property name="PCS_MetFileExtension" value="met"/>
           <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <!-- Where the crawler actions live. Without it PCS_ActionsIds
+               names beans that cannot be resolved, so the post ingest
+               trigger never runs: products are catalogued and the stage
+               that should follow them is never started, with nothing
+               logged to say why. -->
+          <property name="PCS_ActionRepoFile" value="file:[BIGTRANSLATE_HOME]/crawler/policy/action-beans.xml" envReplace="true"/>
           <!-- Read in place. The corpus is 38GB on an external volume and
                copying it buys nothing: a single pass over it takes five
                minutes and happens once. -->
@@ -149,6 +155,12 @@
           <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
           <property name="PCS_MetFileExtension" value="met"/>
           <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <!-- Where the crawler actions live. Without it PCS_ActionsIds
+               names beans that cannot be resolved, so the post ingest
+               trigger never runs: products are catalogued and the stage
+               that should follow them is never started, with nothing
+               logged to say why. -->
+          <property name="PCS_ActionRepoFile" value="file:[BIGTRANSLATE_HOME]/crawler/policy/action-beans.xml" envReplace="true"/>
           <property name="TranslatedDir" value="[BIGTRANSLATE_HOME]/data/translated" envReplace="true"/>
           <property name="PantoglossUrl" value="[PANTOGLOSS_URL]" envReplace="true"/>
           <!-- 32 suits the CPU service, 128 a CUDA one. A node translating
@@ -173,7 +185,9 @@
 
   <task id="urn:bigtranslate:Join_Index_Task" name="Join_Index_Task"
     class="org.apache.oodt.cas.pge.StdPGETaskInstance">
-        <conditions/>
+        <conditions>
+          <condition id="urn:bigtranslate:TranslationsSettled"/>
+        </conditions>
         <configuration>
           <property name="PGETask_Name" value="Join_Index_Task"/>
           <property name="PGETask_ConfigFilePath" value="[BIGTRANSLATE_HOME]/pge/policy/no_filter/PgeConfig_JoinIndex.xml" envReplace="true"/>
@@ -182,6 +196,12 @@
           <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
           <property name="PCS_MetFileExtension" value="met"/>
           <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <!-- Where the crawler actions live. Without it PCS_ActionsIds
+               names beans that cannot be resolved, so the post ingest
+               trigger never runs: products are catalogued and the stage
+               that should follow them is never started, with nothing
+               logged to say why. -->
+          <property name="PCS_ActionRepoFile" value="file:[BIGTRANSLATE_HOME]/crawler/policy/action-beans.xml" envReplace="true"/>
           <property name="CorpusDir" value="[BIGTRANSLATE_CORPUS]" envReplace="true"/>
           <property name="TranslatedDir" value="[BIGTRANSLATE_HOME]/data/translated" envReplace="true"/>
           <property name="SolrUrl" value="[SOLR_URL]" envReplace="true"/>


### PR DESCRIPTION
Everything between "the stages work" and "you can start it and walk away".

## The join starts itself

Extract creates it once; a condition holds it. Creating it per catalogued chunk would make one join per chunk, all waiting on the same condition and then all doing the same work.

## It refuses to index a translation that is not finished

The most dangerous bug of the session. The self-driving run produced **327,232 of 327,232 documents, every workflow instance green, the marker cleared — and the longest strings still in Spanish.**

`ProductCountSettledCondition` waits for the count to stop rising, which is a **guess**. Chunks are sorted by length, so the last ones hold the longest strings and take longest; a two-minute gap between two of them is indistinguishable from the end of the run. The join began on 7 chunks of 10 and indexed every record with whatever it had — and since a missing translation deliberately leaves the original in place, nothing was empty and nothing failed.

Sampled afterwards: **4 of 4 long strings from chunk 9 were still Spanish in the index.**

The join now counts the chunks it must wait for and refuses to run on fewer. Re-verified: 10/10 chunks before the join, 0 of 6 sampled strings untranslated.

## Every shard runs

`JoinShards` said 8 and only shard 0 ever ran — one eighth of a corpus indexed and reported as success (54,634 of 327,232).

## Gloss can see the run

`bin/bigtranslate` wrote the marker for a run it started; an engine-driven run has no such caller, so Gloss showed IDLE throughout one. The stages write it now. And a marker isn't evidence of a *running* job: one sat for a day naming the previous afternoon's corpus while a different run was underway and invisible. It carries a heartbeat, and one that stopped is treated as wreckage.

## The launchers stop obeying dead pid files

A pid file was proof of life, so after a crash every later start refused, naming a process that no longer existed. The resource manager sat down for an hour that way.

## A run has somewhere to start from, and time to finish

`bt-reset` clears what a run derives and nothing else — refusing while the services are up, and never touching the corpus. `bt-initdb` builds the instance schema. The join's wait goes from 4h to 24h: translation alone is 2.4–9 hours at full scale, so 4 would have refused a healthy run at 3am.

354 tests pass, 19 new.