### PR TITLE
Cover the values the corpus is actually full of

### DIFF
--- a/distribution/src/main/resources/bin/pantogloss-translatejson
+++ b/distribution/src/main/resources/bin/pantogloss-translatejson
@@ -392,10 +392,26 @@ class Glossary:
             return None
         return ", ".join(resolved)
 
+    # Trailing decoration seen on controlled-vocabulary values in this
+    # corpus: "Inmediato.", "Temporal -", "Indefinido*", "***Temporal***".
+    #
+    # No comma. A comma separates components here -- "Medio Tiempo, Desde
+    # Casa" is two terms -- so trimming it would make a truncated list look
+    # like a whole value, and the component rules below exist to keep those
+    # apart.
+    _EDGES = " \t.;:*-_!¡·"
+
     def _lookup_term(self, term):
         if term in self._exact:
             return self._exact[term]
-        return self._folded.get(term.strip().casefold())
+        folded = term.strip().casefold()
+        hit = self._folded.get(folded)
+        if hit is not None:
+            return hit
+        # Same value, punctuated. "Inmediato." missed entirely and was the
+        # start date of half a million documents.
+        trimmed = folded.strip(self._EDGES)
+        return self._folded.get(trimmed) if trimmed else None
 
 
 # --------------------------------------------------------------------------

--- a/distribution/src/main/resources/conf/glossary.es-en.tsv
+++ b/distribution/src/main/resources/conf/glossary.es-en.tsv
@@ -37,11 +37,25 @@ Teletrabajo	Remote
 # --- duration ------------------------------------------------------------
 Indefinido	Indefinite
 Indefinida	Indefinite
-Indeterminado	Indeterminate
-Indeterminada	Indeterminate
+Indeterminado	Indefinite
+Indeterminada	Indefinite
 Permanente	Permanent
-Fijo	Fixed
-Fija	Fixed
+Planta	Permanent
+De Planta	Permanent
+Planta Laboral	Permanent
+Estable	Permanent
+Contrato Indefinido	Indefinite
+Termino Indefinido	Indefinite
+Término Indefinido	Indefinite
+Termino Fijo	Fixed Term
+Término Fijo	Fixed Term
+Contrato Fijo	Fixed Term
+Obra Labor	Project Based
+Por Obra	Project Based
+Medio Turno	Part Time
+Tiempo Parcial	Part Time
+Fijo	Fixed Term
+Fija	Fixed Term
 Según Desempeño	Based on Performance
 Segun Desempeño	Based on Performance
 Según Desempeno	Based on Performance
@@ -53,6 +67,12 @@ Por Temporada	Seasonal
 Inmediato	Immediate
 Inmediata	Immediate
 De inmediato	Immediate
+De Inmediato	Immediate
+Inmediatamente	Immediate
+Inmediatamnete	Immediate
+Incorporacion inmediata	Immediate
+Incorporación inmediata	Immediate
+Urgente	Immediate
 Lo antes posible	As soon as possible
 Asap	Immediate
 A convenir con el candidato	To be agreed with the candidate

--- a/tests/test_glossary.py
+++ b/tests/test_glossary.py
@@ -153,3 +153,65 @@ class TestShippedGlossary:
     def test_every_target_is_non_empty(self, glossary):
         for source, target in glossary.entries.items():
             assert target.strip(), "empty target for %r" % source
+
+
+class TestPunctuatedValues:
+    """Controlled-vocabulary values arrive with decoration on them."""
+
+    def test_a_trailing_period_still_matches(self):
+        # "Inmediato." was the start date of roughly half a million
+        # documents and missed the entry for "Inmediato" entirely.
+        g = Glossary({"Inmediato": "Immediate"})
+        assert g.lookup("Inmediato.") == "Immediate"
+
+    @pytest.mark.parametrize("value", ["Temporal -", "***Temporal***",
+                                       "Temporal*", "¡Temporal!", "Temporal."])
+    def test_surrounding_decoration_is_ignored(self, value):
+        g = Glossary({"Temporal": "Temporary"})
+        assert g.lookup(value) == "Temporary"
+
+    def test_a_comma_is_a_separator_and_is_not_trimmed(self):
+        # "Medio Tiempo, Desde Casa" is two terms. Trimming the comma would
+        # make a truncated list resolve as though it were a whole value.
+        g = Glossary({"Medio Tiempo": "Part Time"})
+        assert g.lookup("Medio Tiempo, ") is None
+
+    def test_an_exact_entry_still_wins_over_the_trimmed_one(self):
+        g = Glossary({"Temporal": "Temporary", "Temporal -": "Seasonal"})
+        assert g.lookup("Temporal -") == "Seasonal"
+
+    def test_punctuation_alone_is_not_a_match(self):
+        g = Glossary({"Temporal": "Temporary"})
+        assert g.lookup("---") is None
+        assert g.lookup("") is None
+
+
+class TestTheExpandedEntries:
+    """Values the corpus is full of that had no entry."""
+
+    def setup_method(self):
+        self.g = Glossary.load(str(CONF / "glossary.es-en.tsv"))
+
+    def test_planta_is_a_permanent_position(self):
+        # "personal de planta" is staff, not a factory.  The model rendered
+        # it "Plant" across 1.4 million documents.
+        assert self.g.lookup("Planta") == "Permanent"
+        assert self.g.lookup("planta") == "Permanent"
+
+    def test_fijo_is_a_fixed_term_not_a_permanent_one(self):
+        # "contrato a término fijo" is the opposite of indefinido, so it
+        # must not collapse onto Permanent.
+        assert self.g.lookup("Fijo") == "Fixed Term"
+        assert self.g.lookup("Permanente") == "Permanent"
+
+    def test_indeterminado_and_indefinido_agree(self):
+        # The same concept. The model spread it over Indefinite,
+        # Indeterminate, undetermined, undefined and indefinite.
+        assert self.g.lookup("Indefinido") == "Indefinite"
+        assert self.g.lookup("Indeterminado") == "Indefinite"
+        assert self.g.lookup("Indeterminada") == "Indefinite"
+
+    def test_the_immediate_family_agrees(self):
+        for value in ["Inmediato", "inmediato", "De inmediato",
+                      "Inmediatamente", "Inmediato.", "Urgente"]:
+            assert self.g.lookup(value) == "Immediate", value


### PR DESCRIPTION
Follow-up to #61, which restored the glossary wiring. This fills the content gaps it exposed — counted against **document frequency over a 140-file sample**, not guessed.

### Judgment calls you asked for

- **`Planta` → Permanent.** "Personal de planta" is staff, not a factory. The model rendered it `Plant` across **1.4M documents**.
- **`Fijo` → Fixed Term** (was `Fixed`). "Contrato a término fijo" is the *opposite* of `Permanente`, not a synonym, so it must not collapse onto it. A bare "Fixed" also reads as an adjective with no noun.
- **`Indeterminado` → Indefinite** (was `Indeterminate`). Same concept as `Indefinido`; the model spread one meaning across *Indefinite, Indeterminate, undetermined, undefined, indefinite*. One term now.
- Plus `Estable`, `Urgente`, `Inmediatamente`, `Término Indefinido`, `Obra Labor`, `Tiempo Parcial` and other high-frequency forms.

### Decoration is ignored on lookup

`Inmediato.` missed the `Inmediato` entry **on a trailing period alone**, and was the start date of ~500K documents. `Temporal -`, `Indefinido*` and `***Temporal***` are all in the data too.

**Not commas.** A comma separates components here (`"Medio Tiempo, Desde Casa"` is two terms), so trimming one would make a truncated list resolve as a whole value — exactly what the component rules exist to prevent. The existing suite caught this when I first included commas, which is the test doing its job.

### What it's worth

| field | cells | before | after | docs gained |
|---|---|---|---|---|
| duration | 128,368,046 | 70.1% | 73.2% | +4,007,849 |
| start | 128,388,169 | 84.6% | 86.9% | +2,960,971 |
| jobtype | 128,404,704 | 100.0% | 100.0% | — |

**~7 million documents.** Being straight about the limits: `applications` (11.2%) and `department` (0.6%) barely move, and a glossary is the wrong instrument for them — they're free text, not controlled vocabulary. Their remaining inconsistency (`send CV by email` 4.8M vs `Send CV by email` 3.4M) is the model casing the same sentence two ways, which wants output normalization rather than more entries. Happy to take that on separately if you want it.

392 tests pass (12 new).