### PR TITLE
Stop the science processes too, not just the managers

### DIFF
--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -471,6 +471,52 @@ start_oodt() {
   wait_for_started
 }
 
+# The pids of science processes this install has running.
+#
+# A PGE job script is started by the batch stub and detaches from it, so it
+# outlives every manager. Stopping OODT left them running: a join from a
+# discarded run was found still going 79 minutes later, four shard workers
+# deep, reading the corpus and on its way to writing the very Solr index the
+# next run was about to rebuild.
+#
+# Matched on this install's own job directory, so a second tree on the same
+# machine is left alone. Commands containing "grep" are dropped because the
+# search itself matches the pattern, which has produced phantom pids here
+# before.
+pge_job_pids() {
+  ps -axo pid=,command= 2>/dev/null \
+    | grep -F "$OODT_BASE/data/jobs/" \
+    | grep -F "sciPgeExeScript_" \
+    | grep -v "grep " \
+    | awk '{print $1}'
+}
+
+stop_pge_jobs() {
+  pids=$(pge_job_pids)
+  [ -n "$pids" ] || return 0
+  echo "Stopping science processes left by running jobs."
+  for pid in $pids; do
+    # Children first and by name, because killing the script alone orphans
+    # the python it forked, which is where the actual work happens.
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+      kill "$child" 2>/dev/null
+    done
+    kill "$pid" 2>/dev/null
+  done
+  waited=0
+  while [ "$waited" -lt 20 ]; do
+    [ -z "$(pge_job_pids)" ] && return 0
+    sleep 2
+    waited=$((waited + 2))
+  done
+  for pid in $(pge_job_pids); do
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+      kill -9 "$child" 2>/dev/null
+    done
+    kill -9 "$pid" 2>/dev/null
+  done
+}
+
 stop_oodt() {
   "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" stop "$@" >> "$OODT_OUT" 2>&1  &
   "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" stop "$@" >> "$OODT_OUT" 2>&1 &
@@ -480,6 +526,10 @@ stop_oodt() {
     "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" stop -p "$SOLR_PORT" >> "$OODT_OUT" 2>&1 &
   fi
   stop_pantogloss
+  # After the managers, so nothing hands out new work while these are being
+  # stopped, and before wait_for_stopped so the shutdown is not reported
+  # complete while science processes are still running.
+  stop_pge_jobs
   wait_for_stopped
 }
 


### PR DESCRIPTION
## The failure

A PGE job script is started by the batch stub and **detaches from it**, so it
outlives every manager. `oodt stop` stopped the File Manager, Workflow Manager,
Resource Manager, Tomcat, Solr and the translation service — and left the actual
work running.

Found by accident, mid-cleanup:

```
54197  01:19:05  sh .../data/jobs/join/0_1788986431915/sciPgeExeScript_Join_Index_Task
54297  01:19:04  python3 .../bin/bt-join-index --corpus /Volumes/CHIPOTLE_BRICK/...
54298  01:19:04  python3 .../bin/bt-join-index --corpus ...
54299  01:19:04  python3 .../bin/bt-join-index --corpus ...
54300  01:19:04  python3 .../bin/bt-join-index --corpus ...
```

A join from a run that had been **stopped and discarded** was still going 79
minutes later, four shard workers deep, reading the corpus and on its way to
writing the Solr index the next run was about to rebuild. It had survived a
stop, a restart, a catalogue wipe, and the start of a fresh run. Nothing
reported it, and it was caught only because I happened to list processes for an
unrelated reason.

The damage it was heading for is the quiet kind: a rebuilt index with documents
in it from a run nobody kept.

## The fix

`stop_oodt` now stops the science processes as well.

- **After** the managers, so nothing hands out new work while these are dying.
- **Before** `wait_for_stopped`, so shutdown is not reported complete while work
  is still running.
- **Children by name before the parent** — killing the script alone orphans the
  python it forked, which is where the work is.
- TERM, then KILL for anything still alive after 20s, matching how `bt-node`
  stops a stub.

## Not killing the wrong thing

Matched on *this install's* `data/jobs/` path, so a second tree on the same
machine is untouched. Commands containing `grep` are dropped because the search
matches its own pattern — that has produced phantom pids in this codebase
before, twice.

Verified live against a running extract: the matcher returned exactly the one
job script and nothing else, cross-checked against the real pid.