### PR TITLE
Show the running run's progress, and only the running run's log

### DIFF
--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/ProcessBtWrapper.java
@@ -61,6 +61,9 @@ public class ProcessBtWrapper {
    */
   static final long STALE_AFTER_MILLIS = 10L * 60L * 1000L;
 
+  /** How far before a run's start its own log may already have been written. */
+  static final long STALE_LOG_MARGIN_MILLIS = 60L * 1000L;
+
   /** What the stages record about how far along they are. */
   private static final String[] PROGRESS_KEYS = {
       "stage", "chunksTotal", "chunksDone", "translatingSince"};
@@ -426,18 +429,61 @@ public class ProcessBtWrapper {
 
   /** Whichever of the two logs was written to last, or null if neither was. */
   static File mostRecentLog() {
+    return mostRecentLog(runStartedAt());
+  }
+
+  /**
+   * The most recent log, so long as it belongs to the run in progress.
+   *
+   * <p>Picking the newest of the two files says nothing about which run
+   * wrote it. A run that writes no log of its own leaves the previous
+   * run's as the newest, and the page then shows that instead: one
+   * displayed eleven thousand seconds of a translation from two days
+   * earlier, next to a progress bar describing the run actually
+   * happening.</p>
+   *
+   * <p>A log last written before this run began is a log from an earlier
+   * one. Showing nothing is the honest answer, and the panel already says
+   * so in words.</p>
+   */
+  static File mostRecentLog(long runStartedAt) {
     File[] candidates = {
         new File(FileConstants.logFile()),
         new File(FileConstants.path("/logs/bigtranslate.log"))
     };
     File best = null;
     for (File candidate : candidates) {
-      if (candidate.exists() && candidate.length() > 0
-          && (best == null || candidate.lastModified() > best.lastModified())) {
+      if (!candidate.exists() || candidate.length() == 0) {
+        continue;
+      }
+      // A margin, because a run's first log line lands a moment after the
+      // marker that announces it.
+      if (runStartedAt > 0
+          && candidate.lastModified() < runStartedAt - STALE_LOG_MARGIN_MILLIS) {
+        continue;
+      }
+      if (best == null || candidate.lastModified() > best.lastModified()) {
         best = candidate;
       }
     }
     return best;
+  }
+
+  /** When the run in progress began, or 0 if none is recorded. */
+  private static long runStartedAt() {
+    Map<String, Object> recorded = RunMarker.read();
+    if (recorded == null) {
+      return 0L;
+    }
+    Object started = recorded.get("startedAt");
+    if (started == null) {
+      return 0L;
+    }
+    try {
+      return Long.parseLong(String.valueOf(started).trim());
+    } catch (NumberFormatException e) {
+      return 0L;
+    }
   }
 
   public static long countJobDirs() {

--- a/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/RunMarker.java
+++ b/webapps/gloss-services/src/main/java/org/bigtranslate/gloss/RunMarker.java
@@ -139,9 +139,24 @@ public final class RunMarker {
         run.put(name, value);
       }
     }
-    Long startedAt = longField(body, "startedAt");
-    if (startedAt != null) {
-      run.put("startedAt", startedAt);
+    // Every numeric field the marker carries, not just the start time.
+    //
+    // Parsing only startedAt cost two visible things. The progress panel drew
+    // no meter, because the counts it renders were never in the map; and
+    // isStale never fired, because it reads heartbeatAt and heartbeatAt was
+    // never parsed -- so the guard against reporting a dead run as live could
+    // not have worked in any deployment since it was written.
+    for (String name : new String[] {
+        "startedAt", "heartbeatAt", "translatingSince",
+        "chunksTotal", "chunksDone"}) {
+      Long value = longField(body, name);
+      if (value != null) {
+        run.put(name, value);
+      }
+    }
+    String stage = stringField(body, "stage");
+    if (stage != null) {
+      run.put("stage", stage);
     }
     return run.isEmpty() ? null : run;
   }

--- a/webapps/gloss-services/src/test/java/org/bigtranslate/gloss/TestRunMarkerFields.java
+++ b/webapps/gloss-services/src/test/java/org/bigtranslate/gloss/TestRunMarkerFields.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bigtranslate.gloss;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Reading a marker off disk, rather than building one in memory.
+ *
+ * <p>The staleness tests next door construct the map by hand, so they say
+ * nothing about which fields the parser actually produces. That gap hid two
+ * bugs at once. {@code read} pulled out only status, startedBy, path, exclude
+ * and startedAt, so the progress panel drew no meter -- the counts it renders
+ * were never in the map -- and {@code isStale} never fired once, because it
+ * reads heartbeatAt and heartbeatAt was never parsed. The guard against
+ * reporting a dead run as live could not have worked in any deployment.</p>
+ *
+ * <p>So these go through the file.</p>
+ */
+public class TestRunMarkerFields {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private String previousHome;
+
+  @Before
+  public void pointHomeAtATempDirectory() throws Exception {
+    previousHome = System.getProperty("OODT_HOME");
+    System.setProperty("OODT_HOME", folder.getRoot().getAbsolutePath());
+    assertTrue(new File(folder.getRoot(), "data").mkdirs());
+  }
+
+  @After
+  public void restoreHome() {
+    if (previousHome == null) {
+      System.clearProperty("OODT_HOME");
+    } else {
+      System.setProperty("OODT_HOME", previousHome);
+    }
+  }
+
+  private void writeMarker(String json) throws Exception {
+    FileOutputStream out = new FileOutputStream(RunMarker.markerPath());
+    try {
+      out.write(json.getBytes(StandardCharsets.UTF_8));
+    } finally {
+      out.close();
+    }
+  }
+
+  /** A marker as bin/bt-run-marker writes it mid-translation. */
+  private static final String MID_RUN =
+      "{\"status\": \"TRANSLATING\", \"startedBy\": \"workflow\","
+      + " \"path\": \"/corpus\", \"exclude\": \"\","
+      + " \"startedAt\": 1788764908909, \"heartbeatAt\": 1788816028909,"
+      + " \"stage\": \"translating\", \"chunksTotal\": 458,"
+      + " \"chunksDone\": 401, \"translatingSince\": 1788765472909}";
+
+  @Test
+  public void testTheProgressFieldsSurviveTheParser() throws Exception {
+    writeMarker(MID_RUN);
+    Map<String, Object> run = RunMarker.read();
+    assertNotNull(run);
+    assertEquals("translating", run.get("stage"));
+    assertEquals(Long.valueOf(458L), run.get("chunksTotal"));
+    assertEquals(Long.valueOf(401L), run.get("chunksDone"));
+    assertEquals(Long.valueOf(1788765472909L), run.get("translatingSince"));
+  }
+
+  @Test
+  public void testTheHeartbeatSurvivesTheParser() throws Exception {
+    // Without this, isStale reads a null and every dead run reports as live.
+    writeMarker(MID_RUN);
+    assertEquals(Long.valueOf(1788816028909L),
+        RunMarker.read().get("heartbeatAt"));
+  }
+
+  @Test
+  public void testAMarkerWhoseHeartbeatStoppedReadsAsStale() throws Exception {
+    long longAgo = System.currentTimeMillis()
+        - ProcessBtWrapper.STALE_AFTER_MILLIS - 60000L;
+    writeMarker("{\"status\": \"TRANSLATING\", \"path\": \"/corpus\","
+        + " \"startedAt\": 1, \"heartbeatAt\": " + longAgo + "}");
+    assertTrue("a marker read off disk must reach isStale with its heartbeat",
+        ProcessBtWrapper.isStale(RunMarker.read()));
+  }
+
+  @Test
+  public void testTheOriginalFieldsStillSurvive() throws Exception {
+    writeMarker(MID_RUN);
+    Map<String, Object> run = RunMarker.read();
+    assertEquals("TRANSLATING", run.get("status"));
+    assertEquals("workflow", run.get("startedBy"));
+    assertEquals("/corpus", run.get("path"));
+    assertEquals(Long.valueOf(1788764908909L), run.get("startedAt"));
+  }
+
+  @Test
+  public void testAMarkerWithoutProgressFieldsStillReads() throws Exception {
+    // Written by an older bin/bigtranslate. Absent is absent, not zero: a
+    // meter drawn from a missing count would read 0 of 0.
+    writeMarker("{\"status\": \"TRANSLATING\", \"path\": \"/corpus\","
+        + " \"startedAt\": 1788764908909}");
+    Map<String, Object> run = RunMarker.read();
+    assertEquals("TRANSLATING", run.get("status"));
+    assertEquals(null, run.get("chunksTotal"));
+    assertEquals(null, run.get("stage"));
+  }
+}

--- a/webapps/gloss/src/main/webapp/resources/src/components/ProgressPane.vue
+++ b/webapps/gloss/src/main/webapp/resources/src/components/ProgressPane.vue
@@ -40,7 +40,7 @@
       actually writing; when there genuinely is not one yet, say that rather
       than implying something is stuck.
     -->
-    <pre v-if="log">{{ log }}</pre>
+    <pre v-if="log" class="tail">{{ log }}</pre>
     <p v-else-if="!hasCounts" class="nolog">
       No log output yet. The workflow manager is running this; its progress
       shows above and in OPSUI.
@@ -87,6 +87,25 @@ export default {
 </script>
 
 <style scoped>
+/*
+ * Bounded, and scrolled inside itself. Unbounded it printed the whole log
+ * down the page -- one run showed ninety lines of a translation from two
+ * days earlier and pushed everything else off the screen.
+ */
+.tail {
+  max-height: 18rem;
+  overflow: auto;
+  margin: 0.75rem 0 0;
+  padding: 0.75rem 0.9rem;
+  background: rgba(127, 127, 127, 0.08);
+  border: 1px solid rgba(127, 127, 127, 0.22);
+  border-radius: 2px;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .tally { margin: 0.75rem 0; }
 .bar {
   height: 6px;

--- a/webapps/gloss/src/main/webapp/resources/src/progress.test.js
+++ b/webapps/gloss/src/main/webapp/resources/src/progress.test.js
@@ -14,6 +14,7 @@
 // limitations under the License.
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
 import {
   percent, rateLabel, remainingLabel, elapsedLabel, stageLabel, duration
 } from './progress.js'
@@ -78,4 +79,14 @@ test('reads durations the way a person would say them', () => {
 test('elapsed falls back to the start when nothing has translated yet', () => {
   assert.equal(elapsedLabel({ startedAt: minutesAgo(30) }, NOW), '30m')
   assert.equal(elapsedLabel({}, NOW), '')
+})
+
+test('the log pane is bounded and scrolls inside itself', () => {
+  // Not arithmetic, but worth pinning: unbounded, the pane printed a whole
+  // log down the page. One run showed ninety lines of a translation from
+  // two days earlier and pushed everything else off the screen.
+  const pane = readFileSync(
+    new URL('./components/ProgressPane.vue', import.meta.url), 'utf8')
+  assert.match(pane, /max-height/, 'the log pane is unbounded')
+  assert.match(pane, /overflow:\s*auto/, 'the log pane does not scroll')
 })


### PR DESCRIPTION
Three bugs in the Gloss progress panel, all visible on the same screen: a log from two days earlier printed under a live run, running off the bottom of the page, with no meter beside it.

### The marker parser dropped most of the marker

`RunMarker.read` parsed `status`, `startedBy`, `path`, `exclude` and `startedAt` and stopped. The marker also carries `stage`, `chunksTotal`, `chunksDone`, `translatingSince` and `heartbeatAt`. Dropping them cost two things:

- The panel drew no meter, because the counts it renders were never in the map.
- `isStale` never fired **once**. It reads `heartbeatAt`; `heartbeatAt` was never parsed; a null heartbeat is trusted. The guard against reporting a dead run as live could not have worked in any deployment since it was written.

The existing staleness tests missed this because they build the map by hand, so they say nothing about what the parser actually produces. `TestRunMarkerFields` goes through a real marker file instead.

### The log belonged to a different run

`mostRecentLog` picked whichever of the two candidate logs was written last — which says nothing about *which run* wrote it. A run that writes no log of its own leaves the previous run's as the newest, and the panel showed exactly that: eleven thousand seconds of a translation from two days earlier, next to a progress bar describing the run actually happening. A log last written before this run began is a log from an earlier one; showing nothing is the honest answer, and the panel already says so in words.

### The log pane was unbounded

No `max-height`, no `overflow`, so it printed the whole tail down the page and pushed the rest of the panel off the screen. Bounded now, scrolling inside itself.

### Verification

- `gloss-services`: 10 tests pass (5 new).
- `gloss`: 10 tests pass (1 new).
- Deployed to the running `bt-w1` stack. `/bt/log` returns 0 bytes against the stale Sep 5 log; `/bt/status` now serves `stage`, `chunksTotal`, `chunksDone` and `translatingSince`.