### PR TITLE
Give the W2 pipeline the glossary it was written for

### DIFF
--- a/distribution/src/main/resources/bin/bt-build-translation-db
+++ b/distribution/src/main/resources/bin/bt-build-translation-db
@@ -25,11 +25,15 @@ read are held once by the operating system rather than once per process.
 """
 import argparse
 import glob
+import importlib.machinery
+import importlib.util
 import json
 import os
 import sqlite3
 import sys
 import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
 
 
 def log(message):
@@ -37,7 +41,27 @@ def log(message):
     sys.stderr.flush()
 
 
-def build(translated_dir, out_path):
+def load_glossary(path):
+    """The Glossary from pantogloss-translatejson, or an empty one.
+
+    Loaded by path because it is a command and has no .py suffix, the same
+    way bt-translate-chunk reaches its translate logic. One implementation of
+    the lookup rules -- case folding, and comma-separated components -- is
+    the point; a second copy here would drift from the one that writes the
+    chunks.
+    """
+    spec = importlib.util.spec_from_loader(
+        "pantogloss_translatejson",
+        importlib.machinery.SourceFileLoader(
+            "pantogloss_translatejson",
+            os.path.join(HERE, "pantogloss-translatejson")))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    glossary = module.Glossary.load(path) if path else module.Glossary()
+    return glossary, module.is_untranslatable
+
+
+def build(translated_dir, out_path, glossary=None, untranslatable=None):
     chunks = sorted(glob.glob(os.path.join(translated_dir, "chunk-*.json")))
     if not chunks:
         raise SystemExit("no translated chunks under %s" % translated_dir)
@@ -60,9 +84,27 @@ def build(translated_dir, out_path):
         conn.execute("CREATE TABLE t (s TEXT PRIMARY KEY, e TEXT) WITHOUT ROWID")
 
         total = 0
+        overridden = [0]
         for number, path in enumerate(chunks, 1):
             with open(path, encoding="utf-8") as handle:
                 pairs = json.load(handle)
+            # The glossary is authoritative over whatever the model returned.
+            # Applying it here as well as in bt-translate-chunk is what lets a
+            # corrected glossary reach the index without re-translating: the
+            # chunks on disk cost thirteen hours, and the override is a pure
+            # function of the source string.
+            for source in list(pairs):
+                hit = None
+                if glossary is not None and len(glossary):
+                    hit = glossary.lookup(source)
+                if hit is None and untranslatable is not None \
+                        and untranslatable(source):
+                    # Punctuation the model answered anyway: "!" came back
+                    # as "- I'm sorry." The source is the right answer.
+                    hit = source
+                if hit is not None and hit != pairs[source]:
+                    pairs[source] = hit
+                    overridden[0] += 1
             conn.executemany("INSERT OR REPLACE INTO t (s, e) VALUES (?, ?)",
                              pairs.items())
             total += len(pairs)
@@ -73,6 +115,8 @@ def build(translated_dir, out_path):
         conn.close()
 
     os.replace(tmp, out_path)
+    if overridden[0]:
+        log("  corrected %d model translation(s)" % overridden[0])
     return len(chunks), total
 
 
@@ -82,6 +126,9 @@ def main(argv=None):
         description="Gather translated chunks into one database for the join.")
     parser.add_argument("--translated", required=True)
     parser.add_argument("--out", required=True)
+    parser.add_argument("--glossary", default=None,
+                        help="conf/glossary.es-en.tsv: authoritative "
+                             "overrides applied over the model's output")
     parser.add_argument("--force", action="store_true",
                         help="rebuild even if the database already exists")
     args = parser.parse_args(argv)
@@ -91,7 +138,8 @@ def main(argv=None):
         return 0
 
     started = time.time()
-    chunks, total = build(args.translated, args.out)
+    glossary, untranslatable = load_glossary(args.glossary)
+    chunks, total = build(args.translated, args.out, glossary, untranslatable)
     size = os.path.getsize(args.out) / 1048576.0
     log("%d translations from %d chunks -> %s (%.0f MB) in %.0fs"
         % (total, chunks, args.out, size, time.time() - started))

--- a/distribution/src/main/resources/bin/bt-translate-chunk
+++ b/distribution/src/main/resources/bin/bt-translate-chunk
@@ -57,6 +57,30 @@ def log(message):
     sys.stderr.flush()
 
 
+def resolve_with_glossary(strings, glossary, untranslatable):
+    """Split a chunk into what the glossary settles and what the model must see.
+
+    The glossary is authoritative, so its entries never reach the model. That
+    is the point of it -- on a sample country-day the model left "Inmediato"
+    untranslated in 151 of 211 records while rendering lowercase "inmediato"
+    correctly -- and it also means the highest-frequency values in the corpus
+    stop costing model calls at all.
+    """
+    resolved = {}
+    remaining = []
+    for value in strings:
+        hit = glossary.lookup(value)
+        if hit is not None:
+            resolved[value] = hit
+        elif untranslatable(value):
+            # Punctuation is not language. Left to the model, "!" comes back
+            # as "- I'm sorry."
+            resolved[value] = value
+        else:
+            remaining.append(value)
+    return resolved, remaining
+
+
 def translate_chunk(translator, strings, service_url, batch_size,
                     beam_size, max_length, timeout):
     """Translate in batches, preserving the chunk's existing order.
@@ -90,6 +114,10 @@ def main(argv=None):
     parser.add_argument("--beam-size", type=int, default=0)
     parser.add_argument("--max-length", type=int, default=256)
     parser.add_argument("--service-timeout", type=int, default=1800)
+    parser.add_argument("--glossary", default=None,
+                        help="conf/glossary.es-en.tsv: authoritative "
+                             "source<TAB>English overrides, consulted "
+                             "instead of the model")
     parser.add_argument("--force", action="store_true",
                         help="translate even if the output already exists")
     args = parser.parse_args(argv)
@@ -107,6 +135,15 @@ def main(argv=None):
         parser.error("%s does not hold a list of strings" % args.chunk)
 
     translator = load_translator()
+
+    glossary = (translator.Glossary.load(args.glossary) if args.glossary
+                else translator.Glossary())
+    resolved, strings = resolve_with_glossary(
+        strings, glossary, translator.is_untranslatable)
+    if args.glossary:
+        log("%s: glossary settled %d of %d string(s) from %s"
+            % (name, len(resolved), len(resolved) + len(strings), args.glossary))
+
     # Checked once, before the work: a service that is not there is not
     # something to find out on the last batch.
     health = translator.check_service(args.service_url, 30)
@@ -117,6 +154,8 @@ def main(argv=None):
     out = translate_chunk(translator, strings, args.service_url,
                           args.batch_size, args.beam_size, args.max_length,
                           args.service_timeout)
+    # Glossary last, so it wins: these are overrides, not suggestions.
+    out.update(resolved)
     elapsed = time.time() - started
 
     tmp = out_path + ".partial"

--- a/distribution/src/main/resources/bin/pantogloss-translatejson
+++ b/distribution/src/main/resources/bin/pantogloss-translatejson
@@ -308,6 +308,21 @@ class TranslationCache:
 # glossary
 # --------------------------------------------------------------------------
 
+def is_untranslatable(value):
+    """True for a value with no letter or digit in it.
+
+    These are not language and the model should never see them. Asked to
+    translate "!" it answers "- I'm sorry."; "-----------" comes back the
+    same way, and "###" becomes "# # #". Across the corpus 443 of the 467
+    such strings came back altered, and they reach 4.7 million documents --
+    an apology sitting in a duration column.
+
+    Passing them through unchanged is both more correct and cheaper than
+    asking.
+    """
+    return not any(character.isalnum() for character in value)
+
+
 class Glossary:
     """Authoritative source -> English overrides consulted before the model.
 

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_JoinIndex.xml
@@ -21,7 +21,7 @@
      <!-- One database for every shard to share. Read as JSON each shard
           holds its own 456MB copy of the same table, and eight of those is
           what put the machine over during the first full run. -->
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-build-translation-db --translated [TranslatedDir] --out [TranslationsDb] [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-build-translation-db --translated [TranslatedDir] --glossary [TranslateGlossary] --out [TranslationsDb] [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>EXPECTED=$(ls -d [StringsDir]/chunk-*.json 2>/dev/null | wc -l | tr -d " ")</cmd>
      <cmd>for s in $(seq 0 $(([JoinShards] - 1))); do [BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard $s --of [JoinShards] --expect $EXPECTED [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1 [Ampersand] done; wait</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-join-index --corpus [CorpusDir] --translated [TranslatedDir] --translations-db [TranslationsDb] --solr-url [SolrUrl] --colheaders [ColHeaders] --translate-cols [TranslateCols] --shard 0 --of [JoinShards] --commit-only [GreaterThan][GreaterThan] [JobLogDir]/join_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>

--- a/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
@@ -8,7 +8,7 @@
   <exe dir="[JobDir]" shell="/bin/bash">
      <cmd>export PYTHONIOENCODING=utf-8</cmd>
      <cmd>mkdir -p [JobOutputDir] [JobLogDir] [TranslatedDir]</cmd>
-     <cmd>[BIGTRANSLATE_HOME]/bin/bt-translate-chunk --chunk [ChunkPath] --out-dir [TranslatedDir] --service-url [PantoglossUrl] --batch-size [TranslateBatchSize] [GreaterThan][GreaterThan] [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
+     <cmd>[BIGTRANSLATE_HOME]/bin/bt-translate-chunk --chunk [ChunkPath] --out-dir [TranslatedDir] --glossary [TranslateGlossary] --service-url [PantoglossUrl] --batch-size [TranslateBatchSize] [GreaterThan][GreaterThan] [JobLogDir]/translate_[DateMilis].log 2[GreaterThan][Ampersand]1</cmd>
      <cmd>cp [TranslatedDir]/[ChunkFile] [JobOutputDir]/</cmd>
      <cmd>[BIGTRANSLATE_HOME]/bin/bt-run-marker beat</cmd>
   </exe>

--- a/tests/test_w2_glossary.py
+++ b/tests/test_w2_glossary.py
@@ -1,0 +1,166 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The glossary reaching the pipeline that actually runs.
+
+The glossary was written for a documented set of model failures -- it left
+"Inmediato" untranslated in 151 of 211 records on a sample country-day,
+rendered "correo electronico" as "default mail", and turned "Asap" into
+"Asaph". The W2 rewrite never passed it. In a full corpus run "Inmediato"
+was the value of 75,420,702 documents' start field, untranslated.
+
+These tests are about the wiring, because the wiring is what was missing:
+lookup itself is covered in test_glossary.py.
+"""
+
+import importlib.machinery
+import importlib.util
+import json
+import sqlite3
+
+import pytest
+
+from conftest import BIN, CONF, POLICY, WORKFLOW_POLICY, Glossary, shim
+
+
+def _load(name):
+    spec = importlib.util.spec_from_loader(
+        name.replace("-", "_"),
+        importlib.machinery.SourceFileLoader(name.replace("-", "_"),
+                                             str(BIN / name)))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestUntranslatable:
+    """Punctuation is not language and the model should not see it."""
+
+    @pytest.mark.parametrize("value", ["!", "!!!", "-", "-----------", "###",
+                                       ",.", "   ", "***"])
+    def test_punctuation_is_untranslatable(self, value):
+        assert shim.is_untranslatable(value)
+
+    @pytest.mark.parametrize("value", ["Inmediato", "6 months", "24/7", "A1"])
+    def test_anything_with_a_letter_or_digit_is_not(self, value):
+        assert not shim.is_untranslatable(value)
+
+    def test_this_is_the_shape_that_produced_an_apology(self):
+        # Asked to translate "!" the model answered "- I'm sorry." -- which
+        # reached 4.7 million documents as a duration and a start date.
+        assert shim.is_untranslatable("!")
+
+
+class TestResolveWithGlossary:
+
+    def setup_method(self):
+        self.chunk = _load("bt-translate-chunk")
+
+    def test_glossary_entries_never_reach_the_model(self):
+        g = Glossary({"Inmediato": "Immediate"})
+        resolved, remaining = self.chunk.resolve_with_glossary(
+            ["Inmediato", "Ingeniero"], g, shim.is_untranslatable)
+        assert resolved == {"Inmediato": "Immediate"}
+        assert remaining == ["Ingeniero"]
+
+    def test_casings_collapse_onto_one_entry(self):
+        g = Glossary({"Inmediato": "Immediate"})
+        resolved, remaining = self.chunk.resolve_with_glossary(
+            ["Inmediato", "inmediato", "INMEDIATO"], g, shim.is_untranslatable)
+        assert set(resolved.values()) == {"Immediate"}
+        assert remaining == []
+
+    def test_punctuation_is_resolved_to_itself(self):
+        resolved, remaining = self.chunk.resolve_with_glossary(
+            ["!", "---"], Glossary(), shim.is_untranslatable)
+        assert resolved == {"!": "!", "---": "---"}
+        assert remaining == []
+
+    def test_an_empty_glossary_sends_everything_to_the_model(self):
+        resolved, remaining = self.chunk.resolve_with_glossary(
+            ["Inmediato"], Glossary(), shim.is_untranslatable)
+        assert resolved == {}
+        assert remaining == ["Inmediato"]
+
+
+class TestBuildTranslationDb:
+    """Correcting chunks already on disk, without translating again."""
+
+    def _chunk(self, tmp_path, pairs):
+        d = tmp_path / "translated"
+        d.mkdir(exist_ok=True)
+        (d / "chunk-00000.json").write_text(json.dumps(pairs),
+                                            encoding="utf-8")
+        return d
+
+    def _rows(self, out):
+        conn = sqlite3.connect(str(out))
+        try:
+            return dict(conn.execute("SELECT s, e FROM t"))
+        finally:
+            conn.close()
+
+    def test_the_glossary_overrides_what_the_model_returned(self, tmp_path):
+        # The thirteen hours of translation on disk stay on disk: the
+        # override is a pure function of the source string.
+        db = _load("bt-build-translation-db")
+        d = self._chunk(tmp_path, {"Inmediato": "Inmediato"})
+        out = tmp_path / "t.sqlite"
+        db.build(str(d), str(out), Glossary({"Inmediato": "Immediate"}),
+                 shim.is_untranslatable)
+        assert self._rows(out) == {"Inmediato": "Immediate"}
+
+    def test_punctuation_is_restored_to_its_source(self, tmp_path):
+        db = _load("bt-build-translation-db")
+        d = self._chunk(tmp_path, {"!": "- I'm sorry."})
+        out = tmp_path / "t.sqlite"
+        db.build(str(d), str(out), Glossary(), shim.is_untranslatable)
+        assert self._rows(out) == {"!": "!"}
+
+    def test_model_output_is_kept_where_nothing_overrides_it(self, tmp_path):
+        db = _load("bt-build-translation-db")
+        d = self._chunk(tmp_path, {"Ingeniero": "Engineer"})
+        out = tmp_path / "t.sqlite"
+        db.build(str(d), str(out), Glossary({"Inmediato": "Immediate"}),
+                 shim.is_untranslatable)
+        assert self._rows(out) == {"Ingeniero": "Engineer"}
+
+
+class TestTheWiring:
+    """The bug was never in the lookup; it was that nothing passed it."""
+
+    def test_translate_chunk_is_given_the_glossary(self):
+        text = (POLICY / "no_filter" / "PgeConfig_TranslateChunk.xml").read_text()
+        assert "--glossary [TranslateGlossary]" in text
+
+    def test_the_translation_db_build_is_given_the_glossary(self):
+        text = (POLICY / "no_filter" / "PgeConfig_JoinIndex.xml").read_text()
+        assert "--glossary [TranslateGlossary]" in text
+
+    def test_the_tasks_that_use_it_define_it(self):
+        text = (WORKFLOW_POLICY / "tasks.xml").read_text()
+        # W1's BigTranslate_Task, plus the two W2 tasks that now need it.
+        assert text.count('name="TranslateGlossary"') == 3
+
+    def test_the_glossary_ships(self):
+        assert (CONF / "glossary.es-en.tsv").exists()
+
+    def test_the_documented_failures_are_still_covered(self):
+        # The entries exist because of specific observed errors; a glossary
+        # that lost them would pass every other test here.
+        g = Glossary.load(str(CONF / "glossary.es-en.tsv"))
+        assert g.lookup("Inmediato") == "Immediate"
+        assert g.lookup("correo electronico") == "Email"
+        assert g.lookup("Asap") == "Immediate"
+        assert g.lookup("Medio Tiempo") == "Part Time"

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -163,6 +163,7 @@
           <property name="PCS_ActionRepoFile" value="file:[BIGTRANSLATE_HOME]/crawler/policy/action-beans.xml" envReplace="true"/>
           <property name="TranslatedDir" value="[BIGTRANSLATE_HOME]/data/translated" envReplace="true"/>
           <property name="PantoglossUrl" value="[PANTOGLOSS_URL]" envReplace="true"/>
+          <property name="TranslateGlossary" value="[BIGTRANSLATE_HOME]/conf/glossary.es-en.tsv" envReplace="true"/>
           <!-- 32 suits the CPU service, 128 a CUDA one. A node translating
                with a GPU should override this in its own deployment. -->
           <property name="TranslateBatchSize" value="32"/>
@@ -206,6 +207,7 @@
           <property name="TranslatedDir" value="[BIGTRANSLATE_HOME]/data/translated" envReplace="true"/>
           <property name="SolrUrl" value="[SOLR_URL]" envReplace="true"/>
           <property name="ColHeaders" value="[BIGTRANSLATE_HOME]/conf/colheaders.txt" envReplace="true"/>
+          <property name="TranslateGlossary" value="[BIGTRANSLATE_HOME]/conf/glossary.es-en.tsv" envReplace="true"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
           <!-- Four, not eight. The bottleneck is not Solr and not the
                processor: it is reading 38GB off a single external drive,


### PR DESCRIPTION
The glossary exists because of a documented set of model failures — its own header records them:

> *"on a sample country-day the model left `Inmediato` untranslated in 151 of 211 records while rendering lowercase `inmediato` correctly, translated `correo electronico` as `default mail` across roughly a hundred records, rendered `Medio Tiempo` as both `Half Time` and `Middle Time`, and turned `Asap` into the proper noun `Asaph`."*

W1 passes `--glossary`. **`bt-translate-chunk` has never had the option**, and nothing in W2 defined `TranslateGlossary`. So every one of those failures went straight to the index.

### Impact, measured against the run's own output

796 distinct strings change — but they're the highest-frequency values in the corpus, so they reach **199,981,199 field values**:

| field | docs corrected |
|---|---|
| start | 102,254,817 |
| duration | 54,499,888 |
| jobtype | 18,680,708 |
| applications | 17,309,193 |
| salary | 6,368,699 |
| department | 698,777 |
| title | 169,117 |

```
source              before          after
Inmediato           Inmediato       Immediate     ← 75,420,702 docs
inmediato           immediate       Immediate     ← casing collapses
Indefinido          Indefinita      Indefinite
correo electronico  default mail    Email
Medio Tiempo        Middle Time     Part Time
Asap                Asaph           Immediate
A Convenir          A Convince      To be agreed
```

### Applied in two places, deliberately

- `bt-translate-chunk` consults it **before** the model, so entries never cost a model call.
- `bt-build-translation-db` applies it **over** whatever the chunks hold, so a corrected glossary reaches the index **without translating again**. The chunks on disk cost 13.6 hours; lookup is a pure function of the source string.

### Separable: punctuation no longer goes to the model

Happy to drop this half if you'd rather it stood alone. Asked to translate `"!"` the model answers `"- I'm sorry."`; `"###"` becomes `"# # #"`. **443 of the 467** strings with no letter or digit came back altered, reaching **4,755,577 documents** — an apology sitting in a duration column. A value with nothing alphanumeric in it is not language, so it passes through unchanged.

### Verification

- Ran against the real 458 chunks: **1,239 corrections (796 glossary + 443 punctuation) in 11 seconds**, no re-translation.
- 379 tests pass (25 new), including that the three tasks which use the glossary define it and both PGE configs pass it — the wiring, since the wiring is what was missing.

### Still open, not fixed here

`Planta → "Plant"` (1.4M docs, should likely be "Permanent") and misspelling variants like `Fiijo`, `Indefinicda` are glossary *content* gaps rather than wiring, so they want your call on the right English rather than mine.