### PR TITLE
Stage the chunks from the extract task, not by hand

### DIFF
--- a/distribution/src/main/resources/bin/bt-cluster
+++ b/distribution/src/main/resources/bin/bt-cluster
@@ -51,6 +51,7 @@ fi
 # the ordinary way; these are for driving it from somewhere that has not.
 COMMAND=""
 ONLY_NODE=""
+CHUNK_SRC=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --home)       BIGTRANSLATE_HOME="$2"; shift 2 ;;
@@ -61,6 +62,8 @@ while [ $# -gt 0 ]; do
     --nodes=*)    NODES_CONF="${1#*=}"; shift ;;
     --ssh)        SSH="$2"; shift 2 ;;
     --ssh=*)      SSH="${1#*=}"; shift ;;
+    --chunks)     CHUNK_SRC="$2"; shift 2 ;;
+    --chunks=*)   CHUNK_SRC="${1#*=}"; shift ;;
     --node)       ONLY_NODE="$2"; shift 2 ;;
     --node=*)     ONLY_NODE="${1#*=}"; shift ;;
     -h|--help)    COMMAND="help"; shift ;;
@@ -203,6 +206,13 @@ stage_one() {
   # release a job that then fails, which is the whole failure this prevents.
   mkdir -p "$BIGTRANSLATE_HOME/data/staging"
   manifest="$BIGTRANSLATE_HOME/data/staging/$id.staged"
+  record_staged "$id" "$host"
+}
+
+record_staged() {
+  id=$1; host=$2
+  mkdir -p "$BIGTRANSLATE_HOME/data/staging"
+  manifest="$BIGTRANSLATE_HOME/data/staging/$id.staged"
   # Assigned before it is written, so that a failed ssh is a failure. Piping
   # straight into the file would report the exit status of the local sort,
   # and an unreachable node would quietly produce an empty manifest.
@@ -213,6 +223,39 @@ stage_one() {
   mv "$manifest.tmp" "$manifest"
   staged=$(grep -c . "$manifest" | tr -d ' ')
   echo "  $id has $staged chunk file(s)"
+}
+
+# ----------------------------------------------------------- stage-chunks ---
+
+# Just the chunk files, from wherever they have this moment been written.
+#
+# Called by the extract task, before its output is ingested. That is the only
+# point at which every node can be given the chunks before anything can be
+# asked to translate one: ingest is what fires the chunk event, the event is
+# what creates the translate task, and a task's precondition is evaluated when
+# the task appears. Staging afterwards is a race; staging here removes it.
+stage_chunks_one() {
+  id=$1; host=$2
+  echo "staging chunks to $id ($host)"
+  $SSH "$host" "mkdir -p '$BIGTRANSLATE_HOME/data/strings'" \
+    || die "could not create data/strings on $host"
+  rsync -a --include 'chunk-*.json' --exclude '*' -e "$SSH" \
+    "$CHUNK_SRC/" "$host:$BIGTRANSLATE_HOME/data/strings/" \
+    || die "could not copy chunks to $host"
+  record_staged "$id" "$host"
+}
+
+cmd_stage_chunks() {
+  [ -n "$CHUNK_SRC" ] || CHUNK_SRC="$BIGTRANSLATE_HOME/data/strings"
+  [ -d "$CHUNK_SRC" ] || die "no such directory: $CHUNK_SRC"
+  if [ "$(remote_lines | wc -l | tr -d ' ')" -eq 0 ]; then
+    # One machine, which wrote the chunks itself. Nothing to copy and nothing
+    # to wait for, and saying so is not a failure.
+    echo "no compute nodes beyond the manager; nothing to stage"
+    return 0
+  fi
+  for_each_remote stage_chunks_one
+  echo "chunk staging complete"
 }
 
 cmd_stage() { for_each_remote stage_one; echo "staging complete"; }
@@ -252,12 +295,13 @@ case "${COMMAND:-}" in
   policy) cmd_policy ;;
   deploy) cmd_deploy ;;
   stage)  cmd_stage ;;
+  stage-chunks) cmd_stage_chunks ;;
   start)  cmd_start ;;
   stop)   cmd_stop ;;
   status) cmd_status ;;
   nodes)  node_lines ;;
   help|*)
-    echo "usage: bt-cluster [options] {policy|deploy|stage|start|stop|status|nodes} [node]"
+    echo "usage: bt-cluster [options] {policy|deploy|stage|stage-chunks|start|stop|status|nodes} [node]"
     echo
     echo "options:"
     echo "  --home PATH        deployment root; the same absolute path on"
@@ -273,6 +317,11 @@ case "${COMMAND:-}" in
     echo "  policy   write nodes.xml and the queue mapping from conf/nodes.conf"
     echo "  deploy   install BigTranslate and its python environment on each"
     echo "           remote node, at the same absolute path as here"
+    echo "  stage-chunks  copy just the chunk files from --chunks <dir> to"
+    echo "           each node's data/strings, then record what each node has."
+    echo "           Run by the extract task before its output is ingested, so"
+    echo "           that no translate task exists before every node can serve"
+    echo "           it. Defaults to data/strings for a re-stage by hand."
     echo "  stage    copy conf, scripts, policy and the string chunks to each"
     echo "  start    batch stub and translation service, here and on each node"
     echo "  stop     the same, in reverse"

--- a/distribution/src/main/resources/bin/bt-extract-strings
+++ b/distribution/src/main/resources/bin/bt-extract-strings
@@ -33,6 +33,7 @@ import argparse
 import glob
 import json
 import os
+import subprocess
 import sys
 import time
 
@@ -139,6 +140,48 @@ def write_chunks(strings, out_dir, chunk_size,
     return written
 
 
+def stage_chunks(out_dir, mode):
+    """Push the chunks to the compute nodes, before anything ingests them.
+
+    A translate task reads its chunk from a node-local path, and until the
+    chunk is there any job scheduled to that node fails. Doing this here
+    rather than by hand afterwards is not merely convenience: ingest is what
+    fires the chunk event, the event is what creates the translate task, and
+    a task's precondition is evaluated when the task appears. Staging after
+    that is a race. Staging before it means there is no window at all.
+
+    bt-cluster decides whether there is anywhere to stage to. On a single
+    machine it reports that there is nothing to do and succeeds, so there is
+    no "distributed mode" flag to get wrong: nodes.conf listing more than this
+    machine is what distributed means.
+    """
+    if mode == "never":
+        return
+    home = os.environ.get("BIGTRANSLATE_HOME")
+    if not home:
+        log("BIGTRANSLATE_HOME is not set; not staging chunks")
+        return
+    cluster = os.path.join(home, "bin", "bt-cluster")
+    if not os.path.isfile(cluster):
+        log("no %s; not staging chunks" % cluster)
+        return
+
+    log("staging chunks to the compute nodes")
+    result = subprocess.run(
+        [cluster, "--home", home, "stage-chunks", "--chunks", out_dir],
+        capture_output=True, text=True)
+    for line in (result.stdout or "").splitlines():
+        log("  %s" % line)
+    if result.returncode != 0:
+        for line in (result.stderr or "").splitlines():
+            log("  %s" % line)
+        # Fatal, and loud. A half-staged cluster is worse than an unstaged
+        # one: the condition reads the manifest of whatever did arrive and
+        # releases exactly the chunks that node can serve, so the failures
+        # arrive later, one job at a time, looking like something else.
+        raise SystemExit("staging chunks to the compute nodes failed")
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(
         prog="bt-extract-strings",
@@ -156,6 +199,9 @@ def main(argv=None):
     # measured, which is short enough that losing one to a restart costs
     # little and long enough that per-instance overhead disappears.
     parser.add_argument("--chunk-size", type=int, default=5000)
+    parser.add_argument("--stage", choices=("auto", "never"), default="auto",
+                        help="copy the chunks to the compute nodes when the "
+                             "run is distributed (default: auto)")
     parser.add_argument("--encodings", default=None,
                         help="conf/encoding.txt: encodings to try, in order")
     args = parser.parse_args(argv)
@@ -193,6 +239,8 @@ def main(argv=None):
     log("wrote %d chunks and %s" % (len(chunks), path))
     log("dedup factor %.1fx -- %d strings to translate, not %d cells"
         % (manifest["dedup_factor"], len(seen), cells))
+
+    stage_chunks(args.out_dir, args.stage)
     return 0
 
 


### PR DESCRIPTION
Removes the manual staging step. Asked for directly: *"we shouldn't have to
rely on you hand staging anything to the nodes. That should probably be part of
the end of each of the tasks that extract the strings, if we are running in
distributed mode."*

## Why the end of extract, specifically

A translate task reads its chunk from a node-local path, and until the chunk is
there any job scheduled to that node fails.

The ordering is the whole point:

1. extract writes chunks to the job output directory
2. **ingest** copies them into the archive — and fires the chunk event
3. the event creates the translate task
4. the task's precondition is evaluated when the task appears

So staging *after* ingest races the engine, and staging by hand afterwards is a
race already lost — which is exactly what happened on the last run: the
condition was asked before the copy finished, and 458 tasks parked permanently.

The end of extract is the one moment where every node can be given the chunks
**before anything exists that could ask to translate one**. That removes the
window rather than narrowing it.

## What changed

- `bt-cluster stage-chunks --chunks <dir>` — copies just the chunk files to
  each node's `data/strings` and records what each node actually has, reusing
  the manifest writer `stage` already used.
- `bt-extract-strings` calls it after writing the manifest, with `--stage
  auto|never` (default `auto`).

There is **no distributed-mode flag to get wrong**. `bt-cluster` decides: on a
single machine it reports there is nothing to do and succeeds. `nodes.conf`
listing more than this machine is what "distributed" means.

## Failing loudly

A staging failure aborts the extract task. A half-staged cluster is worse than
an unstaged one: the condition reads the manifest of whatever *did* arrive and
releases exactly the chunks that node can serve, so the failures come back
later, one job at a time, looking like something else.

## Verified

- single machine: `no compute nodes beyond the manager; nothing to stage`,
  exit 0
- real run against the GPU node: 458 chunks copied, manifest written with 458
  entries

The second case matters because the archive is nested by `BasicVersioner`
(`data/strings/chunk-00024.json/chunk-00024.json` — 459 directories, 0 flat
files), so the copy has to descend into per-product directories rather than
match flat names.

---

Stacked on #70, which is stacked on #69 — this builds on the manifest writer
added there.