### PR TITLE
Do not hand out translate work before the model is loaded

### DIFF
--- a/distribution/src/main/resources/bin/oodt
+++ b/distribution/src/main/resources/bin/oodt
@@ -430,6 +430,35 @@ ensure_workflow_instance_schema() {
     || echo "Could not verify the workflow instance database; starting anyway."
 }
 
+# Wait until the translation service will actually answer a translation.
+#
+# It binds its port as soon as uvicorn starts and only reports ready once the
+# model is loaded, which is seconds on a warm cache and minutes on a cold one.
+# A translate job that arrives in between dies with
+#
+#   ServiceUnavailable: the translation service at http://127.0.0.1:8766
+#   stopped answering partway through ([Errno 61] Connection refused)
+#
+# and that is a real, permanent failure for the chunk: nothing retries it.
+# Cheap to prevent and expensive to discover, since until the PGE learned to
+# fail on a failing command these losses were recorded as successes.
+wait_for_pantogloss() {
+  [ -x "$OODT_BASE/.venv/bin/pantogloss" ] || return 0
+  waited=0
+  while [ "$waited" -lt 600 ]; do
+    if curl -s -m 5 "http://127.0.0.1:$PANTOGLOSS_PORT/health" 2>/dev/null \
+        | grep -q '"ready"[[:space:]]*:[[:space:]]*true'; then
+      [ "$waited" -gt 0 ] && echo "Translation service ready after ${waited}s."
+      return 0
+    fi
+    sleep 2
+    waited=$((waited + 2))
+  done
+  echo "Translation service on $PANTOGLOSS_PORT is not reporting ready after"
+  echo "${waited}s; starting anyway. Translate jobs will fail until it is."
+  return 1
+}
+
 start_oodt() {
   ensure_working_dirs
   nohup "$FILEMGR_HOME"/bin/"$FILEMGR_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
@@ -456,6 +485,12 @@ start_oodt() {
 
   ensure_workflow_instance_schema
 
+  # Before the Workflow Manager, and ready before it, because the Workflow
+  # Manager is what hands out translate work. Started here rather than at the
+  # end so the load overlaps the managers coming up instead of following them.
+  start_pantogloss
+  wait_for_pantogloss
+
   nohup "$WORKFLOW_HOME"/bin/"$WORKFLOW_EXEC" start "$@" >> "$OODT_OUT" 2>&1  &
   nohup "$OODT_BASE"/tomcat/bin/"$TOMCAT_EXEC" start "$@" >> "$OODT_OUT" 2>&1 &
   # Solr runs as its own application now, with its own Jetty, rather than as a
@@ -467,7 +502,6 @@ start_oodt() {
     nohup "$SOLR_SERVER_HOME"/bin/"$SOLR_EXEC" start -p "$SOLR_PORT" \
       --solr-home "$OODT_BASE"/solr --user-managed >> "$OODT_OUT" 2>&1 &
   fi
-  start_pantogloss
   wait_for_started
 }
 
@@ -540,8 +574,15 @@ elif [ "$1" = "stop" ]; then
 elif [ "$1" = "start-pantogloss" ]; then
   # For a compute node, which wants the translation service and none of the
   # managers. bin/bt-node uses these two.
+  #
+  # Returns when the service will answer a translation, not when its process
+  # exists. bt-node starts this before the batch stub precisely so that a task
+  # handed to the node has something to translate against, and returning early
+  # defeats that: the stub binds, the manager sees a node that is up, and the
+  # jobs it sends land on a service still loading its model.
   ensure_working_dirs
   start_pantogloss
+  wait_for_pantogloss
 elif [ "$1" = "stop-pantogloss" ]; then
   stop_pantogloss
 elif [ "$1" = "restart" ]; then


### PR DESCRIPTION
## The failure

The translation service binds its port as soon as uvicorn starts, and only
answers translations once the model has loaded — seconds on a warm cache,
minutes on a cold one.

`bin/oodt` started it **last**, after the Workflow Manager. So the component
that hands out translate work was live before the component that performs it
had begun loading. Every job dispatched into that window died:

```
ServiceUnavailable: the translation service at http://127.0.0.1:8766
stopped answering partway through ([Errno 61] Connection refused)
```

That is a **permanent loss for the chunk** — nothing retries a failed task.

## Why it was never noticed

It was invisible until the PGE learned to fail on a failing command (Mnemosyne
#327). Before that, these were recorded as `Success` and the chunk simply had
no output. The first run after `set -e` landed surfaced it immediately.

## The fix

- The service starts **before** the Workflow Manager, and the start blocks until
  `/health` reports `"ready":true`. No window, rather than a smaller one.
- Started earlier rather than merely waited on later, so the model load overlaps
  the managers coming up instead of following them.
- `start-pantogloss` waits too. `bt-node` already started the service before the
  batch stub, with a comment saying exactly why — but the subcommand returned as
  soon as the *process* existed. The stub bound, the manager saw a node that was
  up, and the jobs it sent found a service still loading. The intent was right;
  the mechanism didn't honour it.

Ten minutes is allowed for a cold start, after which it says so and carries on
rather than refusing to start the cluster.

## Verified

Against the live service: the check matches `{"status":"ok","model_status":"ready","ready":true,…}`,
correctly rejects `{"model_status":"loading","ready":false}`, and does not
false-match on the `"model_status":"ready"` substring.

---

Stacked on #74.