### PR TITLE
Keep extract and join on the machine that has the disks

### DIFF
--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -387,11 +387,45 @@ ensure_working_dirs() {
   done
 }
 
+# Wait until something is listening on a port, or give up.
+#
+# Used to order the managers rather than to check health: a manager that
+# binds its port is far enough along to be talked to.
+wait_for_port() {
+  waited=0
+  while [ "$waited" -lt 90 ]; do
+    port_busy "$1" && return 0
+    sleep 2
+    waited=$((waited + 2))
+  done
+  return 1
+}
+
 start_oodt() {
   ensure_working_dirs
   nohup "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
+  nohup "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
+
+  # The Resource Manager before the Workflow Manager, and not merely started
+  # but listening. Under the ResourceRunner the workflow engine opens a client
+  # to the Resource Manager while it is being constructed, so starting the two
+  # together is a race the Workflow Manager loses about as often as it wins:
+  #
+  #   IllegalStateException: Unable to connect to Resource Manager at: ...
+  #   Caused by: java.net.ConnectException: Connection refused
+  #   ... ERROR RpcCommunicationFactory - Error creating server
+  #   Exception in thread "main" IllegalStateException: Unable to create server
+  #
+  # and the Workflow Manager exits. Nothing restarts it, so the run that
+  # follows has a File Manager, a Resource Manager and no engine at all.
+  # Under the local runner the order never mattered, which is why it stood.
+  if ! wait_for_port "$RESMGR_PORT"; then
+    echo "Resource Manager is not listening on $RESMGR_PORT; see $OODT_OUT"
+    echo "Starting the Workflow Manager anyway: it will fail if configured"
+    echo "for the ResourceRunner, and be fine if it is running tasks locally."
+  fi
+
   nohup "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
-  nohup "$RESMGR_HOME"/bin/"$RESMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &  
   nohup "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" start "$@" >> "$OODT_OUT" 2>&1 &
   # Solr runs as its own application now, with its own Jetty, rather than as a
   # war inside Tomcat. --solr-home points it at the bigtranslate core;

--- a/resmgr/src/main/resources/policy/node-to-queue-mapping.xml
+++ b/resmgr/src/main/resources/policy/node-to-queue-mapping.xml
@@ -16,15 +16,28 @@
   limitations under the License.
 -->
 <!--
-  One queue, both nodes. The translate stage is the only work worth
-  distributing, since extract and join are minutes against its hours, and
-  a chunk is portable, so there is nothing to steer: any node may take any
-  chunk and the results merge either way.
+  Two queues, because only one stage is portable.
+
+  A chunk carries no state beyond its own output file, so any node may take
+  any chunk and the results merge either way: that is the translate queue,
+  and every node serves it.
+
+  Extract and join are not portable. Both read the 38GB corpus from
+  /Volumes/CHIPOTLE_BRICK and join writes its index to /Volumes/BTSOLR, and
+  those volumes are attached to the machine running the managers. They do
+  not exist on a compute node, and are not exported. So they get a queue
+  only that machine serves.
+
+  This distinction did not exist while the workflow engine used the local
+  runner, because then extract and join never reached the Resource Manager
+  at all. Under ResourceRunnerFactory every task is submitted, so a stage
+  with no queue of its own is eligible for a node that cannot run it.
 -->
 <cas:nodeMap xmlns:cas="http://oodt.jpl.nasa.gov/1.0/resource">
   <node id="local">
     <queues>
       <queue name="translate"/>
+      <queue name="managers"/>
     </queues>
   </node>
   <node id="gpu">

--- a/tests/test_resource_queues.py
+++ b/tests/test_resource_queues.py
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Which stages may leave the machine, and which may not.
+
+Under the local runner this did not matter: extract and join never reached
+the Resource Manager, so a task without a queue was simply run in a local
+thread. Under ResourceRunnerFactory every task is submitted, and a task with
+no queue of its own is eligible for any node -- including one where the 38GB
+corpus and the Solr volume do not exist.
+"""
+
+import xml.etree.ElementTree as ET
+
+from conftest import WORKFLOW_POLICY
+
+RESMGR_POLICY = WORKFLOW_POLICY.parent.parent.parent.parent.parent / \
+    "resmgr" / "src" / "main" / "resources" / "policy"
+
+W2_TASKS = {
+    "urn:bigtranslate:Extract_Strings_Task": "managers",
+    "urn:bigtranslate:Translate_Chunk_Task": "translate",
+    "urn:bigtranslate:Join_Index_Task": "managers",
+}
+
+
+def _task_properties(task_id):
+    root = ET.parse(str(WORKFLOW_POLICY / "tasks.xml")).getroot()
+    for task in root.iter("task"):
+        if task.get("id") == task_id:
+            return {p.get("name"): p.get("value")
+                    for p in task.iter("property")}
+    raise AssertionError("no task %s" % task_id)
+
+
+class TestEveryW2TaskHasAQueue:
+
+    def test_each_task_names_its_queue(self):
+        for task_id, queue in W2_TASKS.items():
+            props = _task_properties(task_id)
+            assert props.get("QueueName") == queue, (task_id, props.get("QueueName"))
+
+    def test_each_task_declares_a_load(self):
+        # A task the Resource Manager cannot cost cannot be scheduled.
+        for task_id in W2_TASKS:
+            assert _task_properties(task_id).get("TaskLoad"), task_id
+
+
+class TestOnlyTranslateLeavesTheMachine:
+
+    def _map(self):
+        root = ET.parse(str(RESMGR_POLICY / "node-to-queue-mapping.xml")).getroot()
+        out = {}
+        for node in root.iter("node"):
+            out[node.get("id")] = {q.get("name") for q in node.iter("queue")}
+        return out
+
+    def test_every_node_serves_translate(self):
+        # A chunk carries no state beyond its own output file, so any node
+        # may take any chunk.
+        m = self._map()
+        assert m, "no nodes mapped"
+        for node, queues in m.items():
+            assert "translate" in queues, node
+
+    def test_only_the_manager_node_serves_the_managers_queue(self):
+        # Extract reads /Volumes/CHIPOTLE_BRICK and join writes
+        # /Volumes/BTSOLR. Neither volume exists on a compute node.
+        m = self._map()
+        serving = [n for n, q in m.items() if "managers" in q]
+        assert serving == ["local"], serving
+
+    def test_the_compute_node_cannot_take_extract_or_join(self):
+        queues = self._map().get("gpu")
+        assert queues is not None, "the gpu node is not mapped"
+        assert "managers" not in queues

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -141,6 +141,8 @@
           <property name="Encodings" value="[BIGTRANSLATE_HOME]/conf/encoding.txt" envReplace="true"/>
           <property name="TranslateCols" value="[BIGTRANSLATE_HOME]/conf/translate.cols" envReplace="true"/>
           <property name="ChunkSize" value="5000"/>
+          <property name="QueueName" value="managers"/>
+          <property name="TaskLoad" value="1"/>
           <property name="ProductType" value="EmploymentStringChunk"/>
         </configuration>
   </task>
@@ -217,6 +219,8 @@
                four, not faster. Eight was chosen for a parallelism the
                work does not have. -->
           <property name="JoinShards" value="4"/>
+          <property name="QueueName" value="managers"/>
+          <property name="TaskLoad" value="1"/>
           <property name="ProductType" value="EmploymentIndexedShard"/>
         </configuration>
   </task>


### PR DESCRIPTION
Two bugs that exist only once the workflow engine submits through the Resource Manager. Both found while standing up Spaghetti as a second node.

### 1. Only one of three W2 tasks named a queue

`Translate_Chunk_Task` had `QueueName`; `Extract_Strings_Task` and `Join_Index_Task` had neither `QueueName` nor `TaskLoad`.

Harmless under the local runner — extract and join never reached the Resource Manager, they ran in a local thread. Under `ResourceRunnerFactory` **every** task is submitted, and a task with no queue of its own is eligible for any node.

**Extract and join cannot run on any node:**

```
                        Mac        Spaghetti
/Volumes/CHIPOTLE_BRICK  present    ABSENT     ← 38GB corpus, read by extract and join
/Volumes/BTSOLR          present    ABSENT     ← 76G index, written by join
```

Neither volume exists on the compute node, and neither is exported. Only a *chunk* is portable, because it carries no state beyond its own output file.

So: two queues. Every node serves `translate`. Only the node with the disks serves `managers`, and extract and join ask for it.

### 2. The managers started in the wrong order

`start_oodt` launched all four with `&`. Under the ResourceRunner the workflow engine opens a client to the Resource Manager *while being constructed*, so this is a race the Workflow Manager loses as often as it wins:

```
IllegalStateException: Unable to connect to Resource Manager at: http://localhost:9202
Caused by: java.net.ConnectException: Connection refused
ERROR RpcCommunicationFactory - Error creating server
Exception in thread "main" IllegalStateException: Unable to create server
Caused by: IllegalStateException: Null engine
```

The Workflow Manager exits and nothing restarts it, leaving a File Manager, a Resource Manager, and no engine — which is how I hit it. The Resource Manager must now be *listening* before the Workflow Manager starts. If it never comes up, the script says so and starts the Workflow Manager anyway, since a local-runner deployment is fine without it.

### Verification

- 410 tests pass (5 new). `test_resource_queues.py` asserts every W2 task names a queue and a load, that every node serves `translate`, and that **only** `local` serves `managers` — the invariant that keeps a stage away from a machine that cannot run it.
- Deployed and confirmed: all six services up, Workflow Manager surviving startup with the ResourceRunner enabled.

Note: this does not flip the repo default to `ResourceRunnerFactory`. That switch is live in the deployment for the at-scale proof and deserves its own decision once that finishes.