### PR TITLE
Hold a chunk translation until that chunk is on every node

### DIFF
--- a/distribution/src/main/resources/bin/bt-cluster
+++ b/distribution/src/main/resources/bin/bt-cluster
@@ -196,7 +196,22 @@ stage_one() {
     rsync -a --exclude 'setenv.sh' -e "$SSH" \
       "$BIGTRANSLATE_HOME/$d/" "$host:$BIGTRANSLATE_HOME/$d/"
   done
-  staged=$($SSH "$host" "find '$BIGTRANSLATE_HOME/data/strings' -name 'chunk-*.json' -type f 2>/dev/null | wc -l | tr -d ' '")
+  # A manifest of what actually arrived, written here on the manager, because
+  # ChunkStagedCondition runs in the Workflow Manager and cannot stat a remote
+  # disk. Ask the node what it has rather than assuming the rsync copied what
+  # we sent -- a manifest that lists a file the node does not have would
+  # release a job that then fails, which is the whole failure this prevents.
+  mkdir -p "$BIGTRANSLATE_HOME/data/staging"
+  manifest="$BIGTRANSLATE_HOME/data/staging/$id.staged"
+  # Assigned before it is written, so that a failed ssh is a failure. Piping
+  # straight into the file would report the exit status of the local sort,
+  # and an unreachable node would quietly produce an empty manifest.
+  listing=$($SSH "$host" "find '$BIGTRANSLATE_HOME/data/strings' -name 'chunk-*.json' -type f | sed 's|.*/||' | sort") \
+    || die "could not list the staged chunks on $host"
+  printf '%s\n' "$listing" > "$manifest.tmp"
+  # Renamed into place so the condition never reads a half-written list.
+  mv "$manifest.tmp" "$manifest"
+  staged=$(grep -c . "$manifest" | tr -d ' ')
   echo "  $id has $staged chunk file(s)"
 }
 

--- a/extensions/pom.xml
+++ b/extensions/pom.xml
@@ -72,9 +72,15 @@
       <version>${oodt.version}</version>
     </dependency>
     <dependency>
+      <groupId>ai.mattmann.mnemosyne</groupId>
+      <artifactId>cas-workflow</artifactId>
+      <version>${oodt.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.2</version>
+      <version>${junit.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/extensions/src/main/java/org/bigtranslate/workflow/ChunkStagedCondition.java
+++ b/extensions/src/main/java/org/bigtranslate/workflow/ChunkStagedCondition.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bigtranslate.workflow;
+
+import org.apache.oodt.cas.metadata.Metadata;
+import org.apache.oodt.cas.workflow.structs.WorkflowConditionConfiguration;
+import org.apache.oodt.cas.workflow.structs.WorkflowConditionInstance;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Holds a chunk translation until that chunk exists on every compute node.
+ *
+ * <p>A translate task reads its chunk from a node-local path. The chunks are
+ * produced on the manager and copied outwards by {@code bt-cluster stage}, so
+ * between the split finishing and the staging finishing there is a window in
+ * which the Resource Manager will happily schedule a chunk onto a node that
+ * does not have it yet. Every job placed in that window fails.
+ *
+ * <p>What we did instead, for one run, was keep the second node's batch stub
+ * down until staging was over. That works, but it is a hack with two bad
+ * properties: it takes a healthy node out of the cluster in order to express
+ * a timing constraint, and it lives in the head of whoever is running the
+ * cluster rather than in the policy. This condition is the same constraint,
+ * written down.
+ *
+ * <p>The condition is evaluated by the Workflow Manager, not by the node that
+ * will eventually run the task, so it cannot stat the node's disk and ask
+ * directly. It reads instead the manifests {@code bt-cluster stage} leaves
+ * behind on the manager: one file per node, listing the chunk file names
+ * confirmed present on that node once its copy finished. Because any queued
+ * task may be scheduled to any node, a chunk is releasable only when every
+ * node has it, so this holds all translate tasks until the slowest node is
+ * staged, which is precisely what taking the stub down achieved.
+ *
+ * <p>Absent evidence means "not yet", never "go ahead": a missing or
+ * unreadable manifest holds the task, on the same reasoning as
+ * {@code ProductCountMatchesCondition}, where a count that could not be read
+ * is not a count of zero. The single deliberate exception is a missing
+ * {@code nodes.conf}, which is what a plain single-machine install looks
+ * like. There are no remote nodes to stage to there and nothing to wait for,
+ * and holding would deadlock every single-node run forever.
+ */
+public class ChunkStagedCondition implements WorkflowConditionInstance {
+
+  private static final Logger LOG =
+      Logger.getLogger(ChunkStagedCondition.class.getName());
+
+  static final String STAGING_DIR = "StagingDir";
+  static final String NODES_FILE = "NodesFile";
+  static final String FILENAME_KEY = "FilenameKey";
+
+  static final String DEFAULT_FILENAME_KEY = "Filename";
+  static final String MANIFEST_SUFFIX = ".staged";
+
+  /**
+   * A node id that no manifest can match, used to hold every task when
+   * nodes.conf exists but cannot be read.
+   */
+  private static final String UNREADABLE = " unreadable-nodes-conf";
+
+  /**
+   * Manifests are read on every evaluation of every queued task, which for a
+   * few hundred chunks against a polling engine is a great deal of
+   * re-reading of a file that changes once per run. Keyed on size and
+   * timestamp so a restaged manifest is still picked up; bt-cluster renames
+   * the finished file into place, so a manifest never grows in place under a
+   * reader and any change of contents is a change of one or both of these.
+   */
+  private static final Map<String, CachedManifest> CACHE =
+      new ConcurrentHashMap<String, CachedManifest>();
+
+  public ChunkStagedCondition() {
+    super();
+  }
+
+  public boolean evaluate(Metadata metadata,
+      WorkflowConditionConfiguration config) {
+    String stagingDir = config.getProperty(STAGING_DIR);
+    String nodesFile = config.getProperty(NODES_FILE);
+    if (stagingDir == null || nodesFile == null) {
+      LOG.log(Level.SEVERE, "Cannot evaluate without [" + STAGING_DIR
+          + "] and [" + NODES_FILE + "]");
+      return false;
+    }
+
+    String filenameKey = config.getProperty(FILENAME_KEY);
+    if (filenameKey == null || filenameKey.trim().length() == 0) {
+      filenameKey = DEFAULT_FILENAME_KEY;
+    }
+
+    String chunk = baseName(
+        metadata != null ? metadata.getMetadata(filenameKey) : null);
+    if (chunk == null) {
+      LOG.log(Level.SEVERE, "Cannot evaluate without a [" + filenameKey
+          + "] to look for; holding");
+      return false;
+    }
+
+    List<String> nodes = computeNodes(new File(nodesFile));
+    if (nodes == null) {
+      // No nodes.conf: a single-machine install, where the chunk was written
+      // by the split on this very disk. Nothing is staged anywhere, so there
+      // is nothing to wait for.
+      LOG.log(Level.FINE, "No [" + nodesFile + "]; treating as a single-node "
+          + "install and releasing [" + chunk + "]");
+      return true;
+    }
+    if (nodes.isEmpty()) {
+      LOG.log(Level.FINE, "No compute nodes beyond the manager in ["
+          + nodesFile + "]; releasing [" + chunk + "]");
+      return true;
+    }
+
+    for (String node : nodes) {
+      File manifest = new File(stagingDir, node + MANIFEST_SUFFIX);
+      Set<String> staged = read(manifest);
+      if (staged == null) {
+        LOG.log(Level.FINE, "No staging manifest for [" + node + "] at ["
+            + manifest + "]; holding [" + chunk + "]");
+        return false;
+      }
+      if (!staged.contains(chunk)) {
+        LOG.log(Level.FINE, "[" + chunk + "] is not staged on [" + node
+            + "]; holding");
+        return false;
+      }
+    }
+
+    LOG.log(Level.FINE, "[" + chunk + "] is staged on all of " + nodes);
+    return true;
+  }
+
+  /**
+   * The compute nodes: every node in {@code nodes.conf} but the first, which
+   * is the manager and already holds the chunks because it wrote them.
+   *
+   * @return null when the file does not exist, which is a single-machine
+   *         install rather than an error
+   */
+  static List<String> computeNodes(File nodesConf) {
+    if (!nodesConf.isFile()) {
+      return null;
+    }
+    List<String> ids = new ArrayList<String>();
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new InputStreamReader(
+          new FileInputStream(nodesConf), StandardCharsets.UTF_8));
+      String line;
+      boolean seenManager = false;
+      while ((line = reader.readLine()) != null) {
+        String trimmed = line.trim();
+        if (trimmed.length() == 0 || trimmed.startsWith("#")) {
+          continue;
+        }
+        if (!seenManager) {
+          seenManager = true;
+          continue;
+        }
+        ids.add(trimmed.split("\\s+")[0]);
+      }
+      return ids;
+    } catch (Exception e) {
+      // Distinct from having no file at all: the cluster is configured and we
+      // could not read how, so hold rather than assume a single node.
+      LOG.log(Level.WARNING, "Could not read [" + nodesConf + "]: "
+          + e.getMessage());
+      return Collections.singletonList(UNREADABLE);
+    } finally {
+      close(reader);
+    }
+  }
+
+  /**
+   * The chunk names staged on one node, or null if that cannot be determined,
+   * which the caller treats as "not yet".
+   */
+  static Set<String> read(File manifest) {
+    if (!manifest.isFile()) {
+      return null;
+    }
+    long modified = manifest.lastModified();
+    long length = manifest.length();
+    String key = manifest.getAbsolutePath();
+    CachedManifest cached = CACHE.get(key);
+    if (cached != null && cached.modified == modified
+        && cached.length == length) {
+      return cached.names;
+    }
+
+    Set<String> names = new HashSet<String>();
+    BufferedReader reader = null;
+    try {
+      reader = new BufferedReader(new InputStreamReader(
+          new FileInputStream(manifest), StandardCharsets.UTF_8));
+      String line;
+      while ((line = reader.readLine()) != null) {
+        String trimmed = line.trim();
+        if (trimmed.length() > 0) {
+          names.add(baseName(trimmed));
+        }
+      }
+    } catch (Exception e) {
+      LOG.log(Level.WARNING, "Could not read staging manifest [" + manifest
+          + "]: " + e.getMessage());
+      return null;
+    } finally {
+      close(reader);
+    }
+    CACHE.put(key, new CachedManifest(modified, length, names));
+    return names;
+  }
+
+  static String baseName(String path) {
+    if (path == null) {
+      return null;
+    }
+    String trimmed = path.trim();
+    if (trimmed.length() == 0) {
+      return null;
+    }
+    int slash = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+    return slash >= 0 ? trimmed.substring(slash + 1) : trimmed;
+  }
+
+  private static void close(BufferedReader reader) {
+    if (reader != null) {
+      try {
+        reader.close();
+      } catch (Exception ignored) {
+        // Nothing useful to do about a failed close of a file we only read.
+      }
+    }
+  }
+
+  private static final class CachedManifest {
+    private final long modified;
+    private final long length;
+    private final Set<String> names;
+
+    private CachedManifest(long modified, long length, Set<String> names) {
+      this.modified = modified;
+      this.length = length;
+      this.names = names;
+    }
+  }
+}

--- a/extensions/src/test/java/org/bigtranslate/workflow/TestChunkStagedCondition.java
+++ b/extensions/src/test/java/org/bigtranslate/workflow/TestChunkStagedCondition.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.bigtranslate.workflow;
+
+import org.apache.oodt.cas.metadata.Metadata;
+import org.apache.oodt.cas.workflow.structs.WorkflowConditionConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The window this closes is the one between a chunk being split out on the
+ * manager and that chunk reaching the other machines. A job scheduled into
+ * that window lands on a node with no file to translate and fails, and the
+ * only reason it did not happen on the last run is that a node was held down
+ * by hand.
+ */
+public class TestChunkStagedCondition {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private File staging;
+  private File nodesConf;
+
+  @Before
+  public void setUp() throws Exception {
+    staging = folder.newFolder("staging");
+    nodesConf = new File(folder.getRoot(), "nodes.conf");
+  }
+
+  @Test
+  public void holdsWhenNothingHasBeenStagedYet() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    assertFalse("a chunk with no manifest anywhere must not be released",
+        evaluate("chunk-0001.json"));
+  }
+
+  @Test
+  public void releasesOnceEveryNodeHasTheChunk() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json", "chunk-0002.json");
+    assertTrue(evaluate("chunk-0001.json"));
+  }
+
+  @Test
+  public void holdsWhileOneOfTwoNodesIsStillMissingIt() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8", "gpu2 spaghetti2 8");
+    writeManifest("gpu", "chunk-0001.json");
+    writeManifest("gpu2", "chunk-0002.json");
+    assertFalse("the slowest node decides when the chunk is releasable",
+        evaluate("chunk-0001.json"));
+  }
+
+  @Test
+  public void holdsAChunkThatWasNotPartOfTheStagedSet() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json");
+    assertFalse(evaluate("chunk-0009.json"));
+  }
+
+  /**
+   * The manager is the first line and is never staged to, because it wrote
+   * the chunks. Requiring a manifest for it would hold every task forever on
+   * a cluster that is working perfectly.
+   */
+  @Test
+  public void doesNotExpectAManifestForTheManager() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json");
+    assertTrue(evaluate("chunk-0001.json"));
+    assertFalse("only the manager line should be skipped",
+        new File(staging, "ninja.staged").exists());
+  }
+
+  /**
+   * A plain single-machine install has no nodes.conf at all. Holding there
+   * would deadlock every run on a cluster that has nowhere to stage to.
+   */
+  @Test
+  public void releasesWhenThereIsNoClusterConfigured() throws Exception {
+    assertTrue(evaluate("chunk-0001.json"));
+  }
+
+  @Test
+  public void releasesWhenTheOnlyNodeIsTheManager() throws Exception {
+    writeNodes("ninja localhost 8");
+    assertTrue(evaluate("chunk-0001.json"));
+  }
+
+  @Test
+  public void ignoresCommentsAndBlankLinesWhenFindingTheManager()
+      throws Exception {
+    writeNodes("# the first real line is this machine", "", "ninja localhost 8",
+        "# and the rest are compute nodes", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json");
+    assertTrue("a comment above the manager line must not be taken for it",
+        evaluate("chunk-0001.json"));
+  }
+
+  /**
+   * Filename arrives as a full path on the manager while the manifest is
+   * built from basenames on the node, where the absolute path is the same but
+   * there is no reason to depend on that.
+   */
+  @Test
+  public void comparesOnTheFileNameNotTheWholePath() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "/usr/local/bigtranslate/data/strings/chunk-0001.json");
+    assertTrue(evaluate("/some/other/prefix/data/strings/chunk-0001.json"));
+  }
+
+  @Test
+  public void holdsWhenThereIsNoFilenameToLookFor() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json");
+    assertFalse("without a chunk name the condition cannot be satisfied",
+        evaluate(null));
+  }
+
+  @Test
+  public void holdsWhenTheConditionIsNotConfigured() throws Exception {
+    Metadata metadata = new Metadata();
+    metadata.addMetadata("Filename", "chunk-0001.json");
+    assertFalse(new ChunkStagedCondition().evaluate(metadata,
+        new WorkflowConditionConfiguration()));
+  }
+
+  /**
+   * Manifests are cached to keep a polling engine off the disk, so a node
+   * staged after a first look must still be seen.
+   */
+  @Test
+  public void picksUpAManifestWrittenAfterTheFirstEvaluation()
+      throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    assertFalse(evaluate("chunk-0001.json"));
+    writeManifest("gpu", "chunk-0001.json");
+    assertTrue("staging after a hold must release the task",
+        evaluate("chunk-0001.json"));
+  }
+
+  @Test
+  public void picksUpAChunkAddedToAnExistingManifest() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json");
+    assertFalse(evaluate("chunk-0002.json"));
+    writeManifest("gpu", "chunk-0001.json", "chunk-0002.json");
+    assertTrue("a restaged manifest must not be served from the cache",
+        evaluate("chunk-0002.json"));
+  }
+
+  @Test
+  public void readsTheChunkFromAConfiguredMetadataKey() throws Exception {
+    writeNodes("ninja localhost 8", "gpu spaghetti 8");
+    writeManifest("gpu", "chunk-0001.json");
+    Metadata metadata = new Metadata();
+    metadata.addMetadata("ChunkFile", "chunk-0001.json");
+    WorkflowConditionConfiguration config = config();
+    config.addConfigProperty(ChunkStagedCondition.FILENAME_KEY, "ChunkFile");
+    assertTrue(new ChunkStagedCondition().evaluate(metadata, config));
+  }
+
+  // ------------------------------------------------------------- helpers ---
+
+  private boolean evaluate(String filename) {
+    Metadata metadata = new Metadata();
+    if (filename != null) {
+      metadata.addMetadata("Filename", filename);
+    }
+    return new ChunkStagedCondition().evaluate(metadata, config());
+  }
+
+  private WorkflowConditionConfiguration config() {
+    WorkflowConditionConfiguration config =
+        new WorkflowConditionConfiguration();
+    config.addConfigProperty(ChunkStagedCondition.STAGING_DIR,
+        staging.getAbsolutePath());
+    config.addConfigProperty(ChunkStagedCondition.NODES_FILE,
+        nodesConf.getAbsolutePath());
+    return config;
+  }
+
+  private void writeNodes(String... lines) throws Exception {
+    write(nodesConf, lines);
+  }
+
+  private void writeManifest(String node, String... chunks) throws Exception {
+    write(new File(staging, node + ChunkStagedCondition.MANIFEST_SUFFIX),
+        chunks);
+  }
+
+  private void write(File file, String... lines) throws Exception {
+    Writer writer = new OutputStreamWriter(new FileOutputStream(file),
+        StandardCharsets.UTF_8);
+    try {
+      for (String line : lines) {
+        writer.write(line);
+        writer.write("\n");
+      }
+    } finally {
+      writer.close();
+    }
+    // The cache keys on size and timestamp, and a test can rewrite a file
+    // inside the filesystem's timestamp granularity. Staging in real life
+    // takes minutes, so this is a property of the test rather than of the
+    // condition, but a test that passes only on a coarse clock is no test.
+    file.setLastModified(System.currentTimeMillis() + 1000L * lines.length);
+  }
+}

--- a/workflow/src/main/resources/policy/conditions.xml
+++ b/workflow/src/main/resources/policy/conditions.xml
@@ -39,4 +39,24 @@
     </configuration>
   </condition>
 
+  <!-- Holds a chunk translation until that chunk exists on every compute
+       node. The chunks are written on the manager and copied outwards by
+       "bt-cluster stage", and until that copy finishes the Resource Manager
+       will schedule a chunk onto a node that has no such file, where the job
+       fails. The alternative, used once by hand, was to keep the second
+       node's batch stub down for the duration, which takes a working node out
+       of the cluster to express a timing constraint and is remembered by
+       nobody.
+
+       A missing nodes.conf means a single machine install with nowhere to
+       stage to, and releases; anything else unreadable holds. -->
+  <condition id="urn:bigtranslate:ChunkStaged" name="Chunk Staged"
+             class="org.bigtranslate.workflow.ChunkStagedCondition">
+    <configuration>
+      <property name="StagingDir" value="[BIGTRANSLATE_HOME]/data/staging" envReplace="true"/>
+      <property name="NodesFile" value="[BIGTRANSLATE_HOME]/conf/nodes.conf" envReplace="true"/>
+      <property name="FilenameKey" value="Filename"/>
+    </configuration>
+  </condition>
+
 </cas:conditions>

--- a/workflow/src/main/resources/policy/tasks.xml
+++ b/workflow/src/main/resources/policy/tasks.xml
@@ -149,7 +149,9 @@
 
   <task id="urn:bigtranslate:Translate_Chunk_Task" name="Translate_Chunk_Task"
     class="org.apache.oodt.cas.pge.StdPGETaskInstance">
-        <conditions/>
+        <conditions>
+          <condition id="urn:bigtranslate:ChunkStaged"/>
+        </conditions>
         <configuration>
           <property name="PGETask_Name" value="Translate_Chunk_Task"/>
           <property name="PGETask_ConfigFilePath" value="[BIGTRANSLATE_HOME]/pge/policy/no_filter/PgeConfig_TranslateChunk.xml" envReplace="true"/>


### PR DESCRIPTION
Replaces the "keep the second node's batch stub down until staging finishes"
hack with a workflow condition.

## The window

Chunks are written on the manager and copied outwards by `bt-cluster stage`.
Between the split finishing and the staging finishing, the Resource Manager
will happily schedule a chunk onto a node that does not have it, and every job
placed in that window fails. On the last run I kept Spaghetti's batch stub down
for the duration. That works, but it takes a healthy node out of the cluster to
express a timing constraint, and it is remembered by nobody.

## The condition

`ChunkStagedCondition` is evaluated in the Workflow Manager, not on the node
that will run the task, so it cannot stat the node's disk. `bt-cluster stage`
therefore now leaves a manifest per node on the manager — one file per node,
listing the chunk names confirmed present *on that node* after its copy
finished — and the condition reads those.

It asks the node what it actually has rather than trusting that rsync copied
what we sent. A manifest naming a file the node does not have would release a
job that then fails, which is the failure this exists to prevent.

Because any queued task may be scheduled to any node, a chunk is releasable
only when **every** node has it. So this holds all translate tasks until the
slowest node is staged — precisely what taking the stub down achieved, without
removing a node from the cluster.

## Failing closed, with one exception

Missing or unreadable manifest, no `Filename`, unreadable `nodes.conf` → hold.
Same reasoning as `ProductCountMatchesCondition`: a count that could not be read
is not a count of zero.

The deliberate exception is a **missing `nodes.conf`**, which is what a plain
single-machine install looks like. There are no remote nodes and nothing to wait
for, and holding would deadlock every single-node run forever.

## Also fixed in `stage_one`

- The listing is assigned before it is written. Piping ssh straight into the
  file reports the exit status of the local `sort`, so an unreachable node would
  have quietly written an **empty** manifest.
- Basenames via `sed` rather than `find -exec basename`, which is a process per
  file and not portable across nodes.

## Tests

14 tests: holds with nothing staged, holds while one of two nodes lags, holds a
chunk outside the staged set, releases once every node has it, never expects a
manifest for the manager, releases with no `nodes.conf` and with only a manager
line, skips comments when finding the manager line, compares on basename not
path, and picks up both a manifest written after a hold and a chunk added to an
existing manifest (cache invalidation).

## Verified live

Deployed to `bt-w1`, Workflow Manager restarted, condition loads
(`getConditionById urn:bigtranslate:ChunkStaged`), and **both** batch stubs are
now up for the running E2E — the first run where the GPU node is in the cluster
from the start.