### PR TITLE
Stop the translate stage triggering a workflow that does not exist

### DIFF
--- a/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
+++ b/pge/src/main/resources/policy/no_filter/PgeConfig_TranslateChunk.xml
@@ -32,7 +32,22 @@
     <metadata key="Ampersand" val="&#38;"/>
     <metadata key="ProductionDateTime" val="[DATE.UTC]"/>
     <metadata key="DateMilis" val="[DATE_TO_MILLIS([ProductionDateTime],UTC_FORMAT,1970-01-01)]"/>
-    <metadata key="PCS_ActionsIds" val="TriggerPostIngestWorkflow" split="true"/>
+    <!-- No post-ingest action. TriggerPostIngestWorkflow fires
+         [ProductType]Ingest, which for this stage is
+         EmploymentTranslatedChunkIngest, and no workflow answers to that name:
+         sendEvent returned false and every successful translation ended with
+
+           WARNING: Failed to perform crawler action ...
+           java.lang.Exception: Action (id = TriggerPostIngestWorkflow ...) returned false
+           WARNING: Product was not ingested [file=...]
+
+         reported as a failure after the work was done and catalogued.
+
+         There is nothing for a translated chunk to start. The join is
+         triggered once by EmploymentTranslationsComplete and waits for every
+         chunk itself, which is what the expect flag is for. Extract keeps its
+         trigger, because EmploymentStringChunkIngest is what gives each chunk
+         a translate workflow in the first place. -->
     <metadata key="ChunkFile" val="[Filename]"/>
     <metadata key="JobDir" val="[BIGTRANSLATE_HOME]/data/jobs/translate/[ChunkFile]_[DateMilis]"/>
     <metadata key="JobOutputDir" val="[JobDir]/output"/>

--- a/tests/test_resource_queues.py
+++ b/tests/test_resource_queues.py
@@ -85,3 +85,36 @@ class TestOnlyTranslateLeavesTheMachine:
         queues = self._map().get("gpu")
         assert queues is not None, "the gpu node is not mapped"
         assert "managers" not in queues
+
+
+class TestTheTranslateStageStartsNothing:
+    """A stage with nothing downstream must not claim to trigger one.
+
+    TriggerPostIngestWorkflow fires [ProductType]Ingest. For the translate
+    stage that is EmploymentTranslatedChunkIngest, which no workflow answers
+    to, so sendEvent returned false and every successful translation ended
+    with "Action ... returned false" and "Product was not ingested" -- after
+    the work was done and catalogued.
+    """
+
+    def _pge(self, name):
+        return (WORKFLOW_POLICY.parent.parent.parent.parent.parent / "pge" /
+                "src" / "main" / "resources" / "policy" / "no_filter" /
+                name).read_text()
+
+    def test_translate_has_no_post_ingest_action(self):
+        assert "PCS_ActionsIds" not in self._pge("PgeConfig_TranslateChunk.xml")
+
+    def test_extract_keeps_its_post_ingest_action(self):
+        # EmploymentStringChunkIngest is what gives each chunk a translate
+        # workflow; removing it would stop the pipeline entirely.
+        assert "PCS_ActionsIds" in self._pge("PgeConfig_ExtractStrings.xml")
+
+    def test_every_triggered_event_is_declared(self):
+        # The rule the missing event broke: a stage that fires
+        # [ProductType]Ingest needs that event in events.xml.
+        events = (WORKFLOW_POLICY / "events.xml").read_text()
+        for pge, product in [("PgeConfig_ExtractStrings.xml",
+                              "EmploymentStringChunk")]:
+            if "PCS_ActionsIds" in self._pge(pge):
+                assert '"%sIngest"' % product in events, product


### PR DESCRIPTION
Every successful translation ended in a reported failure — after the work was done and the product catalogued:

```
INFO: Successfully ingested product: [...chunk-00200.json]
WARNING: Failed to perform crawler action ...
java.lang.Exception: Action (id = TriggerPostIngestWorkflow ...) returned false
```

`TriggerPostIngestWorkflow` fires `[ProductType]Ingest`. For this stage that's **`EmploymentTranslatedChunkIngest`**, and `events.xml` declares no such event, so `sendEvent` returns false and the action reports failure.

### There is nothing for a translated chunk to start

The join runs **once**, triggered by `EmploymentTranslationsComplete`, and waits for every chunk itself. A per-chunk trigger has no listener by design, not by omission.

**Extract keeps its trigger** — `EmploymentStringChunkIngest` is what gives each chunk a translate workflow, and removing it would stop the pipeline entirely. The two stages differ, and only one of them was wrong.

### Verified on the running deployment

Fired a chunk after deploying to both nodes:

```
Successfully ingested product: [...chunk-00300.json]      ✓
"returned false" occurrences:  0                          ✓ (was 1 per chunk)
```

One warning remains and is unrelated: the crawler declines to ingest `chunk-00300.json.met` as a product in its own right, which is correct behaviour — it's the metadata sidecar — just alarmingly worded.

### Test

`test_every_triggered_event_is_declared` asserts the rule rather than the symptom: a stage that fires `[ProductType]Ingest` must have that event in `events.xml`. 423 tests pass (3 new).