### PR TITLE
Stop setenv.sh failing on every Linux node

### DIFF
--- a/distribution/src/main/resources/bin/setenv.sh
+++ b/distribution/src/main/resources/bin/setenv.sh
@@ -23,8 +23,22 @@
 #
 # which reads like a broken install rather than an unset variable.
 if [ -z "${BIGTRANSLATE_HOME:-}" ]; then
-  # ${BASH_SOURCE[0]} when sourced, $0 when run; either way this file.
-  _bt_setenv="${BASH_SOURCE[0]:-$0}"
+  # ${BASH_SOURCE[0]} when sourced under bash, $0 otherwise. Written without
+  # the subscript because that is array syntax, and a POSIX shell does not
+  # parse it: dash rejects ${BASH_SOURCE[0]} outright with
+  #
+  #   ./bin/oodt: 27: bin/setenv.sh: Bad substitution
+  #
+  # which killed every /bin/sh script that sourced this file. Invisible on
+  # macOS, where /bin/sh is bash, and fatal on Linux, where it is dash -- so
+  # bin/oodt worked on the manager and failed on the compute nodes. Bare
+  # $BASH_SOURCE is element zero under bash and an ordinary unset variable
+  # anywhere else, which is exactly the fallback wanted.
+  if [ -n "${BASH_SOURCE:-}" ]; then
+    _bt_setenv="$BASH_SOURCE"
+  else
+    _bt_setenv="$0"
+  fi
   _bt_bin=$(cd "$(dirname "$_bt_setenv")" 2>/dev/null && pwd)
   if [ -n "$_bt_bin" ]; then
     BIGTRANSLATE_HOME=$(cd "$_bt_bin/.." 2>/dev/null && pwd)


### PR DESCRIPTION
## The failure

```
mattmann@spaghetti:~$ cd ~/bt-w1 && ./bin/oodt restart
./bin/oodt: 27: /home/mattmann/bt-w1/bin/setenv.sh: Bad substitution
```

`setenv.sh` found its own location with `${BASH_SOURCE[0]:-$0}`. The `[0]`
subscript is array syntax, and a POSIX shell does not parse it — dash rejects
the entire expansion.

`bin/oodt` and `bin/bt-cluster` are both `#!/bin/sh`. On Linux `/bin/sh` is
dash, so sourcing this file killed them outright.

## Why it stayed hidden

On macOS `/bin/sh` is bash, so the line is perfectly valid there. It worked on
the manager and failed on every compute node. It also only bites when a script
runs it directly: `bt-cluster` reaches a node over ssh, which uses the login
shell (bash), so node start/stop/status all worked while `./bin/oodt` on the
same machine did not.

## The fix

Bare `$BASH_SOURCE` is element zero under bash, and an ordinary unset variable
under anything else — exactly the fallback intended:

```sh
if [ -n "${BASH_SOURCE:-}" ]; then
  _bt_setenv="$BASH_SOURCE"
else
  _bt_setenv="$0"
fi
```

Verified by sourcing the file under both dash and bash: dash now exits 0, and
bash still resolves `BIGTRANSLATE_HOME` from the script's own location.