### PR TITLE
Decode the corpus with the encodings it is actually written in

### DIFF
--- a/distribution/src/main/resources/bin/bt-extract-strings
+++ b/distribution/src/main/resources/bin/bt-extract-strings
@@ -36,6 +36,9 @@ import os
 import sys
 import time
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bt_encoding  # noqa: E402  (needs the path above)
+
 
 def log(message):
     sys.stderr.write("%s %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
@@ -104,7 +107,8 @@ def distinct_strings(paths, indices, progress_every=200):
     return seen, cells, rows, nbytes, time.time() - started
 
 
-def write_chunks(strings, out_dir, chunk_size):
+def write_chunks(strings, out_dir, chunk_size,
+                 encodings=bt_encoding.DEFAULT_ENCODINGS):
     """Length-sorted chunks, plus a manifest describing the whole set.
 
     Sorted globally and then cut, so each chunk holds strings of nearly
@@ -118,9 +122,10 @@ def write_chunks(strings, out_dir, chunk_size):
         name = "chunk-%05d.json" % (start // chunk_size)
         path = os.path.join(out_dir, name)
         # Decoded here and only here: this is the one point where every
-        # distinct string is touched, and errors are replaced rather than
-        # raised so that one bad byte cannot lose a chunk.
-        text = [value.decode("utf-8", "replace") for value in piece]
+        # distinct string is touched. The corpus is not all UTF-8, so the
+        # encodings from conf/encoding.txt are tried in order rather than
+        # replacing every byte UTF-8 rejects.
+        text = [bt_encoding.decode(value, encodings) for value in piece]
         tmp = path + ".partial"
         with open(tmp, "w", encoding="utf-8") as handle:
             json.dump(text, handle, ensure_ascii=False)
@@ -151,6 +156,8 @@ def main(argv=None):
     # measured, which is short enough that losing one to a restart costs
     # little and long enough that per-instance overhead disappears.
     parser.add_argument("--chunk-size", type=int, default=5000)
+    parser.add_argument("--encodings", default=None,
+                        help="conf/encoding.txt: encodings to try, in order")
     args = parser.parse_args(argv)
 
     if not os.path.isdir(args.corpus):
@@ -172,7 +179,8 @@ def main(argv=None):
     log("%d lines, %d cells, %d distinct in %.0fs"
         % (rows, cells, len(seen), elapsed))
 
-    chunks = write_chunks(seen, args.out_dir, args.chunk_size)
+    chunks = write_chunks(seen, args.out_dir, args.chunk_size,
+                          bt_encoding.read_encodings(args.encodings))
     manifest = {
         "files": len(paths), "bytes": nbytes, "lines": rows,
         "cells": cells, "distinct": len(seen),

--- a/distribution/src/main/resources/bin/bt-extract-strings
+++ b/distribution/src/main/resources/bin/bt-extract-strings
@@ -37,7 +37,7 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import bt_encoding  # noqa: E402  (needs the path above)
+import bt_encoding  # after the path insert above, which makes it importable
 
 
 def log(message):

--- a/distribution/src/main/resources/bin/bt-join-index
+++ b/distribution/src/main/resources/bin/bt-join-index
@@ -37,7 +37,7 @@ import urllib.error
 import urllib.request
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-import bt_encoding  # noqa: E402  (needs the path above)
+import bt_encoding  # after the path insert above, which makes it importable
 
 
 def log(message):

--- a/distribution/src/main/resources/bin/bt-join-index
+++ b/distribution/src/main/resources/bin/bt-join-index
@@ -36,6 +36,9 @@ import time
 import urllib.error
 import urllib.request
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import bt_encoding  # noqa: E402  (needs the path above)
+
 
 def log(message):
     sys.stderr.write("%s %s\n" % (time.strftime("%Y-%m-%d %H:%M:%S"), message))
@@ -98,21 +101,25 @@ class Translations(object):
             pass
 
 
-def records(path, columns):
-    """Yield complete records, rejoining rows split by embedded newlines."""
+def records(path, columns, encodings=bt_encoding.DEFAULT_ENCODINGS):
+    """Yield complete records, rejoining rows split by embedded newlines.
+
+    Read as bytes and decoded a line at a time: the corpus is not all UTF-8,
+    and decoding the whole file as UTF-8 with replacement turned every
+    latin-1 accent into U+FFFD on the way to Solr.
+    """
     wanted = len(columns)
-    with open(path, encoding="utf-8", errors="replace") as handle:
-        pending = ""
-        for line in handle:
-            pending = pending + line if pending else line
-            parts = pending.rstrip("\n").split("\t")
-            if len(parts) >= wanted:
-                yield parts
-                pending = ""
-        if pending.strip():
-            parts = pending.rstrip("\n").split("\t")
-            if len(parts) >= wanted:
-                yield parts
+    pending = ""
+    for line in bt_encoding.lines(path, encodings):
+        pending = pending + line if pending else line
+        parts = pending.rstrip("\n").split("\t")
+        if len(parts) >= wanted:
+            yield parts
+            pending = ""
+    if pending.strip():
+        parts = pending.rstrip("\n").split("\t")
+        if len(parts) >= wanted:
+            yield parts
 
 
 def count_chunks(directory):
@@ -222,6 +229,8 @@ def main(argv=None):
                         help="the database bt-build-translation-db wrote")
     parser.add_argument("--solr-url", required=True)
     parser.add_argument("--colheaders", required=True)
+    parser.add_argument("--encodings", default=None,
+                        help="conf/encoding.txt: encodings to try, in order")
     parser.add_argument("--translate-cols", required=True)
     parser.add_argument("--batch-size", type=int, default=5000)
     parser.add_argument("--timeout", type=int, default=600)
@@ -263,6 +272,7 @@ def main(argv=None):
     mine = paths[args.shard::args.of]
 
     columns = read_columns(args.colheaders)
+    encodings = bt_encoding.read_encodings(args.encodings)
     wanted = set(read_columns(args.translate_cols))
     translate_at = {i for i, name in enumerate(columns) if name in wanted}
 
@@ -301,7 +311,8 @@ def main(argv=None):
     started = time.time()
     for path in mine:
         base = os.path.basename(path)
-        for number, parts in enumerate(records(path, columns)):
+        for number, parts in enumerate(
+                records(path, columns, encodings)):
             seen += 1
             document, missing = build_document(
                 parts, columns, translate_at, table, required, dates,

--- a/distribution/src/main/resources/bin/bt_encoding.py
+++ b/distribution/src/main/resources/bin/bt_encoding.py
@@ -1,0 +1,130 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Decoding a corpus that is not all UTF-8.
+
+The employment TSVs were collected in 2012 from sites that did not agree on
+an encoding, and they are still whatever they were then: of forty files
+sampled, forty failed to decode as UTF-8. "Bolivar" is written with a
+latin-1 0xed, and there are files where a single row carries both.
+
+The original pipeline knew this. tsvtojson took ``-e conf/encoding.txt`` and
+tried each encoding listed there in turn. The replacement scripts hardcoded
+``decode("utf-8", "replace")``, which never fails and never says anything --
+every non-UTF-8 byte simply became U+FFFD. It reached Solr that way: a
+quarter of the indexed documents carry a damaged ``location``, which is the
+field the density-bubble map and the geocoder both read.
+
+The fix has to work a byte sequence at a time, not a line at a time. Most
+lines here are valid UTF-8 carrying one stray latin-1 byte somewhere, so
+"try UTF-8, fall back to latin-1 for the line" re-decodes the whole line and
+turns every correct accent into mojibake -- "Bogota" with a valid UTF-8
+a-acute came back as "BogotA-a" nonsense. That is worse than the bug it
+replaces.
+
+So UTF-8 decodes the line, and only the byte runs it rejects fall back
+through the remaining encodings. Valid UTF-8 stays valid; the stray latin-1
+byte beside it is read as latin-1; nothing becomes U+FFFD unless no listed
+encoding can read it at all.
+"""
+
+import codecs
+import os
+
+# What conf/encoding.txt has always listed, for when it cannot be read.
+DEFAULT_ENCODINGS = ("utf-8", "us-ascii", "latin-1")
+
+
+def read_encodings(path=None):
+    """The encodings to try, in order.
+
+    Reads the same conf/encoding.txt the original pipeline passed to
+    tsvtojson, so the two stay in step. Missing or empty falls back to the
+    defaults rather than to bare UTF-8: a corpus that needed the fallback
+    chain does not stop needing it because a config file went missing.
+    """
+    if not path or not os.path.exists(path):
+        return list(DEFAULT_ENCODINGS)
+    found = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            name = line.strip()
+            if name and not name.startswith("#"):
+                found.append(name)
+    return found or list(DEFAULT_ENCODINGS)
+
+
+def decode(value, encodings=DEFAULT_ENCODINGS):
+    """Decode bytes, falling back per bad byte run rather than per line.
+
+    The first listed encoding decodes the whole value; each run of bytes it
+    rejects is retried against the ones after it. Doing this at the line
+    level instead looks simpler and is wrong: these lines are mostly valid
+    UTF-8 with one stray latin-1 byte, and re-reading the whole line as
+    latin-1 to accommodate that byte mojibakes every accent that was already
+    correct.
+    """
+    if isinstance(value, str):
+        return value
+    if not encodings:
+        return value.decode("utf-8", "replace")
+    primary, rest = encodings[0], list(encodings[1:])
+    try:
+        return value.decode(primary)
+    except LookupError:
+        # An unusable codec name in the config is not worth failing a run.
+        return decode(value, rest) if rest else value.decode("utf-8", "replace")
+    except UnicodeDecodeError:
+        pass
+    return value.decode(primary, _handler_for(rest))
+
+
+_HANDLERS = {}
+
+
+def _handler_for(fallbacks):
+    """An error handler that reads rejected bytes with the next encoding.
+
+    Registered once per fallback list because codecs.register_error is
+    global; the name encodes the list so two different chains cannot collide.
+    """
+    name = "bt_encoding_" + "_".join(fallbacks or ["replace"])
+    if name in _HANDLERS:
+        return name
+
+    def handle(error):
+        raw = error.object[error.start:error.end]
+        for encoding in fallbacks:
+            try:
+                return raw.decode(encoding), error.end
+            except (UnicodeDecodeError, LookupError):
+                continue
+        # Nothing could read it. A replaced byte still beats a lost row.
+        return "\ufffd" * len(raw), error.end
+
+    codecs.register_error(name, handle)
+    _HANDLERS[name] = True
+    return name
+
+
+def lines(path, encodings=DEFAULT_ENCODINGS):
+    """Yield decoded lines, choosing an encoding a line at a time.
+
+    Per line, not per file, because these files are concatenations of
+    several days' collection and the encoding changes partway through more
+    than one of them.
+    """
+    with open(path, "rb") as handle:
+        for raw in handle:
+            yield decode(raw, encodings)

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_ExtractStrings.xml
@@ -9,7 +9,7 @@
      <cmd>export PYTHONIOENCODING=utf-8</cmd>
      <cmd>mkdir -p [JobOutputDir] [JobLogDir]</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker start --path [CorpusDir] --started-by workflow</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-extract-strings --corpus [CorpusDir] --out-dir [JobOutputDir] --colheaders [ColHeaders] --translate-cols [TranslateCols] --chunk-size [ChunkSize] [GreaterThan][GreaterThan] [JobLogDir]/extract_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-extract-strings --corpus [CorpusDir] --out-dir [JobOutputDir] --colheaders [ColHeaders] --encodings [Encodings] --translate-cols [TranslateCols] --chunk-size [ChunkSize] [GreaterThan][GreaterThan] [JobLogDir]/extract_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <!-- Start the join once, here, rather than once per chunk. It waits
           on TranslationsSettled, so it sits until every chunk has an
           answer and then runs a single time. Triggering it from each

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -23,8 +23,8 @@
           what put the machine over during the first full run. -->
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-build-translation-db --translated [TranslatedDir] --glossary [TranslateGlossary] --out [TranslationsDb] [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>EXPECTED=$(ls -d [StringsDir]/chunk-*.json 2>/dev/null | wc -l | tr -d " ")</cmd>
-     <cmd>for s in $(seq 0 $(([JoinShards] - 1))); do [BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard $s --of [JoinShards] --expect $EXPECTED [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1 [Ampersand] done; wait</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard 0 --of [JoinShards] --commit-only [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>for s in $(seq 0 $(([JoinShards] - 1))); do [BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --encodings [Encodings] --translate-cols [TranslateCols] --shard $s --of [JoinShards] --expect $EXPECTED [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1 [Ampersand] done; wait</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --encodings [Encodings] --translate-cols [TranslateCols] --shard 0 --of [JoinShards] --commit-only [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker clear</cmd>
      <cmd>echo "[JoinShards] shards indexed" [GreaterThan] [JobOutputDir]/join.done</cmd>
   </exe>

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,0 +1,109 @@
+"""Decoding a corpus that is not all UTF-8.
+
+The employment TSVs were collected in 2012 from sites that did not agree on
+an encoding. The replacement pipeline hardcoded ``decode("utf-8", "replace")``,
+which never raises and never warns, so every latin-1 accent became U+FFFD on
+the way to Solr -- a quarter of the indexed documents carried a damaged
+``location``, the field the map and the geocoder read.
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+BIN = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                   "distribution", "src", "main", "resources", "bin")
+sys.path.insert(0, BIN)
+import bt_encoding  # noqa: E402
+
+
+# "Bolívar" as the corpus actually stores it: latin-1, invalid as UTF-8.
+BOLIVAR_LATIN1 = b"Cartagena, Bol\xedvar, Colombia"
+
+
+class TestDecode:
+
+    def test_latin_1_survives_instead_of_becoming_a_replacement_char(self):
+        got = bt_encoding.decode(BOLIVAR_LATIN1)
+        assert got == "Cartagena, Bolívar, Colombia"
+        assert "�" not in got
+
+    def test_utf_8_is_preferred_when_both_would_decode(self):
+        # latin-1 accepts any byte sequence, so order is what makes this
+        # UTF-8 rather than mojibake.
+        assert bt_encoding.decode("Bolívar".encode("utf-8")) == "Bolívar"
+
+    def test_an_undecodable_byte_still_yields_a_row(self):
+        # Only reachable when the list has no total codec; a lost row is
+        # worse than a replaced byte.
+        got = bt_encoding.decode(b"\xff\xfe bad", ["utf-8"])
+        assert "bad" in got
+
+    def test_str_passes_through(self):
+        assert bt_encoding.decode("already text") == "already text"
+
+    def test_valid_utf_8_is_not_mojibaked_to_rescue_one_stray_byte(self):
+        # The bug this nearly shipped with. Most lines in this corpus are
+        # valid UTF-8 carrying one stray latin-1 byte somewhere. Falling back
+        # a line at a time re-reads the whole line as latin-1, so every
+        # accent that was already correct comes back as mojibake -- strictly
+        # worse than the U+FFFD it was meant to fix.
+        mixed = "Bogotá".encode("utf-8") + b" Bol\xedvar"
+        got = bt_encoding.decode(mixed)
+        assert got == "Bogotá Bolívar", got
+        assert "Ã" not in got
+
+    def test_only_the_rejected_run_falls_back(self):
+        good = "café".encode("utf-8")
+        assert bt_encoding.decode(good + b"\xed" + good) == "café" + "í" + "café"
+
+    def test_an_unknown_codec_name_is_skipped_not_fatal(self):
+        assert bt_encoding.decode(BOLIVAR_LATIN1,
+                                  ["no-such-codec", "latin-1"]).endswith("Colombia")
+
+
+class TestReadEncodings:
+
+    def test_reads_the_file_the_original_pipeline_used(self, tmp_path):
+        f = tmp_path / "encoding.txt"
+        f.write_text("utf-8\n# a comment\n\nus-ascii\nlatin-1\n")
+        assert bt_encoding.read_encodings(str(f)) == ["utf-8", "us-ascii", "latin-1"]
+
+    def test_a_missing_file_keeps_the_fallback_chain(self, tmp_path):
+        # Not bare utf-8: a corpus that needed the chain does not stop
+        # needing it because a config file went missing.
+        got = bt_encoding.read_encodings(str(tmp_path / "absent.txt"))
+        assert "latin-1" in got
+
+    def test_an_empty_file_keeps_the_fallback_chain(self, tmp_path):
+        f = tmp_path / "encoding.txt"
+        f.write_text("\n# only comments\n")
+        assert "latin-1" in bt_encoding.read_encodings(str(f))
+
+
+class TestLines:
+
+    def test_encoding_is_chosen_per_line_not_per_file(self, tmp_path):
+        # These files are concatenations of several days' collection, and
+        # more than one changes encoding partway through.
+        f = tmp_path / "mixed.tsv"
+        f.write_bytes("Bogotá\n".encode("utf-8") + "Bolívar\n".encode("latin-1"))
+        assert [l.strip() for l in bt_encoding.lines(str(f))] == ["Bogotá", "Bolívar"]
+
+    def test_no_replacement_chars_on_the_shipped_chain(self, tmp_path):
+        f = tmp_path / "mixed.tsv"
+        f.write_bytes(BOLIVAR_LATIN1 + b"\n")
+        assert "�" not in "".join(bt_encoding.lines(str(f)))
+
+
+class TestTheShippedConfig:
+
+    def test_the_shipped_encoding_txt_ends_in_a_total_codec(self):
+        # latin-1 accepts any byte, so it must come last: anything after it
+        # is dead, and without it undecodable rows fall back to replacement.
+        conf = os.path.join(os.path.dirname(BIN), "conf", "encoding.txt")
+        names = bt_encoding.read_encodings(conf)
+        assert names[-1] == "latin-1", names
+        assert names[0] == "utf-8", names

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -138,6 +138,7 @@
           <property name="CorpusDir" value="[BIGTRANSLATE_CORPUS]" envReplace="true"/>
           <property name="StringsDir" value="[BIGTRANSLATE_HOME]/data/strings" envReplace="true"/>
           <property name="ColHeaders" value="[BIGTRANSLATE_HOME]/conf/colheaders.txt" envReplace="true"/>
+          <property name="Encodings" value="[BIGTRANSLATE_HOME]/conf/encoding.txt" envReplace="true"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
           <property name="ChunkSize" value="5000"/>
           <property name="ProductType" value="EmploymentStringChunk"/>
@@ -208,6 +209,7 @@
           <property name="SolrUrl" value="[SOLR_URL]" envReplace="true"/>
           <property name="ColHeaders" value="[BIGTRANSLATE_HOME]/conf/colheaders.txt" envReplace="true"/>
           <property name="TranslateGlossary" value="[BIGTRANSLATE_HOME]/conf/glossary.es-en.tsv" envReplace="true"/>
+          <property name="Encodings" value="[BIGTRANSLATE_HOME]/conf/encoding.txt" envReplace="true"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
           <!-- Four, not eight. The bottleneck is not Solr and not the
                processor: it is reading 38GB off a single external drive,


### PR DESCRIPTION
The employment TSVs were collected in 2012 from sites that did not agree on an encoding. Of forty files sampled, **forty fail to decode as UTF-8**.

The original pipeline knew this — `tsvtojson -e conf/encoding.txt`, a chain of `utf-8`, `us-ascii`, `latin-1`. The W2 scripts hardcoded `decode("utf-8", "replace")`, which never raises and never warns, so every byte UTF-8 rejected silently became U+FFFD. Nothing in W2 read `encoding.txt` at all.

### Impact, measured

Of 2,000 indexed documents sampled, **491 (24.6%)** carry a damaged `location` — roughly **29 million of the 119 million** — and `location` is the field the Gloss density-bubble map and the geocoder both read. One file alone produced 76,409 replacement characters.

```
"location": "Cartagena, Bol�var, Colombia"     ← what shipped
"location": "Cartagena, Bolívar, Colombia"          ← after this change
```

### The part worth reviewing

**The fallback is per byte run, not per line**, and my first attempt got this wrong in a way that was *worse than the bug*. Most lines here are valid UTF-8 carrying one stray latin-1 byte somewhere. Trying latin-1 for the whole line re-decodes the good bytes too:

```
old (utf-8+replace):  2012-10-29  Bogotá  Cundinamarca  ¡Urgente! ...
first attempt:        2012-10-29  BogotÃ¡ Cundinamarca  Â¡Urgente! ...   ← mojibake
this PR:              2012-10-29  Bogotá  Cundinamarca  ¡Urgente! ...
```

So UTF-8 decodes the line and only the runs it rejects fall through the remaining encodings, via a registered `codecs` error handler. Valid UTF-8 stays valid; the stray latin-1 byte beside it reads as latin-1; nothing becomes U+FFFD unless no listed encoding can read it at all.

### Verification

- On the file quoted above: **76,409 replacement characters → 0**, with already-valid UTF-8 byte-identical.
- `Cartagena, Bol\xedvar` → `Cartagena, Bolívar`.
- 367 python tests pass (13 new), including a regression test for the mojibake failure above.

### Cost to correct the live index

The *translated* columns are pure ASCII in this corpus — 0 of 2,286,371 strings carry a replacement char — so the 13.6-hour translation is unaffected. Correcting the index needs a **join re-run only (~76 min)**.