### PR TITLE
Make bt-node stop actually stop, and start refuse to lie

### DIFF
--- a/distribution/src/main/resources/bin/bt-node
+++ b/distribution/src/main/resources/bin/bt-node
@@ -53,11 +53,51 @@ stub_pid() {
   return 1
 }
 
+# Whoever is actually listening on the node port, pid file or no pid file.
+#
+# The file is a claim; this is the fact. They came apart badly: a stop that
+# did not stop left the old stub holding the port, the next start could not
+# bind, and the pid written down was of a process that had already given up.
+# Every job then went to the old stub -- older jars, older configuration --
+# while every deploy landed on disk and was never loaded.
+port_owner() {
+  lsof -nP -iTCP:"$NODE_PORT" -sTCP:LISTEN 2>/dev/null \
+    | awk 'NR > 1 { print $2 }' | sort -u | head -1
+}
+
+# Wait for a condition, up to $2 seconds. Used both ways: for the port to be
+# released after a stop, and for it to be taken after a start.
+wait_for() {
+  waited=0
+  while [ "$waited" -lt "$2" ]; do
+    if $1; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+port_free() { [ -z "$(port_owner)" ]; }
+port_taken() { [ -n "$(port_owner)" ]; }
+
 case "${1:-}" in
   start)
     if pid=$(stub_pid); then
       echo "Batch stub already running (pid $pid)."
       exit 0
+    fi
+    # The pid file said nothing, but something may still hold the port: a
+    # stub whose file was removed by a stop that did not finish the job.
+    # Starting anyway produces a second JVM that cannot bind, exits, and
+    # leaves its pid written down as though it were serving.
+    holder=$(port_owner)
+    if [ -n "$holder" ]; then
+      echo "Port $NODE_PORT is already held by pid $holder, with no pid file."
+      echo "That is an orphaned stub. Stop it first:"
+      echo "  kill $holder"
+      exit 1
     fi
     mkdir -p "$(dirname "$STUB_PID")" "$(dirname "$STUB_LOG")"
     # The translation service first: a task handed to this node the moment
@@ -71,22 +111,64 @@ case "${1:-}" in
       -Dorg.apache.oodt.cas.pge.task.status.legacyMode="true" \
       org.apache.oodt.cas.resource.system.extern.AvroRpcBatchStub \
       --portNum "$NODE_PORT" >> "$STUB_LOG" 2>&1 &
-    echo $! > "$STUB_PID"
-    echo "Batch stub on $NODE_PORT (pid $(cat "$STUB_PID")); log $STUB_LOG"
+    started=$!
+    # Bound, not merely launched. Reporting a pid that never took the port is
+    # how a whole afternoon's worth of jobs went to the wrong process.
+    if ! wait_for port_taken 30; then
+      echo "Batch stub did not reach $NODE_PORT within 30s; see $STUB_LOG"
+      kill "$started" 2>/dev/null
+      exit 1
+    fi
+    holder=$(port_owner)
+    if [ "$holder" != "$started" ]; then
+      echo "Port $NODE_PORT is held by pid $holder, not the stub just started"
+      echo "($started). Refusing to record a pid that is not serving."
+      kill "$started" 2>/dev/null
+      exit 1
+    fi
+    echo "$started" > "$STUB_PID"
+    echo "Batch stub on $NODE_PORT (pid $started); log $STUB_LOG"
     ;;
   stop)
-    if pid=$(stub_pid); then
+    # Whatever is on the port, not merely whatever the file names. A stop
+    # that removes the file and leaves the process running is worse than no
+    # stop at all: the next start believes the port is free.
+    pid=$(stub_pid) || pid=$(port_owner)
+    if [ -n "$pid" ]; then
       kill "$pid" 2>/dev/null
-      rm -f "$STUB_PID"
-      echo "Batch stub stopped."
+      if ! wait_for port_free 20; then
+        echo "Batch stub $pid did not exit in 20s; sending SIGKILL."
+        kill -9 "$pid" 2>/dev/null
+      fi
+      if wait_for port_free 10; then
+        rm -f "$STUB_PID"
+        echo "Batch stub stopped."
+      else
+        echo "Port $NODE_PORT is still held by pid $(port_owner)."
+        echo "The pid file is left in place; this needs looking at by hand."
+        exit 1
+      fi
     else
       echo "No batch stub running."
     fi
     "$BIGTRANSLATE_HOME"/bin/oodt stop-pantogloss
     ;;
   status)
-    if pid=$(stub_pid); then
-      echo "Batch stub running (pid $pid) on $NODE_PORT."
+    filed=$(stub_pid) || filed=""
+    holder=$(port_owner)
+    if [ -n "$filed" ] && [ "$filed" = "$holder" ]; then
+      echo "Batch stub running (pid $filed) on $NODE_PORT."
+    elif [ -n "$holder" ]; then
+      # Said plainly, because this is the state that misleads: jobs go to
+      # $holder while every restart and deploy is aimed at $filed.
+      echo "Port $NODE_PORT is held by pid $holder, but the pid file says" \
+           "${filed:-nothing}."
+      echo "Jobs are going to $holder, which is not the stub this deployment"
+      echo "thinks it is running."
+      exit 1
+    elif [ -n "$filed" ]; then
+      echo "Pid file names $filed but nothing is listening on $NODE_PORT."
+      exit 1
     else
       echo "Batch stub not running."
     fi

--- a/tests/test_bt_node.py
+++ b/tests/test_bt_node.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""What bt-node must not do: report a stub that is not the one serving.
+
+A stop that killed without waiting, and removed the pid file regardless,
+left the old stub holding the port. The next start could not bind, exited,
+and wrote its own pid down as though it were serving. Jobs went to the old
+stub -- older jars, older configuration, stale DNS -- while every restart
+and every jar deployed was aimed at a process that had already given up.
+Nothing reported anything wrong.
+"""
+
+from conftest import BIN
+
+NODE = (BIN / "bt-node").read_text()
+
+
+class TestStopActuallyStops:
+
+    def test_stop_waits_for_the_port_rather_than_assuming(self):
+        assert "wait_for port_free" in NODE
+
+    def test_stop_escalates_when_the_process_ignores_sigterm(self):
+        assert "kill -9" in NODE
+
+    def test_stop_finds_the_port_holder_when_there_is_no_pid_file(self):
+        # The exact orphan case: file gone, process alive, port held.
+        assert "pid=$(stub_pid) || pid=$(port_owner)" in NODE
+
+    def test_stop_keeps_the_pid_file_if_the_port_is_still_held(self):
+        # Removing it would tell the next start the port is free.
+        assert "still held by pid" in NODE
+
+
+class TestStartRefusesToLie:
+
+    def test_start_refuses_when_the_port_is_held_without_a_pid_file(self):
+        assert "orphaned stub" in NODE
+
+    def test_start_waits_for_the_port_to_be_bound(self):
+        assert "wait_for port_taken" in NODE
+
+    def test_start_records_a_pid_only_if_that_pid_holds_the_port(self):
+        assert 'holder" != "$started' in NODE
+        assert "Refusing to record a pid that is not serving" in NODE
+
+
+class TestStatusNamesTheDisagreement:
+
+    def test_status_compares_the_pid_file_against_the_port(self):
+        assert "port_owner" in NODE and "stub_pid" in NODE
+
+    def test_status_says_where_jobs_are_actually_going(self):
+        assert "Jobs are going to" in NODE
+
+    def test_status_fails_when_they_disagree(self):
+        # A mismatch must not read as healthy to a script checking exit codes.
+        assert NODE.count("exit 1") >= 3


### PR DESCRIPTION
This one cost an afternoon, and the symptom was "nothing I deploy has any effect."

### The state neither command could see

```
Spaghetti   pid file 40251   port 2001 held by 33970  (28 min old, 32% CPU)
Mac         pid file 52541   port 2001 held by 49154
```

`stop` killed the process, removed the pid file, and printed `Batch stub stopped` **without ever checking whether it had**. `start` trusted that file alone — so with the file gone and the old stub still holding the port, it launched a second JVM that couldn't bind, exited, and had its pid written down as though it were serving.

Every job went to the **old** stub: older jars, older configuration, a DNS answer cached before the hostname was fixed. Meanwhile every restart and every jar deployed was aimed at a process that had already given up. Nothing reported anything wrong.

### What changed

`port_owner()` asks **who is actually listening** — the fact the pid file was only claiming.

- **`stop`** finds the port holder even with no pid file, waits for the port to be released, escalates to `SIGKILL`, and **keeps** the pid file if the port is still held (removing it is what tells the next `start` the port is free).
- **`start`** refuses when the port is held with no pid file, waits for the port to be *bound*, and records a pid only if that pid is the one holding it.
- **`status`** compares the two and says plainly where jobs are actually going, exiting non-zero on disagreement so a script can't read a mismatch as healthy.

### Verified against the real failure

```
$ rm run/batch-stub.pid          # the orphan state, reproduced
$ bt-node status
Port 2001 is held by pid 52944, but the pid file says nothing.
Jobs are going to 52944, which is not the stub this deployment thinks it is running.

$ bt-node start
Port 2001 is already held by pid 52944, with no pid file.
That is an orphaned stub. Stop it first:
  kill 52944

$ bt-node stop
Batch stub stopped.                # port released, verified 0 listeners
$ bt-node start && bt-node status
Batch stub running (pid 54590) on 2001.    # pid file and port owner agree
```

420 tests pass (10 new). `lsof` is present on both macOS and Ubuntu, which is what `port_owner` uses.