### PR TITLE
Share one translation table instead of copying it per shard

### DIFF
--- a/distribution/src/main/resources/bin/bt-build-translation-db
+++ b/distribution/src/main/resources/bin/bt-build-translation-db
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gather the translated chunks into one database the join can share.
+
+Every join shard needs the whole translation table, because any row may
+hold any string. Read as JSON into a dict that is 207MB of text and about
+456MB in memory, and eight shards hold eight copies of it: three and a half
+gigabytes of the same data, which is what put the machine over.
+
+A database is one copy. Each shard opens it read only, and the pages they
+read are held once by the operating system rather than once per process.
+"""
+import argparse
+import glob
+import json
+import os
+import sqlite3
+import sys
+import time
+
+
+def log(message):
+    sys.stderr.write("%s %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
+    sys.stderr.flush()
+
+
+def build(translated_dir, out_path):
+    chunks = sorted(glob.glob(os.path.join(translated_dir, "chunk-*.json")))
+    if not chunks:
+        raise SystemExit("no translated chunks under %s" % translated_dir)
+
+    # Written beside the target and renamed, so a database that exists is a
+    # database that is complete. A join that opened a half built one would
+    # leave the strings it had not reached in their source language, which
+    # is the failure this pipeline has already had once.
+    tmp = out_path + ".partial"
+    for stale in (tmp, tmp + "-journal"):
+        if os.path.exists(stale):
+            os.remove(stale)
+
+    conn = sqlite3.connect(tmp)
+    try:
+        # No journal and no fsync: this file is derived, and if the build
+        # is interrupted it is rebuilt rather than repaired.
+        conn.execute("PRAGMA journal_mode = OFF")
+        conn.execute("PRAGMA synchronous = OFF")
+        conn.execute("CREATE TABLE t (s TEXT PRIMARY KEY, e TEXT) WITHOUT ROWID")
+
+        total = 0
+        for number, path in enumerate(chunks, 1):
+            with open(path, encoding="utf-8") as handle:
+                pairs = json.load(handle)
+            conn.executemany("INSERT OR REPLACE INTO t (s, e) VALUES (?, ?)",
+                             pairs.items())
+            total += len(pairs)
+            if number % 100 == 0 or number == len(chunks):
+                log("  %d/%d chunks, %d translations" % (number, len(chunks), total))
+        conn.commit()
+    finally:
+        conn.close()
+
+    os.replace(tmp, out_path)
+    return len(chunks), total
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="bt-build-translation-db",
+        description="Gather translated chunks into one database for the join.")
+    parser.add_argument("--translated", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--force", action="store_true",
+                        help="rebuild even if the database already exists")
+    args = parser.parse_args(argv)
+
+    if os.path.exists(args.out) and not args.force:
+        log("%s already exists; leaving it alone" % args.out)
+        return 0
+
+    started = time.time()
+    chunks, total = build(args.translated, args.out)
+    size = os.path.getsize(args.out) / 1048576.0
+    log("%d translations from %d chunks -> %s (%.0f MB) in %.0fs"
+        % (total, chunks, args.out, size, time.time() - started))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/distribution/src/main/resources/bin/bt-join-index
+++ b/distribution/src/main/resources/bin/bt-join-index
@@ -31,6 +31,7 @@ import glob
 import json
 import os
 import sys
+import sqlite3
 import time
 import urllib.error
 import urllib.request
@@ -46,19 +47,55 @@ def read_columns(path):
         return [line.strip() for line in handle if line.strip()]
 
 
-def load_translations(directory):
-    """Every translated chunk, merged into one lookup.
+class Translations(object):
+    """The translation table, shared rather than copied.
 
-    Chunks hold distinct strings and the extract stage made them disjoint,
-    so a later chunk cannot contradict an earlier one; merging is a plain
-    update rather than a reconciliation.
+    Read as JSON into a dict it is about 456MB, and every shard holds its
+    own: eight of them is three and a half gigabytes of the same data, and
+    that is what put a machine over during the first full run. Backed by a
+    database instead, the pages are held once by the operating system
+    however many shards are reading.
+
+    A bounded cache sits in front. The corpus repeats itself heavily -- 836
+    million cells are only 2.29 million distinct strings -- so a small cache
+    answers nearly everything and the database sees very little traffic.
     """
-    table = {}
-    paths = sorted(glob.glob(os.path.join(directory, "chunk-*.json")))
-    for path in paths:
-        with open(path, encoding="utf-8") as handle:
-            table.update(json.load(handle))
-    return table, len(paths)
+
+    def __init__(self, path, cache_limit=200000):
+        # Read only, so several shards can share one file without any of
+        # them being able to alter it.
+        self.conn = sqlite3.connect("file:%s?mode=ro" % path, uri=True)
+        self.conn.execute("PRAGMA query_only = 1")
+        self.cache = {}
+        self.cache_limit = cache_limit
+        self.hits = 0
+        self.misses = 0
+
+    def get(self, source, default=None):
+        cached = self.cache.get(source)
+        if cached is not None:
+            self.hits += 1
+            return cached
+        self.misses += 1
+        row = self.conn.execute(
+            "SELECT e FROM t WHERE s = ?", (source,)).fetchone()
+        if row is None:
+            return default
+        if len(self.cache) < self.cache_limit:
+            # Not an LRU. Evicting properly costs more than it saves here,
+            # and what fills the cache first is what the corpus repeats
+            # most, which is what a cache is for.
+            self.cache[source] = row[0]
+        return row[0]
+
+    def count(self):
+        return self.conn.execute("SELECT count(*) FROM t").fetchone()[0]
+
+    def close(self):
+        try:
+            self.conn.close()
+        except Exception:
+            pass
 
 
 def records(path, columns):
@@ -179,7 +216,10 @@ def main(argv=None):
         description="Apply translations to every row and index the result.")
     parser.add_argument("--corpus", required=True)
     parser.add_argument("--translated", required=True,
-                        help="directory of translated chunk files")
+                        help="directory of translated chunk files, counted "
+                             "to decide whether the translate stage is done")
+    parser.add_argument("--translations-db", required=True,
+                        help="the database bt-build-translation-db wrote")
     parser.add_argument("--solr-url", required=True)
     parser.add_argument("--colheaders", required=True)
     parser.add_argument("--translate-cols", required=True)
@@ -237,12 +277,16 @@ def main(argv=None):
                 "language."
                 % (waited, args.expect, args.expect_timeout))
 
-    table, chunks = load_translations(args.translated)
-    if not table:
-        parser.error("no translations under %s -- did the translate stage "
-                     "finish?" % args.translated)
-    log("shard %d/%d: %d files, %d translations from %d chunks"
-        % (args.shard, args.of, len(mine), len(table), chunks))
+    if not os.path.exists(args.translations_db):
+        parser.error("no translation database at %s; build it with "
+                     "bt-build-translation-db" % args.translations_db)
+    table = Translations(args.translations_db)
+    known = table.count()
+    if known == 0:
+        parser.error("the translation database at %s is empty -- did the "
+                     "translate stage finish?" % args.translations_db)
+    log("shard %d/%d: %d files, %d translations from %s"
+        % (args.shard, args.of, len(mine), known, args.translations_db))
 
     # Read from the schema rather than restated here, so a schema change
     # cannot leave this silently posting documents Solr will reject.
@@ -279,10 +323,15 @@ def main(argv=None):
             timeout=args.timeout * 3).read()
 
     elapsed = time.time() - started
+    lookups = table.hits + table.misses
     log("shard %d/%d: %d records, %d posted, %d skipped for missing "
         "required fields, %.0fs (%.0f docs/s)"
         % (args.shard, args.of, seen, posted, skipped, elapsed,
            posted / elapsed if elapsed else 0))
+    log("shard %d/%d: %d lookups, %.1f%% from cache, %d cached"
+        % (args.shard, args.of, lookups,
+           100.0 * table.hits / lookups if lookups else 0, len(table.cache)))
+    table.close()
     return 0
 
 

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -18,9 +18,13 @@
           repository rather than guessed. The settled condition stops the
           join beginning absurdly early; this stops it beginning early at
           all. -->
+     <!-- One database for every shard to share. Read as JSON each shard
+          holds its own 456MB copy of the same table, and eight of those is
+          what put the machine over during the first full run. -->
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-build-translation-db --translated [TranslatedDir] --out [TranslationsDb] [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>EXPECTED=$(ls -d [StringsDir]/chunk-*.json 2>/dev/null | wc -l | tr -d " ")</cmd>
-     <cmd>for s in $(seq 0 $(([JoinShards] - 1))); do [BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard $s --of [JoinShards] --expect $EXPECTED [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1 [Ampersand] done; wait</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard 0 --of [JoinShards] --commit-only [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>for s in $(seq 0 $(([JoinShards] - 1))); do [BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard $s --of [JoinShards] --expect $EXPECTED [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1 [Ampersand] done; wait</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard 0 --of [JoinShards] --commit-only [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker clear</cmd>
      <cmd>echo "[JoinShards] shards indexed" [GreaterThan] [JobOutputDir]/join.done</cmd>
   </exe>
@@ -38,6 +42,7 @@
     <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
     <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
     <metadata key="ShardIndex" val="0"/>
+    <metadata key="TranslationsDb" val="[BIGTRANSLATE_HOME]/data/translations.sqlite"/>
     <metadata key="StringsDir" val="[BIGTRANSLATE_HOME]/data/strings"/>
     <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/join/[ShardIndex]_[DateMilis]"/>
     <metadata key="JobOutputDir" val="[JobDir]/output"/>

--- a/tests/test_w2_pipeline.py
+++ b/tests/test_w2_pipeline.py
@@ -694,3 +694,90 @@ def test_waiting_for_chunks_counts_what_is_there(tmp_path):
     # A partial set must time out rather than be accepted.
     got = module.wait_for_chunks(str(d), 5, timeout=1, poll=1)
     assert got == 3, "waiting invented chunks that are not there"
+
+
+def test_the_join_shares_one_translation_table():
+    """Eight shards held eight copies of the same 456MB table.
+
+    Read as JSON into a dict the translations are about 456MB, and every
+    shard held its own. Three and a half gigabytes of identical data,
+    alongside Solr's heap and a Lucene merge over three thousand segments,
+    is what stopped the machine two hours into a join.
+    """
+    source = (REPO / "distribution" / "src" / "main" / "resources" / "bin"
+              / "bt-join-index").read_text()
+    assert "class Translations" in source, (
+        "the join still loads the whole table into memory")
+    assert "mode=ro" in source, (
+        "shards open the shared database writable, so they cannot share it")
+    assert "def load_translations" not in source, (
+        "the old whole-table loader is still there")
+
+    builder = (REPO / "distribution" / "src" / "main" / "resources" / "bin"
+               / "bt-build-translation-db")
+    assert builder.exists(), "nothing builds the shared database"
+    assert "os.replace" in builder.read_text(), (
+        "the database is not renamed into place, so a half built one can be "
+        "opened by a shard and leave strings untranslated")
+
+
+def test_the_shard_count_matches_the_bottleneck():
+    """The corpus is read off one external drive.
+
+    Eight readers seeking across a single spindle is slower than four, not
+    faster; the shard count was chosen for a parallelism the work does not
+    have.
+    """
+    tasks = (REPO / "workflow" / "src" / "main" / "resources" / "policy"
+             / "tasks.xml").read_text()
+    start = tasks.index('<task id="urn:bigtranslate:Join_Index_Task"')
+    block = tasks[start:tasks.index("</task>", start)]
+    import re
+    shards = int(re.search(r'name="JoinShards" value="(\d+)"', block).group(1))
+    assert 1 <= shards <= 4, (
+        "%d shards read the same external drive at once" % shards)
+
+
+def test_the_translation_lookup_answers_and_stays_small(tmp_path):
+    """Exercised: the point of the change is memory, so measure it."""
+    import importlib.machinery
+    import importlib.util
+    import json
+    import sqlite3
+    import subprocess
+    import sys as _sys
+
+    translated = tmp_path / "translated"
+    translated.mkdir()
+    pairs = {"origen-%d" % i: "source-%d" % i for i in range(5000)}
+    (translated / "chunk-00000.json").write_text(json.dumps(pairs))
+
+    db = tmp_path / "t.sqlite"
+    builder = (REPO / "distribution" / "src" / "main" / "resources" / "bin"
+               / "bt-build-translation-db")
+    result = subprocess.run(
+        [_sys.executable, str(builder), "--translated", str(translated),
+         "--out", str(db)], capture_output=True, text=True, timeout=120)
+    assert result.returncode == 0, result.stderr[-400:]
+    assert db.exists()
+
+    path = BIN / "bt-join-index"
+    spec = importlib.util.spec_from_loader(
+        "bt_join_index", importlib.machinery.SourceFileLoader(
+            "bt_join_index", str(path)))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    table = module.Translations(str(db), cache_limit=100)
+    assert table.get("origen-42") == "source-42"
+    assert table.get("nothing here") is None
+    assert table.get("nothing here", "kept") == "kept"
+    assert table.count() == 5000
+
+    # The cache is bounded, so a shard's memory does not grow with the
+    # corpus it happens to be reading.
+    for i in range(5000):
+        table.get("origen-%d" % i)
+    assert len(table.cache) <= 100, (
+        "the cache grew past its limit to %d" % len(table.cache))
+    table.close()

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -207,10 +207,12 @@
           <property name="SolrUrl" value="[SOLR_URL]" envReplace="true"/>
           <property name="ColHeaders" value="[BIGTRANSLATE_HOME]/conf/colheaders.txt" envReplace="true"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
-          <!-- Solr posts at about 35,000 documents a second and is not the
-               bottleneck, so the shards exist to overlap reading the corpus
-               with posting rather than to push Solr harder. -->
-          <property name="JoinShards" value="8"/>
+          <!-- Four, not eight. The bottleneck is not Solr and not the
+               processor: it is reading 38GB off a single external drive,
+               and eight readers seeking across one spindle is slower than
+               four, not faster. Eight was chosen for a parallelism the
+               work does not have. -->
+          <property name="JoinShards" value="4"/>
           <property name="ProductType" value="EmploymentIndexedShard"/>
         </configuration>
   </task>


### PR DESCRIPTION
Every join shard needs the whole translation table, because any row may hold any string. Read as JSON into a dict it's 207 MB of text and **~456 MB in memory** — and each shard held its own. Eight copies, **3.5 GB of identical data**.

Alongside Solr's heap and a Lucene merge over 3,186 segments, that stopped the machine two hours into the first full join. Fourteen hours of translation survived; nothing was indexed.

## The change

`bt-build-translation-db` gathers the chunks into one SQLite database; shards open it **read-only**, so the pages are held once by the OS rather than once per process. A bounded cache sits in front — the corpus repeats itself heavily (836M cells are only 2.29M distinct strings), so almost nothing reaches the database twice.

**Measured on the real translations:**

| | before | after |
|---|---|---|
| per shard | ~456 MB before doing any work | **34 MB** after 200k lookups |
| 8 shards | 3.5 GB | 272 MB |
| cache hit rate | — | 99.0% |
| build time | — | 6s, 242 MB on disk |

2,000 sampled pairs verified against the source chunks: **0 mismatches**.

## Four shards, not eight

The bottleneck is neither Solr nor the CPU — it's reading 38 GB off a single external drive. Eight readers seeking across one spindle is slower than four. Eight was chosen for a parallelism this work doesn't have.

## Safety

The database is renamed into place, so one that exists is complete. A shard opening a half-built one would leave every string it hadn't reached in the source language — a failure this pipeline has already had once and shouldn't be able to have again.

354 tests pass, 3 new — including one that builds a real database, checks lookups and misses, and asserts the cache stays bounded.