### PR TITLE
Move the Resource Manager to a queue per queue name

### DIFF
--- a/resmgr/src/main/resources/etc/resource.properties
+++ b/resmgr/src/main/resources/etc/resource.properties
@@ -33,7 +33,24 @@ resource.monitor.factory = org.apache.oodt.cas.resource.monitor.AssignmentMonito
 resource.scheduler.factory = org.apache.oodt.cas.resource.scheduler.LRUSchedulerFactory
 
 # resource jobqueue factory
-resource.jobqueue.factory = org.apache.oodt.cas.resource.jobqueue.JobStackJobQueueFactory
+#
+# BLOCKED until an OODT release carries mnemosyne#317. FifoMappedJobQueue
+# rejects a queue name it has not been told about, and before that change
+# nothing told it: against oodt 1.11.0 this setting makes every submission
+# fail with "An invalid queue name was given". Do not merge ahead of the
+# release, and bump oodt.version in the same change.
+#
+# FifoMappedJobQueue, not JobStack, because this deployment has two queues
+# and JobStack has only one for all of them. Its maximum is a single global
+# figure, so enough queued translate chunks fill the only queue there is and
+# the join that finishes the run can never be submitted -- a stage starved by
+# the stage it is waiting on. FifoMappedJobQueue keeps a queue per name, so
+# translate filling up cannot block managers.
+#
+# The ordering matches too. The workflow engine sorts with
+# HighestFIFOPrioritySorter so that a stalled run makes the oldest chunk
+# obvious; a stack underneath would have contradicted that.
+resource.jobqueue.factory = org.apache.oodt.cas.resource.jobqueue.FifoMappedJobQueueFactory
 
 # resource job repository factory
 resource.jobrepo.factory = org.apache.oodt.cas.resource.jobrepo.MemoryJobRepositoryFactory
@@ -44,7 +61,15 @@ org.apache.oodt.cas.resource.nodes.repo.factory = org.apache.oodt.cas.resource.n
 # queue repository factory
 org.apache.oodt.cas.resource.queues.repo.factory = org.apache.oodt.cas.resource.queuerepo.XmlQueueRepositoryFactory
 
-# JobStack JobQueue config properties
+# JobQueue capacity, per queue name rather than across all of them.
+#
+# 1000 is well clear of what this pipeline queues: the corpus deduplicates to
+# 2,286,371 distinct strings, which at the default chunk size is 458 translate
+# jobs and one each of extract and join. A smaller --chunk-size would raise
+# that, and the number to change is this one.
+org.apache.oodt.cas.resource.jobqueue.fifomappedjobqueue.maxstacksize=1000
+
+# Left for a deployment that switches back to JobStackJobQueueFactory above.
 org.apache.oodt.cas.resource.jobqueue.jobstack.maxstacksize=1000
 
 # XML LRUScheduler config properties


### PR DESCRIPTION
**Draft: blocked on an OODT release carrying [mnemosyne#317](https://github.com/chrismattmann/mnemosyne/pull/317).** Do not merge ahead of it — see the bottom.

### Why switch

`JobStack` keeps **one** queue for every name and **one** maximum across all of them. We just split the pipeline into two queues on purpose — `translate` runs anywhere, `extract`/`join` only where `/Volumes/CHIPOTLE_BRICK` and `/Volumes/BTSOLR` are attached (BT #63) — and that separation means nothing if a single 1000-job capacity covers both. Enough queued translate chunks fill the only queue there is, and the join that finishes the run can never be submitted: a stage starved by the stage it is waiting on.

`FifoMappedJobQueue` keeps a queue per name, so `translate` filling up cannot block `managers`.

Ordering matches too. The workflow engine already sorts with `HighestFIFOPrioritySorter`, on the reasoning that a stalled run should make the oldest chunk obvious. A stack underneath contradicted that.

### Why it's blocked

I verified against the **published** artifact, not a local build:

```
cas-resource-1.11.0.jar → FifoMappedJobQueueFactory
  references to QueueRepository / loadQueues: 0
```

Before mnemosyne#317, `createQueue()` builds the queue bare and nothing ever calls `addQueue` on it, so `validateQueueName` refuses **every** submission with "An invalid queue name was given: translate". Merging this against 1.11.0 would stop the Resource Manager dead.

So this lands **with** the `oodt.version` bump, in the same change, once the release carrying #317 is out. The config file carries the same warning inline, so nobody flips it early by hand.

### Capacity note

1000 per queue is well clear of this pipeline: the corpus deduplicates to 2,286,371 distinct strings, which at the default chunk size is 458 translate jobs plus one each of extract and join. A smaller `--chunk-size` raises that, and the property to change is named in the file.