### PR TITLE
Give conditions a queue, because they never had one

### DIFF
--- a/distribution/src/main/resources/bin/bt-cluster
+++ b/distribution/src/main/resources/bin/bt-cluster
@@ -144,7 +144,15 @@ cmd_policy() {
     echo '     its own output file, so any node may take any chunk. Only the'
     echo '     first serves managers, because extract reads the corpus and'
     echo '     join writes the Solr index, and those disks are attached to'
-    echo '     the machine running the managers. -->'
+    echo '     the machine running the managers.'
+    echo ''
+    echo '     Conditions get a queue of their own, on that same machine. A'
+    echo '     condition reads the manager filesystem, so it can only run'
+    echo '     there; and it is re-asked until it passes, so a few hundred'
+    echo '     gated tasks generate steady scheduling traffic. Sharing the'
+    echo '     managers queue would let that traffic occupy the slots extract'
+    echo '     and join need, and the join is itself gated by a condition,'
+    echo '     so conditions would end up delaying the work they gate. -->'
     echo '<cas:nodeMap xmlns:cas="http://oodt.jpl.nasa.gov/1.0/resource">'
     first=yes
     node_lines | while read -r id host capacity; do
@@ -152,13 +160,28 @@ cmd_policy() {
       echo "  <node id=\"$id\">"
       echo '    <queues>'
       echo '      <queue name="translate"/>'
-      if [ "$first" = yes ]; then echo '      <queue name="managers"/>'; fi
+      if [ "$first" = yes ]; then
+        echo '      <queue name="managers"/>'
+        echo '      <queue name="conditions"/>'
+      fi
       echo '    </queues>'
       echo '  </node>'
       first=no
     done
     echo '</cas:nodeMap>'
   } > "$map_xml"
+
+  # Parsed before anyone depends on them. A generated file that does not
+  # parse takes the Resource Manager down at startup, which takes the Workflow
+  # Manager with it ("Null engine"), and the message that actually names the
+  # problem is several stack traces deep in a log nobody is tailing. The
+  # specific way this has gone wrong here, repeatedly, is a "--" inside an XML
+  # comment, which is not permitted and which nothing warns about at the point
+  # it is written.
+  for generated in "$nodes_xml" "$map_xml"; do
+    python3 -c "import sys,xml.dom.minidom as m; m.parse(sys.argv[1])" "$generated" \
+      || die "generated $generated is not valid XML; it has not been left in a usable state"
+  done
 
   echo "wrote $nodes_xml and $map_xml for $(node_lines | wc -l | tr -d ' ') node(s)"
 }

--- a/tests/test_bt_cluster.py
+++ b/tests/test_bt_cluster.py
@@ -88,18 +88,40 @@ class TestPolicyIsGeneratedFromTheNodeList:
         text = (home / "resmgr" / "policy" / "nodes.xml").read_text()
         assert "localhost" not in text
 
-    def test_only_the_manager_serves_the_managers_queue(self, tmp_path):
-        # Extract reads the corpus and join writes the Solr index; those
-        # disks are attached to the machine running the managers.
+    def _serving(self, tmp_path):
         done, home = run(tmp_path, "policy", nodes=self.THREE)
         root = ET.parse(
             home / "resmgr" / "policy" / "node-to-queue-mapping.xml").getroot()
-        serving = {}
-        for node in root.iter("node"):
-            serving[node.get("id")] = {q.get("name") for q in node.iter("queue")}
-        assert serving["manager"] == {"translate", "managers"}
+        return {
+            node.get("id"): {q.get("name") for q in node.iter("queue")}
+            for node in root.iter("node")
+        }
+
+    def test_only_the_manager_serves_the_managers_queue(self, tmp_path):
+        # Extract reads the corpus and join writes the Solr index; those
+        # disks are attached to the machine running the managers.
+        serving = self._serving(tmp_path)
+        assert serving["manager"] == {"translate", "managers", "conditions"}
         assert serving["gpu"] == {"translate"}
         assert serving["spare"] == {"translate"}
+
+    def test_conditions_have_a_queue_of_their_own_on_the_manager(self, tmp_path):
+        # A condition is dispatched as a task, and a task with no queue lands
+        # on ResourceRunner's default of "high", which nothing here serves.
+        # The Resource Manager cannot schedule it, the condition task fails,
+        # and a failed condition task is read as a condition that said no --
+        # so before this queue existed, no condition in this cluster had ever
+        # run.
+        #
+        # Its own queue rather than sharing managers: a condition is re-asked
+        # until it passes, and a few hundred gated tasks would otherwise crowd
+        # extract and join out of the queue they need.
+        serving = self._serving(tmp_path)
+        assert "conditions" in serving["manager"]
+        for node in ("gpu", "spare"):
+            assert "conditions" not in serving[node], (
+                "a condition reads the manager's own files, so a compute node "
+                "must not be offered one")
 
     def test_generated_files_say_they_are_generated(self, tmp_path):
         done, home = run(tmp_path, "policy", nodes=self.THREE)

--- a/workflow/src/main/resources/policy/conditions.xml
+++ b/workflow/src/main/resources/policy/conditions.xml
@@ -29,6 +29,20 @@
   <condition id="urn:bigtranslate:TranslationsSettled" name="Translations Settled"
              class="org.apache.oodt.cas.pge.condition.ProductCountSettledCondition">
     <configuration>
+      <!-- A condition is dispatched as a task like any other, and under the
+           ResourceRunner a task with no queue falls back to a default of
+           "high", which this deployment does not define. The Resource Manager
+           cannot schedule it, the condition task fails, and a failed condition
+           task reads as a condition that answered no. Every condition here
+           failed that way, every time, which is the real reason the join has
+           only ever been started by hand.
+
+           Conditions get a queue of their own, on the manager, because a
+           condition reads the manager's filesystem and because it is re-asked
+           until it passes; a few hundred gated tasks would otherwise crowd
+           extract and join out of the managers queue. -->
+      <property name="QueueName" value="conditions"/>
+      <property name="TaskLoad" value="1"/>
       <property name="FileManagerUrl" value="[FILEMGR_URL]" envReplace="true"/>
       <property name="ProductTypeName" value="EmploymentTranslatedChunk"/>
       <!-- At least one, so the join cannot run against nothing at all. -->
@@ -53,6 +67,20 @@
   <condition id="urn:bigtranslate:ChunkStaged" name="Chunk Staged"
              class="org.bigtranslate.workflow.ChunkStagedCondition">
     <configuration>
+      <!-- A condition is dispatched as a task like any other, and under the
+           ResourceRunner a task with no queue falls back to a default of
+           "high", which this deployment does not define. The Resource Manager
+           cannot schedule it, the condition task fails, and a failed condition
+           task reads as a condition that answered no. Every condition here
+           failed that way, every time, which is the real reason the join has
+           only ever been started by hand.
+
+           Conditions get a queue of their own, on the manager, because a
+           condition reads the manager's filesystem and because it is re-asked
+           until it passes; a few hundred gated tasks would otherwise crowd
+           extract and join out of the managers queue. -->
+      <property name="QueueName" value="conditions"/>
+      <property name="TaskLoad" value="1"/>
       <property name="StagingDir" value="[BIGTRANSLATE_HOME]/data/staging" envReplace="true"/>
       <property name="NodesFile" value="[BIGTRANSLATE_HOME]/conf/nodes.conf" envReplace="true"/>
       <property name="FilenameKey" value="Filename"/>


### PR DESCRIPTION
## No condition in this deployment has ever run

A condition is dispatched as a task like any other. Under `ResourceRunner`, a
task with no `QueueName` falls back to `DEFAULT_QUEUE_NAME`, which is
**`"high"`** — and this cluster defines exactly two queues: `translate` and
`managers`.

```java
// ResourceRunner.java:70
protected static final String DEFAULT_QUEUE_NAME = "high";

// WorkflowProcessorQueue.toConditionTask() — sets ConditionClassName, no queue
```

So the Resource Manager could not schedule the job, the condition task failed,
and **a failed condition task is indistinguishable from a condition that
answered no.** Every condition failed, every time, from the first run onwards.

## What that had been costing us

This is the real reason the join has only ever been kicked off by hand.
`TranslationsSettled` wasn't unreliable — it *could not possibly* have worked.
Its two `Failure` instances per run sat in plain sight and were read as "not
settled yet".

It also masked the requeue fix (Mnemosyne #326): conditions were being
correctly requeued and correctly re-asked, and failing again each time for a
reason that had nothing to do with their logic. `ChunkStagedCondition` returned
`true` when run directly against the same files, which is what finally made it
obvious that the condition body was never being reached.

## The fix

Conditions get a queue of their own, served by the manager.

Placement is a per-condition engineering decision, not a property of the
mechanism — conditions are ordinary tasks and can run anywhere. Both of ours
read manager-side state, and `ChunkStagedCondition` reads the staging manifests
off the manager's own disk, so the manager is where they belong.

A **separate** queue rather than reusing `managers`, because a condition is
re-asked until it passes. A few hundred gated tasks would otherwise crowd
extract and join out of the queue they need — while the join sits waiting on a
condition that is itself waiting for a slot.

## And a guard against the thing that broke the whole stack

While adding the queue I put a `--` inside an XML comment. That is not
permitted in XML, so `node-to-queue-mapping.xml` failed to parse,
`XmlQueueRepository` handed back a null document, the Resource Manager died on
startup with an NPE, and the Workflow Manager followed it down reporting
`Null engine`. Every manager on the box was down and nothing named the cause
except one line several stack traces deep:

```
[Fatal Error] :14:22: The string "--" is not permitted within comments.
```

This is the **eighth** time a double hyphen in a comment has broken something
in this tree, so `bt-cluster policy` now parses what it generates and refuses
to leave an unusable file behind.

## Verified live

Conditions went from never passing to **277 `Success`** within a minute of the
restart, all 458 translate tasks released, and both nodes saturated with real
work for the first time — ninja 6 processes, GPU 8.