### PR TITLE
Have the File Manager fetch a translated chunk, not the node copy it

### DIFF
--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -157,7 +157,21 @@
           <property name="PCS_WorkflowManagerUrl" value="[WORKFLOW_URL]" envReplace="true"/>
           <property name="PCS_FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
           <property name="PCS_MetFileExtension" value="met"/>
-          <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.LocalDataTransferFactory"/>
+          <!-- Remote, not Local, because this is the one task that runs on
+               another machine. LocalDataTransferFactory copies the file on
+               whichever machine ran the task, so a node ingested its output
+               into its own repository directory and reported success: the
+               File Manager catalogued the absolute path, every machine uses
+               the same absolute path, and the record was indistinguishable
+               from one whose file was here. Ten of twenty chunks were on the
+               wrong disk and nothing said so.
+
+               RemoteDataTransferFactory has the File Manager pull the file,
+               so it lands where the catalogue says. On the manager that is
+               RPC to itself rather than a copy, which for a 284KB chunk is
+               not worth a second setting. Extract and join keep Local: they
+               only ever run here. -->
+          <property name="PCS_ClientTransferServiceFactory" value="org.apache.oodt.cas.filemgr.datatransfer.RemoteDataTransferFactory"/>
           <!-- Where the crawler actions live. Without it PCS_ActionsIds
                names beans that cannot be resolved, so the post ingest
                trigger never runs: products are catalogued and the stage


### PR DESCRIPTION
A 20-chunk run across two machines translated **all twenty**, reported **no errors**, and left **ten of them on the wrong disk**.

```
spaghetti:  /Users/mattmann/bt-w1/data/translated-catalog/chunk-00010.json/chunk-00010.json   143317 bytes
manager:    No such file or directory
```

### Why nothing complained

`LocalDataTransferFactory` copies a file on whichever machine ran the task. On the manager that's right. On a compute node it copies the output into *that node's* repository directory and reports success — and because every machine here uses the **same absolute path** (which it must, since the File Manager catalogues absolute paths), the resulting record is indistinguishable from one whose file is local.

The join reads what the File Manager knows about. A full run would have built its translation database from half the corpus and said nothing — a failure this project has already had once in a different form, and which produced an index still in Spanish.

`RemoteDataTransferFactory` has the File Manager **pull** the file, so it lands where the catalogue says it is. Only the translate task changes; it's the only one that runs anywhere but the manager. Extract and join keep `Local`.

### It cannot be set per node

Worth recording, because it's the obvious next question. The Workflow Manager builds task metadata **before** the Resource Manager has chosen a machine, and `PgeMetadata.DEFAULT_QUERY_ORDER` is `[STATIC, DYNAMIC, LOCAL]` — `STATIC` being the task properties, queried first, ahead of anything a node could override. So a deploy-time or node-local setting can't win, and nothing at metadata-build time knows which machine will run the job.

The manager therefore uses remote transfer to itself: RPC to localhost for a 284KB chunk, not worth a second setting.

### Verified on hardware

```
ran on spaghetti : 00010 00030 00060
on the manager   : 00010 00030 00060      ← all of them
strays on spaghetti: none
```

Before this change the same comparison was 10 on the node and 0 on the manager.