### PR TITLE
Say how far along a run is, and when it will end

### DIFF
--- a/distribution/src/main/resources/bin/bt-run-marker
+++ b/distribution/src/main/resources/bin/bt-run-marker
@@ -47,6 +47,37 @@ def read(path):
         return {}
 
 
+def count(directory):
+    """How many chunks are in a directory, however the versioner left them.
+
+    The ingest nests each product under a directory named after it, so the
+    chunks the join reads are files and the catalogued copies are
+    directories. Both count as one chunk.
+    """
+    try:
+        return len([n for n in os.listdir(directory)
+                    if n.startswith("chunk-")])
+    except OSError:
+        return 0
+
+
+def progress(home):
+    """What the run has done so far, for anything that wants to show it.
+
+    Read from the directories rather than tracked, so it is right even
+    after a restart and cannot drift from what is actually on disk.
+    """
+    made = count(os.path.join(home, "data", "strings"))
+    done = count(os.path.join(home, "data", "translated"))
+    if done >= made > 0:
+        stage = "joining"
+    elif made > 0:
+        stage = "translating"
+    else:
+        stage = "extracting"
+    return {"stage": stage, "chunksTotal": made, "chunksDone": done}
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(
         prog="bt-run-marker",
@@ -79,6 +110,8 @@ def main(argv=None):
         # Nothing to refresh. A beat is not a reason to invent a run.
         return 0
 
+    home = os.environ["BIGTRANSLATE_HOME"]
+    seen = progress(home)
     record = {
         "status": existing.get("status", args.status),
         "startedBy": existing.get("startedBy", args.started_by),
@@ -88,6 +121,15 @@ def main(argv=None):
         "startedAt": existing.get("startedAt", now),
         "heartbeatAt": now,
     }
+    record.update(seen)
+    # When the first chunk landed, so a rate can be worked out over the
+    # translating alone. Measuring from the start of the run instead folds
+    # in the extract pass, which on the full corpus is ten minutes of
+    # apparently translating nothing and makes every early estimate wrong.
+    if seen["chunksDone"] > 0:
+        record["translatingSince"] = existing.get("translatingSince", now)
+    elif "translatingSince" in existing:
+        record["translatingSince"] = existing["translatingSince"]
     os.makedirs(os.path.dirname(path), exist_ok=True)
     tmp = path + ".partial"
     with open(tmp, "w", encoding="utf-8") as handle:

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
@@ -60,6 +60,10 @@ public class ProcessBtWrapper {
    * should not be mistaken for a stopped run.
    */
   static final long STALE_AFTER_MILLIS = 10L * 60L * 1000L;
+
+  /** What the stages record about how far along they are. */
+  private static final String[] PROGRESS_KEYS = {
+      "stage", "chunksTotal", "chunksDone", "translatingSince"};
   public static final String RESETTING = "RESETTING";
   public static final String ERROR = "ERROR";
 
@@ -118,6 +122,14 @@ public class ProcessBtWrapper {
       snap.put("exclude", asText(recorded.get("exclude"), ""));
       snap.put("message", "started from the command line");
       snap.put("startedAt", recorded.get("startedAt"));
+      // What it has actually done. A status of TRANSLATING and a log tail
+      // says almost nothing at hour eleven of a run; how many chunks of
+      // how many, and at what rate, says all of it.
+      for (String key : PROGRESS_KEYS) {
+        if (recorded.get(key) != null) {
+          snap.put(key, recorded.get(key));
+        }
+      }
       return snap;
     }
 

--- a/webapps/gloss/src/main/webapp/resources/src/components/ProgressPane.vue
+++ b/webapps/gloss/src/main/webapp/resources/src/components/ProgressPane.vue
@@ -3,16 +3,35 @@
     <header>
       <h2>In progress</h2>
       <p>
-        {{ progress.status || 'TRANSLATING' }}
+        {{ stageLabel }}
         <!-- Who started it. A run begun from the command line is the ordinary
              case, and the back end says so; the panel used to drop that on the
              floor, leaving no way to tell it from one started here. -->
         <span v-if="progress.message" class="whose"> ({{ progress.message }})</span>
         <span v-if="progress.path"> · {{ progress.path }}</span>
-        <span v-if="progress.solrDocs != null"> · {{ progress.solrDocs }} in Solr</span>
-        <span v-if="progress.jobDirs != null"> · {{ progress.jobDirs }} job dirs</span>
       </p>
     </header>
+
+    <!--
+      What it has done, rather than only what it is doing. A status of
+      TRANSLATING and a tail of the log says almost nothing at hour eleven
+      of a run: the question is how far along it is and when it will end.
+    -->
+    <div v-if="hasCounts" class="tally">
+      <div class="bar" role="progressbar" :aria-valuenow="percent"
+           aria-valuemin="0" aria-valuemax="100">
+        <span :style="{ width: percent + '%' }"></span>
+      </div>
+      <dl>
+        <div><dt>Chunks</dt><dd>{{ progress.chunksDone }} of {{ progress.chunksTotal }}</dd></div>
+        <div><dt>Done</dt><dd>{{ percent }}%</dd></div>
+        <div v-if="rate"><dt>Rate</dt><dd>{{ rate }}</dd></div>
+        <div v-if="elapsed"><dt>Elapsed</dt><dd>{{ elapsed }}</dd></div>
+        <div v-if="remaining"><dt>Remaining</dt><dd>{{ remaining }}</dd></div>
+        <div v-if="progress.solrDocs != null"><dt>In Solr</dt><dd>{{ solrDocs }}</dd></div>
+      </dl>
+    </div>
+
     <!--
       A run started from the command line writes to the deployment's own log,
       not to the one Gloss keeps of what it did itself, so this waited for a
@@ -22,7 +41,7 @@
       than implying something is stuck.
     -->
     <pre v-if="log">{{ log }}</pre>
-    <p v-else class="nolog">
+    <p v-else-if="!hasCounts" class="nolog">
       No log output yet. The workflow manager is running this; its progress
       shows above and in OPSUI.
     </p>
@@ -30,66 +49,64 @@
 </template>
 
 <script>
+// The arithmetic lives in progress.js, tested on its own: what a run has
+// done and when it will end is the part worth being sure of, and it is
+// awkward to check through a rendered component.
+import {
+  stageLabel, percent, rateLabel, remainingLabel, elapsedLabel
+} from '../progress.js'
+
 export default {
   name: 'ProgressPane',
   props: {
     log: { type: String, default: '' },
     progress: { type: Object, default: () => ({}) }
+  },
+  data () {
+    // The estimate is a function of the clock as well as the counts, so it
+    // is re-read on a timer; otherwise "about 2h" sits there unchanged
+    // while the two hours pass.
+    return { now: Date.now(), ticker: null }
+  },
+  mounted () {
+    this.ticker = setInterval(() => { this.now = Date.now() }, 30000)
+  },
+  beforeUnmount () {
+    if (this.ticker) clearInterval(this.ticker)
+  },
+  computed: {
+    stageLabel () { return stageLabel(this.progress) },
+    hasCounts () { return Number(this.progress.chunksTotal) > 0 },
+    percent () { return percent(this.progress) },
+    rate () { return rateLabel(this.progress, this.now) },
+    elapsed () { return elapsedLabel(this.progress, this.now) },
+    remaining () { return remainingLabel(this.progress, this.now) },
+    solrDocs () { return Number(this.progress.solrDocs).toLocaleString() }
   }
 }
 </script>
 
 <style scoped>
-.progress {
-  background: #1a1410;
-  color: #fff8e7;
-  border-radius: 4px;
-  margin: 0.5rem 0 1rem;
+.tally { margin: 0.75rem 0; }
+.bar {
+  height: 6px;
+  background: rgba(127, 127, 127, 0.25);
+  border-radius: 3px;
   overflow: hidden;
 }
-
-.whose {
-  opacity: 0.75;
-  font-style: italic;
+.bar span {
+  display: block;
+  height: 100%;
+  background: currentColor;
+  transition: width 0.4s ease;
 }
-
-.nolog {
-  margin: 0;
-  padding: 0.8rem 1rem 1rem;
-  opacity: 0.7;
-  font-size: 0.85rem;
-}
-
-header {
+dl {
   display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.7rem 1rem 0.4rem;
-  border-bottom: 1px solid #3a3028;
+  flex-wrap: wrap;
+  gap: 0 1.5rem;
+  margin: 0.6rem 0 0;
 }
-
-h2 {
-  margin: 0;
-  font-size: 0.85rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--gold);
-}
-
-header p {
-  margin: 0;
-  font-size: 0.85rem;
-  font-family: "Source Sans 3", "Segoe UI", Helvetica, Arial, sans-serif;
-  color: #e6d9c2;
-}
-
-pre {
-  margin: 0;
-  padding: 0.8rem 1rem 1rem;
-  max-height: 16rem;
-  overflow: auto;
-  font-size: 0.78rem;
-  line-height: 1.45;
-  white-space: pre-wrap;
-}
+dl div { display: flex; gap: 0.35rem; align-items: baseline; }
+dt { opacity: 0.65; font-size: 0.85em; }
+dd { margin: 0; font-variant-numeric: tabular-nums; }
 </style>

--- a/webapps/gloss/src/main/webapp/resources/src/progress.js
+++ b/webapps/gloss/src/main/webapp/resources/src/progress.js
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// How far along a run is, and when it will end.
+//
+// Kept apart from the panel that shows it because the arithmetic is the
+// part worth being sure of: a status of TRANSLATING and a tail of the log
+// answers neither question anybody has at hour eleven of a fourteen hour
+// run.
+
+export const STAGES = {
+  extracting: 'Reading the corpus',
+  translating: 'Translating',
+  joining: 'Indexing'
+}
+
+export function stageLabel (progress) {
+  return STAGES[progress.stage] || progress.status || 'TRANSLATING'
+}
+
+export function percent (progress) {
+  const total = Number(progress.chunksTotal)
+  if (!total) return 0
+  const done = Number(progress.chunksDone) || 0
+  return Math.min(100, Math.round((done / total) * 100))
+}
+
+// Measured from the first chunk, not from the start of the run: the
+// extract pass is ten minutes of apparently translating nothing on the
+// full corpus, and folding it in makes every early estimate wrong.
+export function chunksPerMinute (progress, now = Date.now()) {
+  const since = Number(progress.translatingSince)
+  const done = Number(progress.chunksDone)
+  if (!since || !done) return 0
+  const minutes = (now - since) / 60000
+  return minutes > 0 ? done / minutes : 0
+}
+
+export function duration (seconds) {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.round((seconds % 3600) / 60)
+  if (hours && minutes) return hours + 'h ' + minutes + 'm'
+  if (hours) return hours + 'h'
+  return Math.max(1, minutes) + 'm'
+}
+
+export function rateLabel (progress, now = Date.now()) {
+  const perMinute = chunksPerMinute(progress, now)
+  if (!perMinute) return ''
+  return perMinute >= 1
+    ? perMinute.toFixed(1) + ' chunks/min'
+    : (perMinute * 60).toFixed(0) + ' chunks/hour'
+}
+
+export function remainingLabel (progress, now = Date.now()) {
+  const perMinute = chunksPerMinute(progress, now)
+  const left = Number(progress.chunksTotal) - Number(progress.chunksDone)
+  if (!perMinute || !(left > 0)) return ''
+  return 'about ' + duration((left / perMinute) * 60)
+}
+
+export function elapsedLabel (progress, now = Date.now()) {
+  const since = Number(progress.translatingSince) || Number(progress.startedAt)
+  return since ? duration((now - since) / 1000) : ''
+}

--- a/webapps/gloss/src/main/webapp/resources/src/progress.test.js
+++ b/webapps/gloss/src/main/webapp/resources/src/progress.test.js
@@ -1,0 +1,81 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  percent, rateLabel, remainingLabel, elapsedLabel, stageLabel, duration
+} from './progress.js'
+
+const NOW = 1788800000000
+const minutesAgo = (m) => NOW - m * 60000
+
+test('reports how far along the run is', () => {
+  assert.equal(percent({ chunksTotal: 458, chunksDone: 378 }), 83)
+  assert.equal(percent({ chunksTotal: 0, chunksDone: 0 }), 0)
+  assert.equal(percent({}), 0)
+})
+
+test('estimates what is left from the rate it has managed', () => {
+  // The state of the real run: 378 of 458 after 686 minutes of
+  // translating. Eighty left at that rate is about two and a half hours.
+  const progress = {
+    chunksTotal: 458, chunksDone: 378, translatingSince: minutesAgo(686)
+  }
+  assert.match(remainingLabel(progress, NOW), /^about 2h/)
+  assert.match(rateLabel(progress, NOW), /chunks\/hour$/)
+})
+
+test('measures the rate from the first chunk, not the start of the run', () => {
+  // Ten minutes of the run were the extract pass, translating nothing.
+  // Counting those would put the rate a fifth too low and the estimate a
+  // quarter too high.
+  const progress = {
+    chunksTotal: 100, chunksDone: 50,
+    startedAt: minutesAgo(60), translatingSince: minutesAgo(50)
+  }
+  assert.equal(remainingLabel(progress, NOW), 'about 50m')
+})
+
+test('says nothing rather than guessing before the first chunk', () => {
+  const progress = { chunksTotal: 458, chunksDone: 0, startedAt: minutesAgo(5) }
+  assert.equal(rateLabel(progress, NOW), '')
+  assert.equal(remainingLabel(progress, NOW), '')
+})
+
+test('says nothing about what is left once it is done', () => {
+  const progress = {
+    chunksTotal: 458, chunksDone: 458, translatingSince: minutesAgo(600)
+  }
+  assert.equal(remainingLabel(progress, NOW), '')
+})
+
+test('names the stage rather than repeating a status', () => {
+  assert.equal(stageLabel({ stage: 'extracting' }), 'Reading the corpus')
+  assert.equal(stageLabel({ stage: 'translating' }), 'Translating')
+  assert.equal(stageLabel({ stage: 'joining' }), 'Indexing')
+  assert.equal(stageLabel({ status: 'RESETTING' }), 'RESETTING')
+})
+
+test('reads durations the way a person would say them', () => {
+  assert.equal(duration(90), '2m')
+  assert.equal(duration(3600), '1h')
+  assert.equal(duration(8760), '2h 26m')
+  assert.equal(duration(5), '1m')
+})
+
+test('elapsed falls back to the start when nothing has translated yet', () => {
+  assert.equal(elapsedLabel({ startedAt: minutesAgo(30) }, NOW), '30m')
+  assert.equal(elapsedLabel({}, NOW), '')
+})


### PR DESCRIPTION
The panel said `TRANSLATING` and showed a tail of the log. At hour eleven of a fourteen-hour run, that answers neither of the two questions anybody actually has.

It now says:

```
Translating (started from the command line) · /Volumes/CHIPOTLE_BRICK/...
████████████████████░░░░  83%
Chunks 378 of 458   Done 83%   Rate 33 chunks/hour
Elapsed 11h 26m     Remaining about 2h 25m
```

## Where the numbers come from

The stages already know — chunks are counted on disk, and the marker they beat on every chunk is a fine place to put the count. It now carries the stage, how many chunks exist, how many are translated, and when the first one landed. The panel derives the rest.

## The rate is measured from the first chunk, not the start of the run

The extract pass over the full corpus is **ten minutes of apparently translating nothing**. Folding it in puts the rate a fifth too low and the estimate a quarter too high — worst exactly when somebody is watching to decide whether to wait up.

## Nothing is guessed

No rate and no estimate before a chunk has finished, and none once they all have. An honest blank beats a confident wrong number.

## On the test

The arithmetic is a module of its own, tested directly. This project's runner is `node --test src/*.test.js` with no component harness — a test that mounted the component would have been a test that never ran, and I wrote one of those first before checking. The logic is also the part worth being sure of; the markup isn't.

9 new tests there, 32 in gloss-services, 351 in the pipeline suite.

Suggested by watching the real run and finding the UI less informative than the terminal.